### PR TITLE
Add Decoder.decodeBuffer

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/Decoder.java
+++ b/serde-api/src/main/java/io/micronaut/serde/Decoder.java
@@ -69,6 +69,17 @@ public interface Decoder {
     @Nullable
     Object decodeArbitrary() throws IOException;
 
+    /**
+     * Buffer the whole subtree of this value and return it as a new {@link Decoder}. The returned {@link Decoder} can
+     * be used independently to this {@link Decoder}. This means actual parsing of the subtree can be delayed.
+     * <p>
+     * The returned {@link Decoder} should behave identically to this {@link Decoder}. This means that for example
+     * {@code decoder.decodeDouble()} should be equivalent to {@code decoder.decodeBuffer().decodeDouble()}.
+     *
+     * @return An independent decoder that visits this subtree.
+     */
+    Decoder decodeBuffer() throws IOException;
+
     void skipValue() throws IOException;
 
     void finishStructure() throws IOException;

--- a/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonDecoder.java
+++ b/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonDecoder.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.core.io.NumberInput;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
+import io.micronaut.jackson.core.tree.JsonNodeTreeCodec;
+import io.micronaut.json.tree.JsonNode;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.exceptions.SerdeException;
 
@@ -473,6 +475,15 @@ public class JacksonDecoder implements Decoder {
             default:
                 throw ((Decoder) this).createDeserializationException("Unexpected token " + parser.currentToken() + ", expected value");
         }
+    }
+
+    @Override
+    public Decoder decodeBuffer() throws IOException {
+        preDecodeValue();
+        JsonNodeTreeCodec treeCodec = JsonNodeTreeCodec.getInstance();
+        JsonNode tree = treeCodec.readTree(parser);
+        parser.nextToken();
+        return JacksonDecoder.create(treeCodec.treeAsTokens(tree), view);
     }
 
     private static Map<String, Object> decodeArbitraryMap(Decoder elementDecoder) throws IOException {

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/JacksonDecoderSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/JacksonDecoderSpec.groovy
@@ -1,0 +1,86 @@
+package io.micronaut.serde.jackson
+
+import com.fasterxml.jackson.core.JsonFactoryBuilder
+import spock.lang.Specification
+
+class JacksonDecoderSpec extends Specification {
+    def "unwrap arrays normal"() {
+        given:
+        def factory = new JsonFactoryBuilder().build()
+
+        expect:
+        JacksonDecoder.create(factory.createParser('["a"]')).decodeString() == 'a'
+        JacksonDecoder.create(factory.createParser('[42]')).decodeInt() == 42
+        JacksonDecoder.create(factory.createParser('[42]')).decodeDouble() == 42
+        JacksonDecoder.create(factory.createParser('[42]')).decodeBigInteger() == BigInteger.valueOf(42)
+        JacksonDecoder.create(factory.createParser('[42]')).decodeBigDecimal() == BigDecimal.valueOf(42)
+        JacksonDecoder.create(factory.createParser('[true]')).decodeBoolean()
+    }
+
+    def "unwrap arrays nested"() {
+        given:
+        def factory = new JsonFactoryBuilder().build()
+
+        when:
+        JacksonDecoder.create(factory.createParser('[["a"]]')).decodeString()
+
+        then:
+        thrown DeserializationException
+    }
+
+    def "unwrapping places the cursor correctly"() {
+        given:
+        def factory = new JsonFactoryBuilder().build()
+        def decoder = JacksonDecoder.create(factory.createParser('[["a"],42]'))
+        def array = decoder.decodeArray()
+
+        expect:
+        array.decodeString() == 'a'
+        array.decodeInt() == 42
+        array.finishStructure()
+    }
+
+    def 'char reading'() {
+        given:
+        def factory = new JsonFactoryBuilder().build()
+        def decoder = JacksonDecoder.create(factory.createParser('["a",42]'))
+        def array = decoder.decodeArray()
+
+        expect:
+        array.decodeChar() == (char) 'a'
+        array.decodeChar() == (char) '*'
+    }
+
+    def 'buffering'() {
+        given:
+        def factory = new JsonFactoryBuilder().build()
+
+        expect:
+        JacksonDecoder.create(factory.createParser('"a"')).decodeBuffer().decodeString() == 'a'
+        JacksonDecoder.create(factory.createParser('42')).decodeBuffer().decodeInt() == 42
+        JacksonDecoder.create(factory.createParser('42')).decodeBuffer().decodeDouble() == 42
+        JacksonDecoder.create(factory.createParser('42')).decodeBuffer().decodeBigInteger() == BigInteger.valueOf(42)
+        JacksonDecoder.create(factory.createParser('42')).decodeBuffer().decodeBigDecimal() == BigDecimal.valueOf(42)
+        JacksonDecoder.create(factory.createParser('true')).decodeBuffer().decodeBoolean()
+
+        when:
+        def decoder = JacksonDecoder.create(factory.createParser('[{"foo":"bar"}, false]'))
+        def array = decoder.decodeArray()
+        def buffer = array.decodeBuffer()
+
+        then:
+        array.hasNextArrayValue()
+        !array.decodeBoolean()
+        !array.hasNextArrayValue()
+        array.finishStructure()
+
+        when:
+        def object = buffer.decodeObject()
+
+        then:
+        object.decodeKey() == 'foo'
+        object.decodeString() == 'bar'
+        object.decodeKey() == null
+        object.finishStructure()
+    }
+}

--- a/serde-jsonp/src/main/java/io/micronaut/serde/json/stream/JsonParserDecoder.java
+++ b/serde-jsonp/src/main/java/io/micronaut/serde/json/stream/JsonParserDecoder.java
@@ -190,6 +190,11 @@ public class JsonParserDecoder implements Decoder {
     }
 
     @Override
+    public Decoder decodeBuffer() throws IOException {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
     public void skipValue() throws IOException {
         jsonParser.skipObject();
     }


### PR DESCRIPTION
Allows buffering data for later decoding, needed for subtype deserialization.
Also copied over the old JacksonDecoderSpec.

Adds #1