### PR TITLE
BSON `decodeBuffer` support

### DIFF
--- a/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonMappingSpec.groovy
+++ b/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonMappingSpec.groovy
@@ -76,7 +76,6 @@ class BsonMappingSpec extends Specification implements BsonJsonSpec, BsonBinaryS
             newPets.pets[1] instanceof Cat
     }
 
-    @PendingFeature(reason = "Should work when 'decodeBuffer' is implemented")
     def "validate mapping inheritance type order"() {
         given:
             def dogJson = """{"breed": "Unknown", "_id": {"\$oid": "618b890200bbd4063ab74213"}, "name": "Bark", "_t": "Dog"}"""


### PR DESCRIPTION
To support BSON-specific types, we have to construct a `BsonReader` for the buffered data. This patch does this by writing out the data to a byte array and opening a new reader on it. This is a bit wasteful, but seems like the best solution short of building a custom `BsonReader` implementation.