### PR TITLE
Implement currentPath for jsonp and bson encoders

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/Encoder.java
+++ b/serde-api/src/main/java/io/micronaut/serde/Encoder.java
@@ -150,7 +150,7 @@ public interface Encoder extends AutoCloseable {
     void encodeNull() throws IOException;
 
     /**
-     * Return an anaysis of the current path.
+     * Return an analysis of the current path.
      *
      * @return The current path if known
      */

--- a/serde-bson/src/main/java/io/micronaut/serde/bson/AbstractBsonMapper.java
+++ b/serde-bson/src/main/java/io/micronaut/serde/bson/AbstractBsonMapper.java
@@ -74,7 +74,7 @@ public abstract class AbstractBsonMapper implements ObjectMapper {
             if (object == null) {
                 bsonWriter.writeNull();
             } else {
-                BsonWriterEncoder encoder = new BsonWriterEncoder(bsonWriter, false);
+                BsonWriterEncoder encoder = new BsonWriterEncoder(bsonWriter);
                 serialize(encoder, object, type);
             }
             bsonWriter.flush();
@@ -143,7 +143,7 @@ public abstract class AbstractBsonMapper implements ObjectMapper {
             if (object == null) {
                 bsonWriter.writeNull();
             } else {
-                BsonWriterEncoder encoder = new BsonWriterEncoder(bsonWriter, false);
+                BsonWriterEncoder encoder = new BsonWriterEncoder(bsonWriter);
                 serialize(encoder, object);
             }
             bsonWriter.flush();

--- a/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonWriterEncoderSpec.groovy
+++ b/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonWriterEncoderSpec.groovy
@@ -15,19 +15,19 @@ class BsonWriterEncoderSpec extends Specification {
         outer.encodeKey('foo')
         outer.encodeString('bar')
         then:
-        outer.currentPath() == '*->foo'
+        outer.currentPath() == '->foo'
 
         when:
         outer.encodeKey('')
         outer.encodeString('bar')
         then:
-        outer.currentPath() == '*->'
+        outer.currentPath() == '->'
 
         when:
         outer.encodeKey('baz')
         def array = outer.encodeArray(Argument.VOID)
         array.encodeString('foo')
         then:
-        array.currentPath() == '*->baz->*'
+        array.currentPath() == '->baz->1'
     }
 }

--- a/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonWriterEncoderSpec.groovy
+++ b/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonWriterEncoderSpec.groovy
@@ -1,0 +1,33 @@
+package io.micronaut.serde.bson
+
+import io.micronaut.core.type.Argument
+import org.bson.BsonDocument
+import org.bson.BsonDocumentWriter
+import spock.lang.Specification
+
+class BsonWriterEncoderSpec extends Specification {
+    def 'currentPath'() {
+        given:
+        def encoder = new BsonWriterEncoder(new BsonDocumentWriter(new BsonDocument()))
+
+        when:
+        def outer = encoder.encodeObject(Argument.VOID)
+        outer.encodeKey('foo')
+        outer.encodeString('bar')
+        then:
+        outer.currentPath() == '*->foo'
+
+        when:
+        outer.encodeKey('')
+        outer.encodeString('bar')
+        then:
+        outer.currentPath() == '*->'
+
+        when:
+        outer.encodeKey('baz')
+        def array = outer.encodeArray(Argument.VOID)
+        array.encodeString('foo')
+        then:
+        array.currentPath() == '*->baz->*'
+    }
+}

--- a/serde-jsonp/src/main/java/io/micronaut/serde/json/stream/JsonStreamEncoder.java
+++ b/serde-jsonp/src/main/java/io/micronaut/serde/json/stream/JsonStreamEncoder.java
@@ -28,6 +28,7 @@ final class JsonStreamEncoder implements Encoder {
     private final JsonGenerator jsonGenerator;
     private final JsonStreamEncoder parent;
     private String currentKey;
+    private int currentIndex;
 
     public JsonStreamEncoder(JsonGenerator jsonGenerator) {
         this.jsonGenerator = jsonGenerator;
@@ -37,6 +38,10 @@ final class JsonStreamEncoder implements Encoder {
     private JsonStreamEncoder(JsonStreamEncoder parent) {
         this.jsonGenerator = parent.jsonGenerator;
         this.parent = parent;
+    }
+
+    private void postEncodeValue() {
+        currentIndex++;
     }
 
     @Override
@@ -53,7 +58,11 @@ final class JsonStreamEncoder implements Encoder {
 
     @Override
     public void finishStructure() throws IOException {
+        if (parent == null) {
+            throw new IllegalStateException("Not a structure");
+        }
         jsonGenerator.writeEnd();
+        parent.postEncodeValue();
     }
 
     @Override
@@ -65,61 +74,73 @@ final class JsonStreamEncoder implements Encoder {
     @Override
     public void encodeString(String value) throws IOException {
         jsonGenerator.write(value);
+        postEncodeValue();
     }
 
     @Override
     public void encodeBoolean(boolean value) throws IOException {
         jsonGenerator.write(value);
+        postEncodeValue();
     }
 
     @Override
     public void encodeByte(byte value) throws IOException {
         jsonGenerator.write(value);
+        postEncodeValue();
     }
 
     @Override
     public void encodeShort(short value) throws IOException {
         jsonGenerator.write(value);
+        postEncodeValue();
     }
 
     @Override
     public void encodeChar(char value) throws IOException {
         jsonGenerator.write(value);
+        postEncodeValue();
     }
 
     @Override
     public void encodeInt(int value) throws IOException {
         jsonGenerator.write(value);
+        postEncodeValue();
     }
 
     @Override
     public void encodeLong(long value) throws IOException {
         jsonGenerator.write(value);
+        postEncodeValue();
     }
 
     @Override
     public void encodeFloat(float value) throws IOException {
         jsonGenerator.write(value);
+        postEncodeValue();
     }
 
     @Override
     public void encodeDouble(double value) throws IOException {
         jsonGenerator.write(value);
+        postEncodeValue();
     }
 
     @Override
     public void encodeBigInteger(BigInteger value) throws IOException {
         jsonGenerator.write(value);
+        postEncodeValue();
     }
 
     @Override
     public void encodeBigDecimal(BigDecimal value) throws IOException {
         jsonGenerator.write(value);
+        postEncodeValue();
     }
 
     @Override
     public void encodeNull() throws IOException {
         jsonGenerator.writeNull();
+        postEncodeValue();
     }
 
     @NonNull
@@ -132,7 +153,9 @@ final class JsonStreamEncoder implements Encoder {
                 builder.insert(0, "->");
             }
             if (enc.currentKey == null) {
-                builder.insert(0, '*');
+                if (enc.parent != null) {
+                    builder.insert(0, enc.currentIndex);
+                }
             } else {
                 builder.insert(0, enc.currentKey);
             }

--- a/serde-jsonp/src/test/groovy/io/micronaut/serde/json/stream/JsonStreamEncoderSpec.groovy
+++ b/serde-jsonp/src/test/groovy/io/micronaut/serde/json/stream/JsonStreamEncoderSpec.groovy
@@ -14,19 +14,19 @@ class JsonStreamEncoderSpec extends Specification {
         outer.encodeKey('foo')
         outer.encodeString('bar')
         then:
-        outer.currentPath() == '*->foo'
+        outer.currentPath() == '->foo'
 
         when:
         outer.encodeKey('')
         outer.encodeString('bar')
         then:
-        outer.currentPath() == '*->'
+        outer.currentPath() == '->'
 
         when:
         outer.encodeKey('baz')
         def array = outer.encodeArray(Argument.VOID)
         array.encodeString('foo')
         then:
-        array.currentPath() == '*->baz->*'
+        array.currentPath() == '->baz->0'
     }
 }

--- a/serde-jsonp/src/test/groovy/io/micronaut/serde/json/stream/JsonStreamEncoderSpec.groovy
+++ b/serde-jsonp/src/test/groovy/io/micronaut/serde/json/stream/JsonStreamEncoderSpec.groovy
@@ -27,6 +27,6 @@ class JsonStreamEncoderSpec extends Specification {
         def array = outer.encodeArray(Argument.VOID)
         array.encodeString('foo')
         then:
-        array.currentPath() == '->baz->0'
+        array.currentPath() == '->baz->1'
     }
 }

--- a/serde-jsonp/src/test/groovy/io/micronaut/serde/json/stream/JsonStreamEncoderSpec.groovy
+++ b/serde-jsonp/src/test/groovy/io/micronaut/serde/json/stream/JsonStreamEncoderSpec.groovy
@@ -1,0 +1,32 @@
+package io.micronaut.serde.json.stream
+
+import io.micronaut.core.type.Argument
+import jakarta.json.Json
+import spock.lang.Specification
+
+class JsonStreamEncoderSpec extends Specification {
+    def 'currentPath'() {
+        given:
+        def encoder = new JsonStreamEncoder(Json.createGenerator(new ByteArrayOutputStream()))
+
+        when:
+        def outer = encoder.encodeObject(Argument.VOID)
+        outer.encodeKey('foo')
+        outer.encodeString('bar')
+        then:
+        outer.currentPath() == '*->foo'
+
+        when:
+        outer.encodeKey('')
+        outer.encodeString('bar')
+        then:
+        outer.currentPath() == '*->'
+
+        when:
+        outer.encodeKey('baz')
+        def array = outer.encodeArray(Argument.VOID)
+        array.encodeString('foo')
+        then:
+        array.currentPath() == '*->baz->*'
+    }
+}


### PR DESCRIPTION
Path is calculated lazily because it's only needed for error messages. Using a reference to the parent encoder keeps memory use relatively low.

Resolves #60
Resolves #61