### PR TITLE
Runtime naming strategy

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/DefaultDecoderContext.java
+++ b/serde-api/src/main/java/io/micronaut/serde/DefaultDecoderContext.java
@@ -15,14 +15,15 @@
  */
 package io.micronaut.serde;
 
-import java.util.Collection;
-
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.beans.BeanIntrospection;
 import io.micronaut.core.type.Argument;
+import io.micronaut.serde.config.naming.PropertyNamingStrategy;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.reference.AbstractPropertyReferenceManager;
 import io.micronaut.serde.reference.PropertyReference;
+
+import java.util.Collection;
 
 /**
  * Default implementation of {@link io.micronaut.serde.Deserializer.DecoderContext}.
@@ -46,6 +47,11 @@ class DefaultDecoderContext extends AbstractPropertyReferenceManager implements 
     @Override
     public final <T> Deserializer<? extends T> findDeserializer(Argument<? extends T> type) throws SerdeException {
         return registry.findDeserializer(type);
+    }
+
+    @Override
+    public <D extends PropertyNamingStrategy> D findNamingStrategy(Class<? extends D> namingStrategyClass) throws SerdeException {
+        return registry.findNamingStrategy(namingStrategyClass);
     }
 
     @Override

--- a/serde-api/src/main/java/io/micronaut/serde/DefaultEncoderContext.java
+++ b/serde-api/src/main/java/io/micronaut/serde/DefaultEncoderContext.java
@@ -17,6 +17,7 @@ package io.micronaut.serde;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
+import io.micronaut.serde.config.naming.PropertyNamingStrategy;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.reference.AbstractPropertyReferenceManager;
 import io.micronaut.serde.reference.PropertyReference;
@@ -44,6 +45,11 @@ class DefaultEncoderContext extends AbstractPropertyReferenceManager implements 
     @Override
     public final <T> Serializer<? super T> findSerializer(Argument<? extends T> forType) throws SerdeException {
         return registry.findSerializer(forType);
+    }
+
+    @Override
+    public <D extends PropertyNamingStrategy> D findNamingStrategy(Class<? extends D> namingStrategyClass) throws SerdeException {
+        return registry.findNamingStrategy(namingStrategyClass);
     }
 
     @Override

--- a/serde-api/src/main/java/io/micronaut/serde/DefaultSerdeRegistry.java
+++ b/serde-api/src/main/java/io/micronaut/serde/DefaultSerdeRegistry.java
@@ -28,6 +28,7 @@ import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.BeanDefinition;
+import io.micronaut.serde.config.naming.PropertyNamingStrategy;
 import io.micronaut.serde.deserializers.ObjectDeserializer;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.serdes.NumberSerde;
@@ -199,6 +200,11 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
     @Override
     public <T, D extends Deserializer<? extends T>> D findCustomDeserializer(Class<? extends D> deserializerClass) throws SerdeException {
         return beanContext.findBean(deserializerClass).orElseThrow(() -> new SerdeException("Cannot find deserializer: " + deserializerClass));
+    }
+
+    @Override
+    public <D extends PropertyNamingStrategy> D findNamingStrategy(Class<? extends D> namingStrategyClass) throws SerdeException {
+        return beanContext.findBean(namingStrategyClass).orElseThrow(() -> new SerdeException("Cannot find naming strategy: " + namingStrategyClass));
     }
 
     @Override

--- a/serde-api/src/main/java/io/micronaut/serde/Deserializer.java
+++ b/serde-api/src/main/java/io/micronaut/serde/Deserializer.java
@@ -15,8 +15,6 @@
  */
 package io.micronaut.serde;
 
-import java.io.IOException;
-
 import io.micronaut.core.annotation.Indexed;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
@@ -26,6 +24,8 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.reference.PropertyReference;
 import io.micronaut.serde.reference.PropertyReferenceManager;
+
+import java.io.IOException;
 
 /**
  * Interface that represents a deserializer.
@@ -83,7 +83,7 @@ public interface Deserializer<T> {
     /**
      * Context object passed to the {@link #deserialize(Decoder, io.micronaut.serde.Deserializer.DecoderContext, io.micronaut.core.type.Argument)} method along with the decoder.
      */
-    interface DecoderContext extends PropertyReferenceManager, DeserializerLocator {
+    interface DecoderContext extends PropertyReferenceManager, DeserializerLocator, NamingStrategyLocator {
 
         /**
          * @return Conversion service

--- a/serde-api/src/main/java/io/micronaut/serde/NamingStrategyLocator.java
+++ b/serde-api/src/main/java/io/micronaut/serde/NamingStrategyLocator.java
@@ -16,28 +16,26 @@
 package io.micronaut.serde;
 
 import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.config.naming.PropertyNamingStrategy;
+import io.micronaut.serde.exceptions.SerdeException;
 
 /**
- * Represents a registry where specific serializers can be looked up.
+ * Locator interface for a naming strategy.
  *
- * @author graemerocher
  * @since 1.0.0
- *
  */
-public interface SerdeRegistry extends SerializerLocator, DeserializerLocator, NamingStrategyLocator {
+public interface NamingStrategyLocator {
 
     /**
-     * Creates a new encoder context.
-     * @param view The view
-     * @return The encoder context
+     * Gets a naming strategy.
+     *
+     * @param namingStrategyClass The naming strategy class, should not be {@code null}
+     * @param <D>                 The naming strategy type
+     * @return The naming strategy
+     * @throws SerdeException if no naming strategy is found
      */
-    @NonNull Serializer.EncoderContext newEncoderContext(@Nullable Class<?> view);
+    @NonNull
+    <D extends PropertyNamingStrategy> D findNamingStrategy(@NonNull Class<? extends D> namingStrategyClass)
+            throws SerdeException;
 
-    /**
-     * Creates a new decoder context.
-     * @param view The view
-     * @return The decoder context
-     */
-    @NonNull Deserializer.DecoderContext newDecoderContext(@Nullable Class<?> view);
 }

--- a/serde-api/src/main/java/io/micronaut/serde/Serializer.java
+++ b/serde-api/src/main/java/io/micronaut/serde/Serializer.java
@@ -15,8 +15,6 @@
  */
 package io.micronaut.serde;
 
-import java.io.IOException;
-
 import io.micronaut.core.annotation.Indexed;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
@@ -26,6 +24,8 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.reference.PropertyReferenceManager;
 import io.micronaut.serde.reference.SerializationReference;
+
+import java.io.IOException;
 
 /**
  * Models a build time serializer. That is a class computed at build-time that can
@@ -86,7 +86,7 @@ public interface Serializer<T> {
      * Context object passes to the
      * {@link #serialize(Encoder, io.micronaut.serde.Serializer.EncoderContext, Object, io.micronaut.core.type.Argument)}  method.
      */
-    interface EncoderContext extends SerializerLocator, PropertyReferenceManager {
+    interface EncoderContext extends SerializerLocator, PropertyReferenceManager, NamingStrategyLocator {
 
         /**
          * @return Conversion service

--- a/serde-api/src/main/java/io/micronaut/serde/annotation/Serdeable.java
+++ b/serde-api/src/main/java/io/micronaut/serde/annotation/Serdeable.java
@@ -15,11 +15,6 @@
  */
 package io.micronaut.serde.annotation;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
 import io.micronaut.context.annotation.AliasFor;
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.serde.Deserializer;
@@ -27,6 +22,11 @@ import io.micronaut.serde.Serializer;
 import io.micronaut.serde.config.annotation.SerdeConfig;
 import io.micronaut.serde.config.naming.IdentityStrategy;
 import io.micronaut.serde.config.naming.PropertyNamingStrategy;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * A Serde is an annotation that can be applied to type to indicate that
@@ -87,6 +87,12 @@ public @interface Serdeable {
          */
         @AliasFor(annotation = SerdeConfig.class, member = SerdeConfig.SERIALIZE_AS)
         Class<?> as() default void.class;
+
+        /**
+         * @return Naming strategy to use.
+         */
+        @AliasFor(annotation = SerdeConfig.class, member = SerdeConfig.NAMING)
+        Class<? extends PropertyNamingStrategy> naming() default IdentityStrategy.class;
     }
 
     /**
@@ -118,5 +124,11 @@ public @interface Serdeable {
          */
         @AliasFor(annotation = SerdeConfig.class, member = SerdeConfig.DESERIALIZE_AS)
         Class<?> as() default void.class;
+
+        /**
+         * @return Naming strategy to use.
+         */
+        @AliasFor(annotation = SerdeConfig.class, member = SerdeConfig.NAMING)
+        Class<? extends PropertyNamingStrategy> naming() default IdentityStrategy.class;
     }
 }

--- a/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
@@ -143,6 +143,11 @@ public @interface SerdeConfig {
     String NAMING = "naming";
 
     /**
+     * Runtime naming strategy class.
+     */
+    String RUNTIME_NAMING = "runtimeNaming";
+
+    /**
      * Internal metadata type for wrapped settings.
      */
     @Internal

--- a/serde-api/src/main/java/io/micronaut/serde/config/naming/IdentityStrategy.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/naming/IdentityStrategy.java
@@ -15,12 +15,14 @@
  */
 package io.micronaut.serde.config.naming;
 
+import io.micronaut.core.annotation.AnnotatedElement;
+
 /**
  * Property name as is without changes.
  */
 public final class IdentityStrategy implements PropertyNamingStrategy {
     @Override
-    public String translate(String name) {
-        return name;
+    public String translate(AnnotatedElement element) {
+        return element.getName();
     }
 }

--- a/serde-api/src/main/java/io/micronaut/serde/config/naming/KebabCaseStrategy.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/naming/KebabCaseStrategy.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.config.naming;
 
+import io.micronaut.core.annotation.AnnotatedElement;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.StringUtils;
@@ -24,7 +25,8 @@ import io.micronaut.core.util.StringUtils;
  */
 public final class KebabCaseStrategy implements PropertyNamingStrategy {
     @Override
-    public @NonNull String translate(@NonNull String name) {
+    public @NonNull String translate(@NonNull AnnotatedElement element) {
+        String name = element.getName();
         if (StringUtils.isNotEmpty(name)) {
             return NameUtils.hyphenate(name, true);
         }

--- a/serde-api/src/main/java/io/micronaut/serde/config/naming/LowerCamelCaseStrategy.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/naming/LowerCamelCaseStrategy.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.config.naming;
 
+import io.micronaut.core.annotation.AnnotatedElement;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.StringUtils;
 
@@ -23,7 +24,8 @@ import io.micronaut.core.util.StringUtils;
  */
 public class LowerCamelCaseStrategy implements PropertyNamingStrategy {
     @Override
-    public String translate(String name) {
+    public String translate(AnnotatedElement element) {
+        String name = element.getName();
         if (StringUtils.isNotEmpty(name)) {
             return NameUtils.decapitalize(name);
         }

--- a/serde-api/src/main/java/io/micronaut/serde/config/naming/LowerCaseStrategy.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/naming/LowerCaseStrategy.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.config.naming;
 
+import io.micronaut.core.annotation.AnnotatedElement;
 import io.micronaut.core.util.StringUtils;
 
 /**
@@ -22,7 +23,8 @@ import io.micronaut.core.util.StringUtils;
  */
 public final class LowerCaseStrategy implements PropertyNamingStrategy {
     @Override
-    public String translate(String name) {
+    public String translate(AnnotatedElement element) {
+        String name = element.getName();
         if (StringUtils.isNotEmpty(name)) {
             return name.toLowerCase();
         }

--- a/serde-api/src/main/java/io/micronaut/serde/config/naming/LowerDotCaseStrategy.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/naming/LowerDotCaseStrategy.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.config.naming;
 
+import io.micronaut.core.annotation.AnnotatedElement;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.StringUtils;
 
@@ -23,7 +24,8 @@ import io.micronaut.core.util.StringUtils;
  */
 public final class LowerDotCaseStrategy implements PropertyNamingStrategy {
     @Override
-    public String translate(String name) {
+    public String translate(AnnotatedElement element) {
+        String name = element.getName();
         if (StringUtils.isNotEmpty(name)) {
             return NameUtils.hyphenate(name, true)
                     .replace('-', '.');

--- a/serde-api/src/main/java/io/micronaut/serde/config/naming/PropertyNamingStrategy.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/naming/PropertyNamingStrategy.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.config.naming;
 
+import io.micronaut.core.annotation.AnnotatedElement;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.util.StringUtils;
 
@@ -71,10 +72,10 @@ public interface PropertyNamingStrategy {
 
     /**
      * Translate the given name into the desired format.
-     * @param name The name to translate
+     * @param element The annotated element to translate
      * @return The translated name
      */
-    @NonNull String translate(@NonNull String name);
+    @NonNull String translate(@NonNull AnnotatedElement element);
 
     /**
      * Return an existing naming strategy for each name.

--- a/serde-api/src/main/java/io/micronaut/serde/config/naming/SnakeCaseStrategy.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/naming/SnakeCaseStrategy.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.config.naming;
 
+import io.micronaut.core.annotation.AnnotatedElement;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.StringUtils;
 
@@ -23,7 +24,8 @@ import io.micronaut.core.util.StringUtils;
  */
 public final class SnakeCaseStrategy implements PropertyNamingStrategy {
     @Override
-    public String translate(String name) {
+    public String translate(AnnotatedElement element) {
+        String name = element.getName();
         if (StringUtils.isNotEmpty(name)) {
             return NameUtils.underscoreSeparate(name).toLowerCase();
         }

--- a/serde-api/src/main/java/io/micronaut/serde/config/naming/UpperCamelCaseStrategy.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/naming/UpperCamelCaseStrategy.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.config.naming;
 
+import io.micronaut.core.annotation.AnnotatedElement;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.StringUtils;
 
@@ -23,7 +24,8 @@ import io.micronaut.core.util.StringUtils;
  */
 public class UpperCamelCaseStrategy implements PropertyNamingStrategy {
     @Override
-    public String translate(String name) {
+    public String translate(AnnotatedElement element) {
+        String name = element.getName();
         if (StringUtils.isNotEmpty(name)) {
             return NameUtils.capitalize(name);
         }

--- a/serde-api/src/main/java/io/micronaut/serde/config/naming/UpperCamelCaseStrategyWithSpaces.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/naming/UpperCamelCaseStrategyWithSpaces.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.config.naming;
 
+import io.micronaut.core.annotation.AnnotatedElement;
 import io.micronaut.core.naming.NameUtils;
 import io.micronaut.core.util.StringUtils;
 
@@ -25,7 +26,8 @@ import java.util.StringTokenizer;
  */
 public class UpperCamelCaseStrategyWithSpaces implements PropertyNamingStrategy {
     @Override
-    public String translate(String name) {
+    public String translate(AnnotatedElement element) {
+        String name = element.getName();
         if (StringUtils.isNotEmpty(name)) {
             StringTokenizer t = new StringTokenizer(NameUtils.hyphenate(name), "-", false);
             StringBuilder builder = new StringBuilder();

--- a/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonMappingSpec.groovy
+++ b/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonMappingSpec.groovy
@@ -236,6 +236,15 @@ class BsonMappingSpec extends Specification implements BsonJsonSpec, BsonBinaryS
             newSaleBson.get('quantity').isInt32()
     }
 
+    def "validate custom naming strategies"() {
+        given:
+            def e = new NamingStrategiesEntity(renameCompileTime: "val1", renameRunTime: "val2", "notRenamedProperty": "test")
+        when:
+            def json = bsonJsonMapper.writeValueAsString(e);
+        then:
+            json == """{"rename-compile-time": "val1", "bar yes": "val2", "notRenamedProperty": "test", "rename-compile-time": "val1"}"""
+    }
+
     @Serdeable
     static class Wrapper1 {
         List<Person2> persons

--- a/serde-bson/src/test/java/io/micronaut/serde/bson/NamingStrategiesEntity.java
+++ b/serde-bson/src/test/java/io/micronaut/serde/bson/NamingStrategiesEntity.java
@@ -1,0 +1,71 @@
+package io.micronaut.serde.bson;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.core.annotation.AnnotatedElement;
+import io.micronaut.serde.annotation.Serdeable;
+import io.micronaut.serde.config.naming.KebabCaseStrategy;
+import io.micronaut.serde.config.naming.PropertyNamingStrategy;
+import jakarta.inject.Singleton;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Serdeable
+public class NamingStrategiesEntity {
+
+    @Serdeable.Serializable(naming = KebabCaseStrategy.class)
+    private String renameCompileTime;
+
+    @MyAnn
+    @Serdeable.Serializable(naming = RunTimePropertyNamingStrategy.class)
+    private String renameRunTime;
+
+    private String notRenamedProperty;
+
+    public String getRenameCompileTime() {
+        return renameCompileTime;
+    }
+
+    public void setRenameCompileTime(String renameCompileTime) {
+        this.renameCompileTime = renameCompileTime;
+    }
+
+    public String getRenameRunTime() {
+        return renameRunTime;
+    }
+
+    public void setRenameRunTime(String renameRunTime) {
+        this.renameRunTime = renameRunTime;
+    }
+
+    public String getNotRenamedProperty() {
+        return notRenamedProperty;
+    }
+
+    public void setNotRenamedProperty(String notRenamedProperty) {
+        this.notRenamedProperty = notRenamedProperty;
+    }
+
+    @Singleton
+    public static class RunTimePropertyNamingStrategy implements PropertyNamingStrategy {
+
+        private final BeanContext beanContext;
+
+        public RunTimePropertyNamingStrategy(BeanContext beanContext) {
+            this.beanContext = beanContext;
+        }
+
+        @Override
+        public String translate(AnnotatedElement element) {
+            return beanContext == null ? "fail" : "bar " + (element.getAnnotationMetadata().hasAnnotation(MyAnn.class) ? "yes" : "no");
+        }
+    }
+
+    @Documented
+    @Retention(RUNTIME)
+    public @interface MyAnn {
+    }
+
+}


### PR DESCRIPTION
If the naming strategy is not recognized or initialized it's remapped as a runtime naming strategy. It's also possible now to have per property naming strategies