### PR TITLE
Generate lazy references to SerdeConfig enums

### DIFF
--- a/serde-processor/src/main/java/io/micronaut/serde/processor/bson/BsonDiscriminatorTransformer.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/bson/BsonDiscriminatorTransformer.java
@@ -46,7 +46,7 @@ public class BsonDiscriminatorTransformer implements NamedAnnotationTransformer 
         String discriminatorPropertyName = annotation.stringValue("key").orElse(BSON_DEFAULT_DISCRIMINATOR_PROPERTY_NAME);
         builder.member(SerdeConfig.TYPE_PROPERTY, discriminatorPropertyName);
         AnnotationValueBuilder<SerdeConfig.Subtyped> subtypedBuilder = AnnotationValue.builder(SerdeConfig.Subtyped.class);
-        subtypedBuilder.member(SerdeConfig.Subtyped.DISCRIMINATOR_VALUE, SerdeConfig.Subtyped.DiscriminatorValueKind.CLASS_SIMPLE_NAME);
+        subtypedBuilder.member(SerdeConfig.Subtyped.DISCRIMINATOR_VALUE, SerdeConfig.Subtyped.DiscriminatorValueKind.CLASS_SIMPLE_NAME.name());
         subtypedBuilder.member(SerdeConfig.Subtyped.DISCRIMINATOR_PROP, discriminatorPropertyName);
         return Arrays.asList(builder.build(), subtypedBuilder.build());
     }

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/jackson/JsonCreatorMapper.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/jackson/JsonCreatorMapper.java
@@ -35,7 +35,7 @@ public final class JsonCreatorMapper implements NamedAnnotationMapper {
     public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
         final AnnotationValueBuilder<Creator> builder = AnnotationValue.builder(Creator.class);
         annotation.enumValue("mode", SerdeConfig.CreatorMode.class)
-                .ifPresent(e -> builder.member("mode", e));
+                .ifPresent(e -> builder.member("mode", e.name()));
         return Collections.singletonList(builder.build());
     }
 

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/jackson/JsonIncludeMapper.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/jackson/JsonIncludeMapper.java
@@ -35,7 +35,7 @@ public class JsonIncludeMapper implements NamedAnnotationMapper {
         if (v != null) {
             return Collections.singletonList(
                     AnnotationValue.builder(SerdeConfig.class)
-                            .member(SerdeConfig.INCLUDE, v)
+                            .member(SerdeConfig.INCLUDE, v.name())
                             .build()
             );
         }

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/jsonb/JsonbNillableTransformer.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/jsonb/JsonbNillableTransformer.java
@@ -39,7 +39,7 @@ public class JsonbNillableTransformer implements NamedAnnotationTransformer {
         SerdeConfig.SerInclude include = includeNull ? SerdeConfig.SerInclude.ALWAYS : SerdeConfig.SerInclude.NON_ABSENT;
         return Collections.singletonList(
                 AnnotationValue.builder(SerdeConfig.class)
-                        .member(SerdeConfig.INCLUDE, include)
+                        .member(SerdeConfig.INCLUDE, include.name())
                         .build()
 
         );

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/jsonb/JsonbPropertyTransformer.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/jsonb/JsonbPropertyTransformer.java
@@ -39,7 +39,7 @@ public class JsonbPropertyTransformer implements NamedAnnotationTransformer {
         annotation.booleanValue("nillable")
                 .ifPresent(include -> {
             if (include) {
-                builder.member("include", SerdeConfig.SerInclude.ALWAYS);
+                builder.member("include", SerdeConfig.SerInclude.ALWAYS.name());
             }    
         });
         return Collections.singletonList(builder.build());


### PR DESCRIPTION
This avoids errors in the introspection when serde-api isn't present on the classpath at runtime. See https://github.com/micronaut-projects/micronaut-security/pull/889