### PR TITLE
Add decoder context and argument type in `getDefault` method

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/Deserializer.java
+++ b/serde-api/src/main/java/io/micronaut/serde/Deserializer.java
@@ -75,8 +75,10 @@ public interface Deserializer<T> {
     /**
      * Obtains a default value that can be returned from this deserializer in the case where a value is absent.
      * @return The default value
+     * @param decoderContext The decoder context, never {@code null}
+     * @param type The generic type to be deserialized
      */
-    default @Nullable T getDefaultValue() {
+    default @Nullable T getDefaultValue(@NonNull DecoderContext decoderContext, @NonNull Argument<? super T> type) {
         return null;
     }
 

--- a/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonMappingSpec.groovy
+++ b/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonMappingSpec.groovy
@@ -181,6 +181,7 @@ class BsonMappingSpec extends Specification implements BsonJsonSpec, BsonBinaryS
             def newSale = bsonBinaryMapper.readValue(bytes, Argument.of(Sale1))
         then:
             newSale.quantity.amount == 123
+            newSale.nullQuantity.amount == 123456
         when:
             def jsonBytes = bsonJsonMapper.writeValueAsBytes(sale)
             def str = new String(jsonBytes)
@@ -188,6 +189,7 @@ class BsonMappingSpec extends Specification implements BsonJsonSpec, BsonBinaryS
             def newSaleBson = bsonJsonMapper.readValue(str, Argument.of(BsonDocument))
         then:
             readSale.quantity.amount == 123
+            readSale.nullQuantity.amount == 123456
             newSaleBson.get('quantity').isInt32()
     }
 

--- a/serde-bson/src/test/java/io/micronaut/serde/bson/QuantityAttributeConverter.java
+++ b/serde-bson/src/test/java/io/micronaut/serde/bson/QuantityAttributeConverter.java
@@ -8,6 +8,7 @@ import io.micronaut.serde.Serde;
 import jakarta.inject.Singleton;
 
 import java.io.IOException;
+import java.util.Objects;
 
 // Keep Serde<Object> so it isn't pickup as Serde<Quantity>
 @Singleton
@@ -15,6 +16,8 @@ public class QuantityAttributeConverter implements Serde<Object> {
 
     @Override
     public Quantity deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super Object> type) throws IOException {
+        Objects.requireNonNull(decoder);
+        Objects.requireNonNull(decoderContext);
         if (!type.isAnnotationPresent(MyAnn1.class)) {
             throw new IllegalStateException("MyAnn1 is expected to be present");
         }
@@ -26,9 +29,23 @@ public class QuantityAttributeConverter implements Serde<Object> {
 
     @Override
     public void serialize(Encoder encoder, EncoderContext context, Object value, Argument<? extends Object> type) throws IOException {
+        Objects.requireNonNull(encoder);
+        Objects.requireNonNull(context);
         if (!type.isAnnotationPresent(MyAnn1.class)) {
             throw new IllegalStateException("MyAnn1 is expected to be present");
         }
         encoder.encodeInt(((Quantity) value).getAmount());
+    }
+
+    @Override
+    public Object getDefaultValue(DecoderContext decoderContext, Argument<? super Object> type) {
+        Objects.requireNonNull(decoderContext);
+        if (!type.isAnnotationPresent(MyAnn1.class)) {
+            throw new IllegalStateException("MyAnn1 is expected to be present");
+        }
+        if (!type.isAnnotationPresent(MyAnn2.class)) {
+            throw new IllegalStateException("MyAnn2 is expected to be present");
+        }
+        return new Quantity(123456);
     }
 }

--- a/serde-bson/src/test/java/io/micronaut/serde/bson/Sale1.java
+++ b/serde-bson/src/test/java/io/micronaut/serde/bson/Sale1.java
@@ -1,5 +1,6 @@
 package io.micronaut.serde.bson;
 
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.serde.annotation.Serdeable;
 import org.bson.codecs.pojo.annotations.BsonId;
 
@@ -11,6 +12,13 @@ public class Sale1 {
     @Serdeable.Deserializable(using = QuantityAttributeConverter.class, as = Integer.class)
     private Quantity quantity;
 
+    @NonNull
+    @MyAnn1
+    @MyAnn2
+    @Serdeable.Serializable(using = QuantityAttributeConverter.class, as = Integer.class)
+    @Serdeable.Deserializable(using = QuantityAttributeConverter.class, as = Integer.class)
+    private Quantity nullQuantity;
+
     @BsonId
     private String id;
 
@@ -20,6 +28,14 @@ public class Sale1 {
 
     public Quantity getQuantity() {
         return quantity;
+    }
+
+    public Quantity getNullQuantity() {
+        return nullQuantity;
+    }
+
+    public void setNullQuantity(Quantity nullQuantity) {
+        this.nullQuantity = nullQuantity;
     }
 
     public String getId() {

--- a/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeRegistry.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeRegistry.java
@@ -1142,7 +1142,7 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
         }
 
         @Override
-        public OptionalInt getDefaultValue() {
+        public OptionalInt getDefaultValue(DecoderContext decoderContext, Argument<? super OptionalInt> type) {
             return OptionalInt.empty();
         }
 
@@ -1200,7 +1200,7 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
         }
 
         @Override
-        public OptionalDouble getDefaultValue() {
+        public OptionalDouble getDefaultValue(DecoderContext decoderContext, Argument<? super OptionalDouble> type) {
             return OptionalDouble.empty();
         }
 
@@ -1236,7 +1236,7 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
         }
 
         @Override
-        public OptionalLong getDefaultValue() {
+        public OptionalLong getDefaultValue(DecoderContext decoderContext, Argument<? super OptionalLong> type) {
             return OptionalLong.empty();
         }
 

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/CoreDeserializers.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/CoreDeserializers.java
@@ -199,7 +199,7 @@ public class CoreDeserializers {
             }
 
             @Override
-            public Optional<V> getDefaultValue() {
+            public Optional<V> getDefaultValue(DecoderContext decoderContext, Argument<? super Optional<V>> type) {
                 return Optional.empty();
             }
         };
@@ -217,7 +217,7 @@ public class CoreDeserializers {
                 if (type.isInstance(o)) {
                     return (M) o;
                 } else if (o instanceof Map) {
-                    final M map = getDefaultValue();
+                    final M map = getDefaultValue(decoderContext, type);
                     map.putAll((Map) o);
                     return map;
                 } else {
@@ -232,7 +232,7 @@ public class CoreDeserializers {
                 final Deserializer<? extends V> valueDeser = valueType.equalsType(Argument.OBJECT_ARGUMENT) ? null : decoderContext.findDeserializer(valueType);
                 final Decoder objectDecoder = decoder.decodeObject(type);
                 String key = objectDecoder.decodeKey();
-                M map = getDefaultValue();
+                M map = getDefaultValue(decoderContext, type);
                 while (key != null) {
                     K k;
                     if (keyType.isInstance(key)) {
@@ -267,6 +267,11 @@ public class CoreDeserializers {
 
         @Override
         @NonNull
+        default M getDefaultValue(DecoderContext decoderContext, Argument<? super M> type) {
+            return getDefaultValue();
+        }
+
+        @NonNull
         M getDefaultValue();
     }
 
@@ -281,7 +286,7 @@ public class CoreDeserializers {
             @SuppressWarnings("unchecked") final Argument<E> generic = (Argument<E>) generics[0];
             final Deserializer<? extends E> valueDeser = decoderContext.findDeserializer(generic);
             final Decoder arrayDecoder = decoder.decodeArray();
-            C collection = getDefaultValue();
+            C collection = getDefaultValue(decoderContext, type);
             while (arrayDecoder.hasNextArrayValue()) {
                 collection.add(
                         valueDeser.deserialize(
@@ -301,6 +306,11 @@ public class CoreDeserializers {
         }
 
         @Override
+        @NonNull
+        default C getDefaultValue(DecoderContext decoderContext, Argument<? super C> type) {
+            return getDefaultValue();
+        }
+
         @NonNull
         C getDefaultValue();
     }

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBean.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBean.java
@@ -618,7 +618,7 @@ class DeserBean<T> {
                     .orElse(null);
         }
 
-        public void setDefault(@NonNull B bean) throws SerdeException {
+        public void setDefault(Deserializer.DecoderContext decoderContext, @NonNull B bean) throws SerdeException {
             if (writer != null && defaultValue != null) {
                 writer.accept(bean, defaultValue);
                 return;
@@ -627,7 +627,7 @@ class DeserBean<T> {
                 return;
             }
             if (writer != null) {
-                P newDefaultValue = (P) deserializer.getDefaultValue();
+                P newDefaultValue = (P) deserializer.getDefaultValue(decoderContext, (Argument) argument);
                 if (newDefaultValue != null) {
                     writer.accept(bean, newDefaultValue);
                     return;
@@ -637,7 +637,7 @@ class DeserBean<T> {
                     "] is not present in supplied data");
         }
 
-        public void setDefault(@NonNull Object[] params) throws SerdeException {
+        public void setDefault(Deserializer.DecoderContext decoderContext, @NonNull Object[] params) throws SerdeException {
             if (defaultValue != null) {
                 params[index] = defaultValue;
                 return;
@@ -645,7 +645,7 @@ class DeserBean<T> {
             if (!required) {
                 return;
             }
-            P newDefaultValue = (P) deserializer.getDefaultValue();
+            P newDefaultValue = (P) deserializer.getDefaultValue(decoderContext, (Argument) argument);
             if (newDefaultValue != null) {
                 params[index] = newDefaultValue;
                 return;

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/ObjectDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/ObjectDeserializer.java
@@ -261,7 +261,7 @@ public class ObjectDeserializer implements NullableDeserializer<Object>, Updatin
                             if (ref != null) {
                                 final Object o = ref.getReference();
                                 if (o == null) {
-                                    sp.setDefault(params);
+                                    sp.setDefault(decoderContext, params);
                                 } else {
                                     params[sp.index] = o;
                                 }
@@ -271,7 +271,7 @@ public class ObjectDeserializer implements NullableDeserializer<Object>, Updatin
                         if (sp.unwrapped != null && buffer != null) {
                             final Object o = materializeFromBuffer(sp, buffer, decoderContext);
                             if (o == null) {
-                                sp.setDefault(params);
+                                sp.setDefault(decoderContext, params);
                             } else {
                                 params[sp.index] = o;
                             }
@@ -280,7 +280,7 @@ public class ObjectDeserializer implements NullableDeserializer<Object>, Updatin
                                 anyValues.bind(params);
                                 anyValues = null;
                             } else {
-                                sp.setDefault(params);
+                                sp.setDefault(decoderContext, params);
                             }
                         }
                     }
@@ -551,7 +551,7 @@ public class ObjectDeserializer implements NullableDeserializer<Object>, Updatin
                     if (propertyType.isNullable()) {
                         property.set(obj, null);
                     } else {
-                        property.setDefault(obj);
+                        property.setDefault(decoderContext, obj);
                     }
                     continue;
                 }
@@ -644,14 +644,14 @@ public class ObjectDeserializer implements NullableDeserializer<Object>, Updatin
                     if (ref != null) {
                         final Object o = ref.getReference();
                         if (o == null) {
-                            dp.setDefault(obj);
+                            dp.setDefault(decoderContext, obj);
                         } else {
                             //noinspection unchecked
                             ((DeserBean.DerProperty) dp).set(obj, o);
                         }
                     }
                 } else {
-                    dp.setDefault(obj);
+                    dp.setDefault(decoderContext, obj);
                 }
             }
         }
@@ -707,7 +707,7 @@ public class ObjectDeserializer implements NullableDeserializer<Object>, Updatin
                         }
                     }
                     if (!satisfied) {
-                        der.setDefault(object);
+                        der.setDefault(decoderContext, object);
                     }
                 }
             }


### PR DESCRIPTION
BTW it might be a good idea to change the order of the parameters in `createSpecific` to have the same order as in `deserialize`: context and then the type, in the same way, `serialize` can have context, type, and then value.