### PR TITLE
add DeserializationConfiguration default value

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/config/DeserializationConfiguration.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/DeserializationConfiguration.java
@@ -15,10 +15,7 @@
  */
 package io.micronaut.serde.config;
 
-import java.util.OptionalInt;
-
 import io.micronaut.context.annotation.ConfigurationProperties;
-import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.core.util.StringUtils;
 

--- a/serde-api/src/main/java/io/micronaut/serde/config/DeserializationConfiguration.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/DeserializationConfiguration.java
@@ -18,6 +18,7 @@ package io.micronaut.serde.config;
 import java.util.OptionalInt;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.core.util.StringUtils;
 
@@ -38,5 +39,6 @@ public interface DeserializationConfiguration {
     /**
      * @return The array size thresh hold for use in binding. Defaults to {@code 100}.
      */
-    OptionalInt getArraySizeThreshold();
+    @Bindable(defaultValue = "100")
+    int getArraySizeThreshold();
 }

--- a/serde-api/src/test/groovy/io/micronaut/serde/config/DeserializationConfigurationSpec.groovy
+++ b/serde-api/src/test/groovy/io/micronaut/serde/config/DeserializationConfigurationSpec.groovy
@@ -1,0 +1,16 @@
+package io.micronaut.serde.config
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class DeserializationConfigurationSpec extends Specification {
+    @Inject
+    DeserializationConfiguration deserializationConfiguration;
+
+    void "micronaut.serde.deserialization.array-size-threshold defaults to 100"() {
+        expect:
+        deserializationConfiguration.arraySizeThreshold == 100
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/config/SerdeJsonConfiguration.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/config/SerdeJsonConfiguration.java
@@ -46,6 +46,6 @@ public class SerdeJsonConfiguration implements JsonConfiguration {
 
     @Override
     public int getArraySizeThreshold() {
-        return deserialization.getArraySizeThreshold().orElse(100);
+        return deserialization.getArraySizeThreshold();
     }
 }


### PR DESCRIPTION
Javadoc says it defaults to 100 but the bean of type `DeserializationConfiguration` does not have any default value.