### PR TITLE
Do not require primitive constructor values by default

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
@@ -68,6 +68,11 @@ public @interface SerdeConfig {
     String PROPERTY = "property";
 
     /**
+     * Whether this property is required (must be present in the input).
+     */
+    String REQUIRED = "required";
+
+    /**
      * Is it ignored.
      */
     String IGNORED = "ignored";

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/JsonPropertySpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/JsonPropertySpec.groovy
@@ -204,13 +204,13 @@ import io.micronaut.serde.annotation.Serdeable;
 
 @Serdeable
 class Test {
-    private final int value;
+    private final $type value;
     
-    Test(int value) {
+    Test($type value) {
         this.value = value;
     }
 
-    public int getValue() {
+    public $type getValue() {
         return value;
     }
 }
@@ -224,6 +224,15 @@ class Test {
 
         cleanup:
         ctx.close()
+
+        where:
+        type      | value
+        "byte" | (byte) 0
+        "short" | (short) 0
+        "int" | 0
+        "long" | 0L
+        "float" | 0F
+        "double" | 0D
     }
 
     @Unroll

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/JsonPropertySpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/JsonPropertySpec.groovy
@@ -201,6 +201,7 @@ package test;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.micronaut.serde.annotation.Serdeable;
+import io.micronaut.core.annotation.Nullable;
 
 @Serdeable
 class Test {
@@ -220,19 +221,26 @@ class Test {
         def bean =
                 jsonMapper.readValue('{}', argumentOf(ctx, 'test.Test'))
         then:
-        bean.value == 0
+        bean.value == value
 
         cleanup:
         ctx.close()
 
         where:
         type      | value
-        "byte" | (byte) 0
-        "short" | (short) 0
-        "int" | 0
-        "long" | 0L
-        "float" | 0F
-        "double" | 0D
+        "byte"    | (byte) 0
+        "short"   | (short) 0
+        "int"     | 0
+        "long"    | 0L
+        "float"   | 0F
+        "double"  | 0D
+
+        "@Nullable Byte"    | null
+        "@Nullable Short"   | null
+        "@Nullable Integer" | null
+        "@Nullable Long"    | null
+        "@Nullable Float"   | null
+        "@Nullable Double"  | null
     }
 
     @Unroll

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/jackson/JsonPropertyMapper.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/jackson/JsonPropertyMapper.java
@@ -60,6 +60,9 @@ public class JsonPropertyMapper implements NamedAnnotationMapper {
                 // no-op
             }
         }
+        if (annotation.booleanValue("required").orElse(false)) {
+            builder.member(SerdeConfig.REQUIRED, true);
+        }
         values.add(builder.build());
         return values;
     }

--- a/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeRegistry.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeRegistry.java
@@ -20,6 +20,7 @@ import io.micronaut.context.BeanRegistration;
 import io.micronaut.context.annotation.Secondary;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.annotation.Order;
 import io.micronaut.core.beans.BeanIntrospection;
 import io.micronaut.core.order.OrderUtil;
@@ -447,6 +448,12 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
                     getType(), Argument.BYTE
             );
         }
+
+        @Nullable
+        @Override
+        public Byte getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Byte> type) {
+            return type.isPrimitive() ? (byte) 0 : null;
+        }
     }
 
     private static final class DoubleSerde extends SerdeRegistrar<Double> implements NumberSerde<Double> {
@@ -474,6 +481,12 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
             return Arrays.asList(
                     getType(), Argument.DOUBLE
             );
+        }
+
+        @Nullable
+        @Override
+        public Double getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Double> type) {
+            return type.isPrimitive() ? 0D : null;
         }
     }
 
@@ -503,6 +516,12 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
                     getType(), Argument.SHORT
             );
         }
+
+        @Nullable
+        @Override
+        public Short getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Short> type) {
+            return type.isPrimitive() ? (short) 0 : null;
+        }
     }
 
     private static final class FloatSerde extends SerdeRegistrar<Float> implements NumberSerde<Float> {
@@ -530,6 +549,12 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
             return Arrays.asList(
                     getType(), Argument.FLOAT
             );
+        }
+
+        @Nullable
+        @Override
+        public Float getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Float> type) {
+            return type.isPrimitive() ? 0F : null;
         }
     }
 
@@ -559,6 +584,12 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
                     getType(), Argument.INT
             );
         }
+
+        @Nullable
+        @Override
+        public Integer getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Integer> type) {
+            return type.isPrimitive() ? 0 : null;
+        }
     }
 
     private static final class LongSerde extends SerdeRegistrar<Long> implements NumberSerde<Long> {
@@ -586,6 +617,12 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
             return Arrays.asList(
                     getType(), Argument.LONG
             );
+        }
+
+        @Nullable
+        @Override
+        public Long getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Long> type) {
+            return type.isPrimitive() ? 0L : null;
         }
     }
 

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBean.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBean.java
@@ -664,31 +664,20 @@ class DeserBean<T> {
 
         public void setDefault(Deserializer.DecoderContext decoderContext, @NonNull B bean) throws SerdeException {
             if (!explicitlyRequired) {
-                if (defaultValue != null) {
+                P def = defaultValue;
+                if (def == null) {
+                    if (!mustSetField) {
+                        return;
+                    }
+                    def = (P) deserializer.getDefaultValue(decoderContext, (Argument) argument);
+                }
+                if (def != null) {
                     if (beanProperty != null) {
-                        beanProperty.setUnsafe(bean, defaultValue);
+                        beanProperty.setUnsafe(bean, def);
                         return;
                     }
                     if (beanMethod != null) {
-                        beanMethod.invoke(bean, defaultValue);
-                        return;
-                    }
-                }
-
-                if (!mustSetField) {
-                    return;
-                }
-                if (beanProperty != null) {
-                    P newDefaultValue = (P) deserializer.getDefaultValue(decoderContext, (Argument) argument);
-                    if (newDefaultValue != null) {
-                        beanProperty.setUnsafe(bean, newDefaultValue);
-                        return;
-                    }
-                }
-                if (beanMethod != null) {
-                    P newDefaultValue = (P) deserializer.getDefaultValue(decoderContext, (Argument) argument);
-                    if (newDefaultValue != null) {
-                        beanMethod.invoke(bean, newDefaultValue);
+                        beanMethod.invoke(bean, def);
                         return;
                     }
                 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SpecificObjectDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SpecificObjectDeserializer.java
@@ -655,7 +655,7 @@ class SpecificObjectDeserializer implements Deserializer<Object>, UpdatingDeseri
                     if (!satisfied) {
                         if (der.defaultValue != null) {
                             params[der.index] = der.defaultValue;
-                        } else if (der.required) {
+                        } else if (der.mustSetField) {
                             throw new SerdeException("Unable to deserialize type [" + unwrapped.introspection.getBeanType() + "]. Required constructor parameter [" + der.argument + "] at index [" + der.index + "] is not present in supplied data");
 
                         }


### PR DESCRIPTION
This matches jackson behavior. There was previously an error trying to set primitives to `null`, this patch assigns them the default value, instead.
Also introduces support for `@JsonProperty(required=true)` to allow requiring primitive properties as well.
Fixes #169