### PR TITLE
Fix subtyping serialization

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
-projectVersion=1.0.2-SNAPSHOT
+projectVersion=1.1.0-SNAPSHOT
 projectGroup=io.micronaut.serde
 micronautDocsVersion=2.0.0
-micronautVersion=3.3.3
+micronautVersion=3.4.4
 micronautTestVersion=3.0.5
 groovyVersion=3.0.9
 spockVersion=2.0-groovy-3.0

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/JsonTypeInfoSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/JsonTypeInfoSpec.groovy
@@ -517,7 +517,7 @@ class Cat extends Animal {
 
         then:
         readDog.getClass().name.contains(".Dog")
-        readDog.friend.getClass().name.contains(".Cat")    
+        readDog.friend.getClass().name.contains("Cat")    
 
         cleanup:
         context.close()

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/JsonTypeInfoSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/JsonTypeInfoSpec.groovy
@@ -509,8 +509,15 @@ class Cat extends Animal {
         def catJson = writeJson(jsonMapper, cat)
 
         then:
-        dogJson == '{"type":"dog","barkVolume":1.1,"name":"Fred", "friend": {"type":"cat","likesCream":true,"lives":9,"name":"Joe"}}'
+        dogJson == '{"type":"dog","barkVolume":1.1,"friend":{"type":"cat","likesCream":true,"lives":9,"name":"Joe"},"name":"Fred"}'
         catJson == '{"type":"cat","likesCream":true,"lives":9,"name":"Joe"}'
+
+        when:
+        def readDog = jsonMapper.readValue(dogJson, argumentOf(context, 'subtypes.Animal'))
+
+        then:
+        readDog.getClass().name.contains(".Dog")
+        readDog.friend.getClass().name.contains(".Cat")    
 
         cleanup:
         context.close()

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/CustomizedObjectArraySerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/CustomizedObjectArraySerializer.java
@@ -42,7 +42,6 @@ public final class CustomizedObjectArraySerializer implements Serializer<Object[
     public void serialize(Encoder encoder, EncoderContext context, Argument<? extends Object[]> type, Object[] value)
             throws IOException {
         final Encoder arrayEncoder = encoder.encodeArray(type);
-        // TODO: need better generics handling in core for arrays
         for (Object v : value) {
             componentSerializer.serialize(
                     arrayEncoder,

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedObjectSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedObjectSerializer.java
@@ -41,6 +41,8 @@ import java.util.Map;
  *     <li>When the user explicitly calls {@link io.micronaut.json.JsonMapper#writeValue}{@code (gen, }{@link Object}{@code
  *     .class)}</li>
  * </ul>
+ *
+ * @param <T> The type to serialize
  */
 @Internal
 public class CustomizedObjectSerializer<T> implements Serializer<T> {

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/ObjectSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/ObjectSerializer.java
@@ -149,11 +149,11 @@ public final class ObjectSerializer implements CustomizableSerializer<Object> {
                     };
                 }
             }
-            if (serBean.simpleBean) {
-                return new SimpleObjectSerializer<>(serBean);
-            } else if (serBean.subtyped) {
+            if (serBean.subtyped) {
                 return new RuntimeTypeSerializer(encoderContext);        
-            }
+            } else if (serBean.simpleBean) {
+                return new SimpleObjectSerializer<>(serBean);
+            } 
             return new CustomizedObjectSerializer<>(serBean);
         }
     }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/ObjectSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/ObjectSerializer.java
@@ -18,7 +18,6 @@ package io.micronaut.serde.support.serializers;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.beans.exceptions.IntrospectionException;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.util.CollectionUtils;
@@ -28,7 +27,6 @@ import io.micronaut.serde.SerdeIntrospections;
 import io.micronaut.serde.Serializer;
 import io.micronaut.serde.config.SerializationConfiguration;
 import io.micronaut.serde.config.annotation.SerdeConfig;
-import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.util.TypeKey;
 import io.micronaut.serde.util.CustomizableSerializer;
 import jakarta.inject.Singleton;
@@ -42,6 +40,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
+
+import io.micronaut.core.beans.exceptions.IntrospectionException;
+import io.micronaut.serde.exceptions.SerdeException;
 
 /**
  * Fallback {@link io.micronaut.serde.Serializer} for general {@link Object} values. For deserialization, deserializes to
@@ -211,7 +212,7 @@ public final class ObjectSerializer implements CustomizableSerializer<Object> {
 
     private static class RuntimeTypeSerializer implements Serializer<Object> {
         private final EncoderContext encoderContext;
-        private Serializer<Object> inner;
+        private final Map<Class<?>, Serializer<Object>> inners = new ConcurrentHashMap();
 
         public RuntimeTypeSerializer(EncoderContext encoderContext) {
             this.encoderContext = encoderContext;
@@ -255,10 +256,21 @@ public final class ObjectSerializer implements CustomizableSerializer<Object> {
         }
 
         private Serializer<Object> getSerializer(EncoderContext context, Object value) throws SerdeException {
-            if (inner == null) {
-                inner = tryToFindSerializer(context, value);
+            try {
+                return inners.computeIfAbsent(value.getClass(), (t) -> {
+                    try {
+                        return tryToFindSerializer(context, value);
+                    } catch (SerdeException ex) {
+                        throw new IntrospectionException("No serializer found for type: " + value.getClass(), ex);
+                    }
+                });
+            } catch (IntrospectionException e) {
+                if (e.getCause() instanceof SerdeException) {
+                    throw (SerdeException) e.getCause();
+                } else {
+                    throw e;
+                }
             }
-            return inner;
         }
 
         protected Serializer<Object> tryToFindSerializer(EncoderContext context, Object value) throws SerdeException {

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/ObjectSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/ObjectSerializer.java
@@ -212,7 +212,7 @@ public final class ObjectSerializer implements CustomizableSerializer<Object> {
 
     private static class RuntimeTypeSerializer implements Serializer<Object> {
         private final EncoderContext encoderContext;
-        private final Map<Class<?>, Serializer<Object>> inners = new ConcurrentHashMap();
+        private final Map<Class<?>, Serializer<Object>> inners = new ConcurrentHashMap<>(10);
 
         public RuntimeTypeSerializer(EncoderContext encoderContext) {
             this.encoderContext = encoderContext;
@@ -257,7 +257,7 @@ public final class ObjectSerializer implements CustomizableSerializer<Object> {
 
         private Serializer<Object> getSerializer(EncoderContext context, Object value) throws SerdeException {
             try {
-                return inners.computeIfAbsent(value.getClass(), (t) -> {
+                return inners.computeIfAbsent(value.getClass(), t -> {
                     try {
                         return tryToFindSerializer(context, value);
                     } catch (SerdeException ex) {

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBean.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBean.java
@@ -51,6 +51,8 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import io.micronaut.serde.config.annotation.SerdeConfig;
+
 @Internal
 final class SerBean<T> {
     private static final Comparator<BeanProperty<?, Object>> BEAN_PROPERTY_COMPARATOR = (o1, o2) -> OrderUtil.COMPARATOR.compare(
@@ -80,6 +82,7 @@ final class SerBean<T> {
     public SerProperty<T, Object> jsonValue;
     public final SerializationConfiguration configuration;
     public final boolean simpleBean;
+    public final boolean subtyped;
 
     private volatile boolean initialized;
     private List<Initializer> initializers = new ArrayList<>();
@@ -273,6 +276,7 @@ final class SerBean<T> {
             }
         }
         simpleBean = isSimpleBean();
+        subtyped = introspection.getAnnotationMetadata().hasDeclaredAnnotation(SerdeConfig.SerSubtyped.class);
     }
 
     public void initialize(Serializer.EncoderContext encoderContext) throws SerdeException {

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBean.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBean.java
@@ -36,7 +36,6 @@ import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.serde.SerdeIntrospections;
 import io.micronaut.serde.Serializer;
 import io.micronaut.serde.config.SerializationConfiguration;
-import io.micronaut.serde.config.annotation.SerdeConfig;
 import io.micronaut.serde.config.naming.PropertyNamingStrategy;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.util.SerdeAnnotationUtil;
@@ -278,7 +277,8 @@ final class SerBean<T> {
             }
         }
         simpleBean = isSimpleBean();
-        subtyped = Modifier.isAbstract(introspection.getBeanType().getModifiers()) || introspection.getAnnotationMetadata().hasDeclaredAnnotation(SerdeConfig.SerSubtyped.class);
+        boolean isAbstractIntrospection = Modifier.isAbstract(introspection.getBeanType().getModifiers());
+        subtyped = isAbstractIntrospection || introspection.getAnnotationMetadata().hasDeclaredAnnotation(SerdeConfig.SerSubtyped.class);
     }
 
     public void initialize(Serializer.EncoderContext encoderContext) throws SerdeException {

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBean.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBean.java
@@ -15,6 +15,8 @@
  */
 package io.micronaut.serde.support.serializers;
 
+import java.lang.reflect.Modifier;
+
 import io.micronaut.core.annotation.AnnotatedElement;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
@@ -276,7 +278,7 @@ final class SerBean<T> {
             }
         }
         simpleBean = isSimpleBean();
-        subtyped = introspection.getAnnotationMetadata().hasDeclaredAnnotation(SerdeConfig.SerSubtyped.class);
+        subtyped = Modifier.isAbstract(introspection.getBeanType().getModifiers()) || introspection.getAnnotationMetadata().hasDeclaredAnnotation(SerdeConfig.SerSubtyped.class);
     }
 
     public void initialize(Serializer.EncoderContext encoderContext) throws SerdeException {


### PR DESCRIPTION
Use the runtime type if subtyping is involved or the type is abstract. Fixes #204

Also fixes #176
