### PR TITLE
Throw EOFException when attempting to parse empty JSON input

### DIFF
--- a/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonDecoder.java
+++ b/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonDecoder.java
@@ -25,6 +25,7 @@ import io.micronaut.serde.Decoder;
 import io.micronaut.serde.exceptions.InvalidFormatException;
 import io.micronaut.serde.exceptions.SerdeException;
 
+import java.io.EOFException;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -56,6 +57,9 @@ public final class JacksonDecoder extends AbstractChildReuseStreamDecoder {
     public static Decoder create(JsonParser parser, Class<?> view) throws IOException {
         if (!parser.hasCurrentToken()) {
             parser.nextToken();
+            if (!parser.hasCurrentToken()) {
+                throw new EOFException("No JSON input to parse");
+            }
         }
         if (parser instanceof UTF8StreamJsonParser) {
             return new SpecializedJacksonDecoder((UTF8StreamJsonParser) parser, view);

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/JacksonDecoderSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/JacksonDecoderSpec.groovy
@@ -117,4 +117,11 @@ class JacksonDecoderSpec extends Specification {
                 f4: [56, [f5: 'bar']]
         ]
     }
+
+    def "empty input"() {
+        when:
+        createDecoder('').decodeString()
+        then:
+        thrown EOFException
+    }
 }


### PR DESCRIPTION
Previously it would throw an NPE further downstream, which is misleading and may be handled improperly.
Fixes #214