### PR TITLE
Make jackson JsonMapper available in boostrap context

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/config/DeserializationConfiguration.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/DeserializationConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.config;
 
+import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.core.util.StringUtils;
@@ -23,6 +24,7 @@ import io.micronaut.core.util.StringUtils;
  * Configuration for deserialization.
  */
 @ConfigurationProperties(DeserializationConfiguration.PREFIX)
+@BootstrapContextCompatible
 public interface DeserializationConfiguration {
     String PREFIX = SerdeConfiguration.PREFIX + ".deserialization";
 

--- a/serde-api/src/main/java/io/micronaut/serde/config/SerializationConfiguration.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/SerializationConfiguration.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.config;
 
+import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.bind.annotation.Bindable;
@@ -25,6 +26,7 @@ import io.micronaut.serde.config.annotation.SerdeConfig;
  * Configuration for serialization.
  */
 @ConfigurationProperties(SerializationConfiguration.PREFIX)
+@BootstrapContextCompatible
 public interface SerializationConfiguration {
     String PREFIX = SerdeConfiguration.PREFIX + ".serialization";
 

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/BootstrapContextSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/BootstrapContextSpec.groovy
@@ -1,0 +1,53 @@
+package io.micronaut.serde.jackson
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.BootstrapContextCompatible
+import io.micronaut.context.annotation.Requires
+import io.micronaut.context.env.BootstrapPropertySourceLocator
+import io.micronaut.context.env.Environment
+import io.micronaut.context.env.PropertySource
+import io.micronaut.context.exceptions.ConfigurationException
+import io.micronaut.core.type.Argument
+import io.micronaut.core.util.StringUtils
+import io.micronaut.json.JsonMapper
+import io.micronaut.serde.annotation.Serdeable
+import jakarta.inject.Singleton
+import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
+class BootstrapContextSpec extends Specification {
+
+    @RestoreSystemProperties
+    void 'mapper should be available in bootstrap context'() {
+        given:
+        System.setProperty(Environment.BOOTSTRAP_CONTEXT_PROPERTY, StringUtils.TRUE)
+        def ctx = ApplicationContext.run(['spec.name': 'BootstrapContextSpec'])
+
+        expect:
+        ctx.getRequiredProperty('bootstrap-deser', MyBean).foo == 'bar'
+
+        cleanup:
+        ctx.close()
+    }
+
+    @Requires(property = 'spec.name', value = 'BootstrapContextSpec')
+    @Singleton
+    @BootstrapContextCompatible
+    static class Tester implements BootstrapPropertySourceLocator {
+        private final JsonMapper mapper
+
+        Tester(JsonMapper mapper) {
+            this.mapper = mapper
+        }
+
+        @Override
+        Iterable<PropertySource> findPropertySources(Environment environment) throws ConfigurationException {
+            return [PropertySource.of(['bootstrap-deser': mapper.readValue('{"foo":"bar"}', Argument.of(MyBean))])]
+        }
+    }
+
+    @Serdeable
+    static class MyBean {
+        String foo
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeIntrospections.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeIntrospections.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support;
 
+import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
 import io.micronaut.core.annotation.AnnotationValue;
@@ -49,6 +50,7 @@ import java.util.Set;
  * @author graemerocher
  */
 @Singleton
+@BootstrapContextCompatible
 public class DefaultSerdeIntrospections implements SerdeIntrospections {
 
     private final Set<String> serdePackages;

--- a/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeRegistry.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeRegistry.java
@@ -42,6 +42,7 @@ import java.util.stream.Stream;
 
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanRegistration;
+import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Secondary;
 import io.micronaut.context.exceptions.ConfigurationException;
 import io.micronaut.core.annotation.NonNull;
@@ -76,6 +77,7 @@ import jakarta.inject.Singleton;
  * Default implementation of the {@link io.micronaut.serde.SerdeRegistry} interface.
  */
 @Singleton
+@BootstrapContextCompatible
 public class DefaultSerdeRegistry implements SerdeRegistry {
 
     private final Serializer<Object> objectSerializer;

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/ObjectDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/ObjectDeserializer.java
@@ -18,6 +18,7 @@ package io.micronaut.serde.support.deserializers;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.beans.BeanIntrospection;
@@ -42,6 +43,7 @@ import jakarta.inject.Singleton;
  */
 @Singleton
 @Primary
+@BootstrapContextCompatible
 public class ObjectDeserializer implements CustomizableDeserializer<Object>, DeserBeanRegistry {
     private final SerdeIntrospections introspections;
     private final boolean ignoreUnknown;

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/CoreSerdes.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/CoreSerdes.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.Period;
 
+import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.type.Argument;
@@ -32,6 +33,7 @@ import jakarta.inject.Singleton;
  * Factory class for core serdes.
  */
 @Factory
+@BootstrapContextCompatible
 public class CoreSerdes {
     /**
      * Serde used for object arrays.
@@ -39,6 +41,7 @@ public class CoreSerdes {
      */
     @Singleton
     @NonNull
+    @BootstrapContextCompatible
     protected Serde<Object[]> objectArraySerde() {
         return new ObjectArraySerde();
     }
@@ -49,6 +52,7 @@ public class CoreSerdes {
      */
     @Singleton
     @NonNull
+    @BootstrapContextCompatible
     protected NullableSerde<Duration> durationSerde() {
         return new NullableSerde<Duration>() {
             @Override
@@ -71,6 +75,7 @@ public class CoreSerdes {
      */
     @Singleton
     @NonNull
+    @BootstrapContextCompatible
     protected NullableSerde<Period> periodSerde() {
         return new NullableSerde<Period>() {
             @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/ObjectSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/ObjectSerializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.serializers;
 
+import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
@@ -59,6 +60,7 @@ import io.micronaut.serde.exceptions.SerdeException;
 @Internal
 @Singleton
 @Primary
+@BootstrapContextCompatible
 public final class ObjectSerializer implements CustomizableSerializer<Object> {
     private final SerdeIntrospections introspections;
     private final SerializationConfiguration configuration;
@@ -156,7 +158,7 @@ public final class ObjectSerializer implements CustomizableSerializer<Object> {
             } else {
                 outer = new CustomizedObjectSerializer<>(serBean);
             }
-            
+
             if (serBean.subtyped) {
                 return new RuntimeTypeSerializer(encoderContext) {
                     @Override
@@ -165,10 +167,10 @@ public final class ObjectSerializer implements CustomizableSerializer<Object> {
                             return outer;
                         } else {
                             return super.tryToFindSerializer(context, value);
-                        }                        
+                        }
                     }
 
-                };        
+                };
             } else {
                 return outer;
             }
@@ -197,7 +199,7 @@ public final class ObjectSerializer implements CustomizableSerializer<Object> {
     private Serializer<Object> createRuntimeSerializer(EncoderContext encoderContext, Argument<? extends Object> type, IntrospectionException e) {
         // no introspection, create dynamic serialization case
         return new RuntimeTypeSerializer(encoderContext) {
-            
+
             @Override
             protected Serializer<Object> tryToFindSerializer(EncoderContext context, Object value) throws SerdeException {
                 final Class<Object> theType = (Class<Object>) value.getClass();


### PR DESCRIPTION
This patch adds a test for bootstrap compatibility, and adds `@BootstrapContextCompatible` to all necessary dependencies.
Fixes #238