### PR TITLE
Allow core deserializers to be used in bootstrap context

### DIFF
--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/BootstrapContextSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/BootstrapContextSpec.groovy
@@ -48,7 +48,7 @@ class BootstrapContextSpec extends Specification {
 
         @Override
         Publisher<PropertySource> getPropertySources(Environment environment) {
-            return Publishers.just(PropertySource.of(['bootstrap-deser': mapper.readValue('{"foo":"bar"}', Argument.of(MyBean))]))
+            return Publishers.just(PropertySource.of(['bootstrap-deser': mapper.readValue('{"foo":"bar", "strings":["one", "two"]}', Argument.of(MyBean))]))
         }
 
         @Override
@@ -60,5 +60,6 @@ class BootstrapContextSpec extends Specification {
     @Serdeable
     static class MyBean {
         String foo
+        List<String> strings
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/CoreDeserializers.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/CoreDeserializers.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.deserializers;
 
+import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Factory;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Order;
@@ -46,6 +47,7 @@ import java.util.TreeSet;
  * Core deserializers.
  */
 @Factory
+@BootstrapContextCompatible
 public class CoreDeserializers {
 
     /**


### PR DESCRIPTION
Without this change Vault fails to read keys when Micronaut Serialization is used