### PR TITLE
Issue #371:  Sets the currentToken to null after skipping a value

### DIFF
--- a/serde-bson/src/main/java/io/micronaut/serde/bson/BsonReaderDecoder.java
+++ b/serde-bson/src/main/java/io/micronaut/serde/bson/BsonReaderDecoder.java
@@ -314,6 +314,7 @@ public final class BsonReaderDecoder extends AbstractStreamDecoder {
     @Override
     protected void skipChildren() {
         bsonReader.skipValue();
+        currentToken = null;
     }
 
     @Override


### PR DESCRIPTION
The value of `currentToken` is used to read the next token. The MongoDB BSON reader consumes the full value and sets the internal state to TYPE. This change sets the `currentToken` to `null` so the next token can be read correctly