### PR TITLE
Add property filter

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/PropertyFilter.java
+++ b/serde-api/src/main/java/io/micronaut/serde/PropertyFilter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde;
+
+import io.micronaut.core.annotation.Indexed;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+
+/**
+ * Models a build time property filter. That is a class computed at build-time that can
+ * be used to decide which bean properties to serialize.
+ * Use {@link jakarta.inject.Named} annotation to specify a name for the property filter.
+ *
+ * @author Andriy Dmytruk
+ */
+@Indexed(PropertyFilter.class)
+public interface PropertyFilter {
+
+    /**
+     *
+     * @param encoderContext the encoder context
+     * @param propertySerializer the serializer of the property
+     * @param bean the object being serialized
+     * @param propertyName the name of the property
+     * @param propertyValue the property being serialized
+     *
+     * @return whether the property should be included in serialization
+     */
+    boolean shouldInclude(@NonNull Serializer.EncoderContext encoderContext, @NonNull Serializer<Object> propertySerializer, @NonNull Object bean, @NonNull String propertyName, @Nullable Object propertyValue);
+}

--- a/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
@@ -83,6 +83,11 @@ public @interface SerdeConfig {
     String INCLUDE = "include";
 
     /**
+     * Property filter name.
+     */
+    String FILTER = "filter";
+
+    /**
      * Is this property to be used only for reading.
      */
     String READ_ONLY = "readOnly";
@@ -185,6 +190,9 @@ public @interface SerdeConfig {
      */
     @Internal
     @interface SerIgnored {
+        /**
+         * Ignore handling meta annotation on type.
+         */
         @interface SerType { }
     }
 
@@ -264,10 +272,16 @@ public @interface SerdeConfig {
          */
         String DISCRIMINATOR_PROP = "dp";
 
+        /**
+         * The discriminator type.
+         */
         enum DiscriminatorType {
             PROPERTY, WRAPPER_OBJECT
         }
 
+        /**
+         * The discriminator value kind.
+         */
         enum DiscriminatorValueKind {
             CLASS_NAME, CLASS_SIMPLE_NAME, NAME
         }

--- a/serde-jackson/src/main/java/io/micronaut/serde/jackson/SpecializedJacksonEncoder.java
+++ b/serde-jackson/src/main/java/io/micronaut/serde/jackson/SpecializedJacksonEncoder.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.serde.jackson;
 
-import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonStreamContext;
 import com.fasterxml.jackson.core.json.UTF8JsonGenerator;
 import io.micronaut.core.annotation.NonNull;

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/JsonFilterSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/JsonFilterSpec.groovy
@@ -1,0 +1,110 @@
+package io.micronaut.serde.jackson.annotation
+
+import io.micronaut.serde.PropertyFilter
+import io.micronaut.serde.Serializer
+import io.micronaut.serde.jackson.JsonCompileSpec
+import jakarta.inject.Named
+import spock.lang.Requires
+import spock.lang.Unroll
+import jakarta.inject.Singleton
+
+
+@Requires({ jvm.isJava17Compatible() })
+class JsonFilterSpec extends JsonCompileSpec {
+
+    @Unroll
+    void "test @JsonFilter by boolean value for #value, (included = #include)"() {
+        given:
+        def context = buildContext("""
+package jsonfilter;
+
+import io.micronaut.serde.annotation.Serdeable;
+import com.fasterxml.jackson.annotation.JsonFilter;
+import io.micronaut.serde.Serializer;
+import io.micronaut.serde.PropertyFilter;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+@Serdeable
+@JsonFilter("explicitly-set")
+record Test (
+    String value,
+    boolean include
+) {}
+
+@Named("explicitly-set")
+@Singleton
+class ExplicitlySetFilter implements PropertyFilter {
+    public boolean shouldInclude(Serializer.EncoderContext context, Serializer<Object> ser, Object object, String name, Object val) {
+        if (object instanceof Test) {
+            return name.equals("value") && ((Test) object).include();
+        }
+        return true;
+    }
+}
+""")
+        def bean = newInstance(context, 'jsonfilter.Test', value, include)
+        String json = writeJson(jsonMapper, bean)
+
+        expect:
+        json == result
+
+        cleanup:
+        context.close()
+
+        where:
+        value   | include    | result
+        null    | true       | '{"value":null}'
+        null    | false      | '{}'
+        "value" | true       | '{"value":"value"}'
+        "value" | false      | '{}'
+        ""      | true       | '{"value":""}'
+        ""      | false      | '{}'
+    }
+
+    @Unroll
+    void "test @JsonFilter ignore a value for #value, (ignore = #ignoredValue)"() {
+        given:
+        def context = buildContext("""
+package jsonfilter;
+
+import io.micronaut.serde.annotation.Serdeable;
+import com.fasterxml.jackson.annotation.JsonFilter;
+import java.util.List;
+
+@Serdeable
+@JsonFilter("ignore-value")
+record Test (
+    ${type} value
+) {}
+""")
+        context.getBean(IgnoreValueFilter).ignoredValue = ignoredValue
+        def bean = newInstance(context, 'jsonfilter.Test', value)
+        String json = writeJson(jsonMapper, bean)
+
+        expect:
+        json == result
+
+        cleanup:
+        context.close()
+
+        where:
+        type           | ignoredValue | value       | result
+        'String'       | null         | null        | '{}'
+        'String'       | 'ignored'    | null        | '{"value":null}'
+        'String'       | 'ignored'    | 'ignored'   | '{}'
+        'List<String>' | ['ignored']  | ['ignored'] | '{}'
+        'List<String>' | []           | ['a', 'b']  | '{"value":["a","b"]}'
+        'List<String>' | null         | []          | '{"value":[]}'
+    }
+
+    @Named("ignore-value")
+    @Singleton
+    static class IgnoreValueFilter implements PropertyFilter {
+        Object ignoredValue
+
+        boolean shouldInclude(Serializer.EncoderContext context, Serializer<Object> ser, Object object, String name, Object val) {
+            return val != ignoredValue
+        }
+    }
+}

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/JsonIncludeSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/JsonIncludeSpec.groovy
@@ -76,4 +76,46 @@ record Test(
         NON_EMPTY  | "Map<String, String>" | ["test": "test"] | '{"test":{"test":"test"}}'
 
     }
+
+    @Unroll
+    void "test @JsonInclude(#include) on class for #type with #value"() {
+        given:
+        def context = buildContext("""
+package jsoninclude;
+
+import io.micronaut.serde.annotation.Serdeable;
+import com.fasterxml.jackson.annotation.*;
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.*;
+
+@Serdeable
+@JsonInclude(${include.name()})
+record Test(
+    $type test
+) {}
+""")
+        def bean = newInstance(context, 'jsoninclude.Test', value)
+        String json = writeJson(jsonMapper, bean)
+
+        expect:
+        json == result
+
+        cleanup:
+        context.close()
+
+        where:
+        include    | type                  | value            | result
+        ALWAYS     | "String"              | ""               | '{"test":""}'
+        ALWAYS     | "String"              | null             | '{"test":null}'
+        ALWAYS     | "String"              | "test"           | '{"test":"test"}'
+        NON_NULL   | "String"              | ""               | '{"test":""}'
+        NON_NULL   | "String"              | null             | '{}'
+        NON_NULL   | "String"              | "test"           | '{"test":"test"}'
+        NON_ABSENT | "String"              | ""               | '{"test":""}'
+        NON_ABSENT | "String"              | null             | '{}'
+        NON_ABSENT | "String"              | "test"           | '{"test":"test"}'
+        NON_EMPTY  | "String"              | ""               | '{}'
+        NON_EMPTY  | "String"              | null             | '{}'
+        NON_EMPTY  | "String"              | "test"           | '{"test":"test"}'
+
+    }
 }

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/SerdeAnnotationVisitor.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/SerdeAnnotationVisitor.java
@@ -102,7 +102,6 @@ public class SerdeAnnotationVisitor implements TypeElementVisitor<SerdeConfig, S
     private Set<String> getUnsupportedJacksonAnnotations() {
         return CollectionUtils.setOf(
                 "com.fasterxml.jackson.annotation.JsonKey",
-                "com.fasterxml.jackson.annotation.JsonFilter",
                 "com.fasterxml.jackson.annotation.JsonAutoDetect",
                 "com.fasterxml.jackson.annotation.JsonMerge",
                 "com.fasterxml.jackson.annotation.JsonIdentityInfo",

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/jackson/JsonFilterMapper.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/jackson/JsonFilterMapper.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.processor.jackson;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+import io.micronaut.serde.config.annotation.SerdeConfig;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Maps the {@code com.fasterxml.jackson.annotation.JsonFilter} annotation to {@link SerdeConfig}.
+ */
+public class JsonFilterMapper implements NamedAnnotationMapper {
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        final String name = annotation.stringValue().orElse(null);
+        if (name != null) {
+            return Collections.singletonList(
+                    AnnotationValue.builder(SerdeConfig.class)
+                            .member(SerdeConfig.FILTER, name)
+                            .build()
+            );
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getName() {
+        return "com.fasterxml.jackson.annotation.JsonFilter";
+    }
+}

--- a/serde-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
+++ b/serde-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
@@ -22,6 +22,7 @@ io.micronaut.serde.processor.jackson.JsonTypeNameMapper
 io.micronaut.serde.processor.jackson.JsonAnySetterMapper
 io.micronaut.serde.processor.jackson.JsonFormatMapper
 io.micronaut.serde.processor.jackson.JsonIncludeMapper
+io.micronaut.serde.processor.jackson.JsonFilterMapper
 io.micronaut.serde.processor.jackson.JacksonIgnorePropertiesMapper
 io.micronaut.serde.processor.jackson.JacksonIgnoreTypeMapper
 io.micronaut.serde.processor.jackson.JsonUnwrappedMapper

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedObjectSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedObjectSerializer.java
@@ -78,27 +78,35 @@ public class CustomizedObjectSerializer<T> implements Serializer<T> {
                         continue;
                     }
                 }
+
                 final Serializer<Object> serializer = property.serializer;
-                switch (property.include) {
-                case NON_NULL:
-                    if (v == null) {
+
+                if (serBean.propertyFilter != null) {
+                    if (!serBean.propertyFilter.shouldInclude(context, serializer, value, property.name, v)) {
                         continue;
                     }
-                    break;
-                case NON_ABSENT:
-                    if (serializer.isAbsent(context, v)) {
-                        continue;
+                } else {
+                    switch (property.include) {
+                        case NON_NULL:
+                            if (v == null) {
+                                continue;
+                            }
+                            break;
+                        case NON_ABSENT:
+                            if (serializer.isAbsent(context, v)) {
+                                continue;
+                            }
+                            break;
+                        case NON_EMPTY:
+                            if (serializer.isEmpty(context, v)) {
+                                continue;
+                            }
+                            break;
+                        case NEVER:
+                            continue;
+                        default:
+                            // fall through
                     }
-                    break;
-                case NON_EMPTY:
-                    if (serializer.isEmpty(context, v)) {
-                        continue;
-                    }
-                    break;
-                case NEVER:
-                    continue;
-                default:
-                    // fall through
                 }
 
                 if (property.views != null && !context.hasView(property.views)) {

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/ObjectSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/ObjectSerializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.serializers;
 
+import io.micronaut.context.BeanContext;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Primary;
 import io.micronaut.core.annotation.AnnotationMetadata;
@@ -67,11 +68,13 @@ import io.micronaut.serde.exceptions.SerdeException;
 public final class ObjectSerializer implements CustomizableSerializer<Object> {
     private final SerdeIntrospections introspections;
     private final SerializationConfiguration configuration;
+    private final BeanContext beanContext;
     private final Map<TypeKey, Supplier<SerBean<Object>>> serBeanMap = new ConcurrentHashMap<>(50);
 
-    public ObjectSerializer(SerdeIntrospections introspections, SerializationConfiguration configuration) {
+    public ObjectSerializer(SerdeIntrospections introspections, SerializationConfiguration configuration, BeanContext beanContext) {
         this.introspections = introspections;
         this.configuration = configuration;
+        this.beanContext = beanContext;
     }
 
     @Override
@@ -206,7 +209,7 @@ public final class ObjectSerializer implements CustomizableSerializer<Object> {
     @SuppressWarnings("unchecked")
     private SerBean<Object> create(Argument<? extends Object> type, EncoderContext encoderContext) {
         try {
-            return new SerBean<>((Argument<Object>) type, introspections, encoderContext, configuration);
+            return new SerBean<>((Argument<Object>) type, introspections, encoderContext, configuration, beanContext);
         } catch (SerdeException e) {
             throw new IntrospectionException("Error creating deserializer for type [" + type + "]: " + e.getMessage(), e);
         }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBean.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBean.java
@@ -17,6 +17,9 @@ package io.micronaut.serde.support.serializers;
 
 import java.lang.reflect.Modifier;
 
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.context.exceptions.NoSuchBeanException;
 import io.micronaut.core.annotation.AnnotatedElement;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
@@ -33,10 +36,13 @@ import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.order.Ordered;
 import io.micronaut.core.type.Argument;
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.serde.PropertyFilter;
 import io.micronaut.serde.SerdeIntrospections;
 import io.micronaut.serde.Serializer;
 import io.micronaut.serde.config.SerializationConfiguration;
 import io.micronaut.serde.config.naming.PropertyNamingStrategy;
+import io.micronaut.serde.exceptions.RuntimeSerdeException;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.util.SerdeAnnotationUtil;
 
@@ -85,6 +91,7 @@ final class SerBean<T> {
     public final SerializationConfiguration configuration;
     public final boolean simpleBean;
     public final boolean subtyped;
+    public final PropertyFilter propertyFilter;
 
     private volatile boolean initialized;
     private List<Initializer> initializers = new ArrayList<>();
@@ -94,10 +101,12 @@ final class SerBean<T> {
     SerBean(Argument<T> definition,
             SerdeIntrospections introspections,
             Serializer.EncoderContext encoderContext,
-            SerializationConfiguration configuration) throws SerdeException {
+            SerializationConfiguration configuration,
+            BeanContext beanContext) throws SerdeException {
         this.configuration = configuration;
         final AnnotationMetadata annotationMetadata = definition.getAnnotationMetadata();
         this.introspection = introspections.getSerializableIntrospection(definition);
+        this.propertyFilter = getPropertyFilterIfPresent(beanContext, definition.getSimpleName());
         PropertyNamingStrategy entityPropertyNamingStrategy = getPropertyNamingStrategy(introspection, encoderContext, null);
         final Collection<Map.Entry<BeanProperty<T, Object>, AnnotationMetadata>> properties =
                 introspection.getBeanProperties().stream()
@@ -310,6 +319,9 @@ final class SerBean<T> {
         if (wrapperProperty != null || anyGetter != null) {
             return false;
         }
+        if (propertyFilter != null) {
+            return false;
+        }
         for (SerProperty<T, Object> property : writeProperties) {
             if (property.backRef != null || property.include != SerdeConfig.SerInclude.ALWAYS || property.views != null || property.managedRef != null) {
                 return false;
@@ -374,6 +386,19 @@ final class SerBean<T> {
                     .orElse("");
         }
         return n;
+    }
+
+    private PropertyFilter getPropertyFilterIfPresent(BeanContext beanContext, String typeName) {
+        Optional<String> filterName = introspection.stringValue(SerdeConfig.class, SerdeConfig.FILTER);
+        if (filterName.isPresent() && !filterName.get().isEmpty()) {
+            try {
+                return beanContext.getBean(PropertyFilter.class, Qualifiers.byName(filterName.get()));
+            } catch (NoSuchBeanException e) {
+                throw new ConfigurationException("Json filter with name '" + filterName + "' was defined on type " +
+                    typeName + " but no PropertyFilter with the name exists");
+            }
+        }
+        return null;
     }
 
     static final class PropSerProperty<B, P> extends SerProperty<B, P> {

--- a/serde-tck/src/main/groovy/io/micronaut/serde/MockSerdeIntrospections.groovy
+++ b/serde-tck/src/main/groovy/io/micronaut/serde/MockSerdeIntrospections.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.serde
 
 import io.micronaut.context.ApplicationContext

--- a/src/main/docs/guide/jacksonAnnotations.adoc
+++ b/src/main/docs/guide/jacksonAnnotations.adoc
@@ -48,8 +48,8 @@ NOTE: If an unsupported annotation or member is used, a compilation error will r
 |
 
 |link:{jacksonAnnotationJavadoc}/JsonFilter.html[@JsonFilter]
-|❌
-|
+|✅
+|supported only on types, implement the io.micronaut.serde.PropertyFilter interface
 
 |link:{jacksonAnnotationJavadoc}/JsonFormat.html[@JsonFormat]
 |✅


### PR DESCRIPTION
Adds support for the [JsonFilter](https://fasterxml.github.io/jackson-annotations/javadoc/2.7/com/fasterxml/jackson/annotation/JsonFilter.html) annotation on types.

* The annotation seems to be only used during serialization, therefore deserialization is not modified.
* The annotation is allowed on properties but this wasn't implemented.
* [Jackson PropertyFilter](https://fasterxml.github.io/jackson-databind/javadoc/2.9/com/fasterxml/jackson/databind/ser/PropertyFilter.html) can be used to filter out container elements. It wasn't implemented yet.