### PR TITLE
Fix Property Filter usage with json property renaming

### DIFF
--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedObjectSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedObjectSerializer.java
@@ -82,7 +82,7 @@ public class CustomizedObjectSerializer<T> implements Serializer<T> {
                 final Serializer<Object> serializer = property.serializer;
 
                 if (serBean.propertyFilter != null) {
-                    if (!serBean.propertyFilter.shouldInclude(context, serializer, value, property.name, v)) {
+                    if (!serBean.propertyFilter.shouldInclude(context, serializer, value, property.argument.getName(), v)) {
                         continue;
                     }
                 } else {


### PR DESCRIPTION
Given the following property:
```java
@JsonProperty("my-property")
String myProperty;
```
the `PropertyFilter` should get `myProperty` as name instead of `my-property`.