### PR TITLE
Issue #371:  Sets the currentToken to null after skipping a value (#372)

### DIFF
--- a/serde-bson/src/main/java/io/micronaut/serde/bson/BsonReaderDecoder.java
+++ b/serde-bson/src/main/java/io/micronaut/serde/bson/BsonReaderDecoder.java
@@ -314,6 +314,7 @@ public final class BsonReaderDecoder extends AbstractStreamDecoder {
     @Override
     protected void skipChildren() {
         bsonReader.skipValue();
+        currentToken = null;
     }
 
     @Override


### PR DESCRIPTION
The value of `currentToken` is used to read the next token. The MongoDB BSON reader consumes the full value and sets the internal state to TYPE. This change sets the `currentToken` to `null` so the next token can be read correctly

(cherry picked from commit d874b7a9b93ceda9851872843bcbd9e40436968f)

NOTE: This has already been merged into `master` via #372 This is an attempt to get it into 1.5.1-SNAPSHOT build. (Sorry, I should have targeted this branch before)