### PR TITLE
Improve @JsonSubtypes Handling

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
@@ -99,8 +99,15 @@ public @interface SerdeConfig {
 
     /**
      * A type name mapping. Used for subtype binding.
+     * The type name to be used during serialization.
      */
     String TYPE_NAME = "typeName";
+
+    /**
+     * A type name mapping used for subtype binding with multiple names.
+     * All the names would be mapped to the class during deserialization.
+     */
+    String TYPE_NAMES = "typeNames";
 
     /**
      * A type name mapping. Used for subtype binding.

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/JsonSubtypesSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/JsonSubtypesSpec.groovy
@@ -1,0 +1,310 @@
+package io.micronaut.serde.jackson.annotation
+
+import io.micronaut.serde.jackson.JsonCompileSpec
+
+class JsonSubtypesSpec extends JsonCompileSpec {
+
+    void 'test json sub types using name deserialization'() {
+        given:
+        def context = buildContext('test.Base', """
+package test;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(
+    @JsonSubTypes.Type(value = Sub.class, name = "sub-class")
+)
+class Base {
+    private String string;
+
+    public Base(String string) {
+        this.string = string;
+    }
+
+    public String getString() {
+        return string;
+    }
+}
+
+@Serdeable
+class Sub extends Base {
+    private Integer integer;
+
+    public Sub(String string, Integer integer) {
+        super(string);
+        this.integer = integer;
+    }
+
+    public Integer getInteger() {
+        return integer;
+    }
+}
+""")
+        when:
+        def baseArg = argumentOf(context, "test.Base")
+        def result = jsonMapper.readValue('{"type":"sub-class","string":"a","integer":1}', baseArg)
+
+        then:
+        result.getClass().name == 'test.Sub'
+        result.string == 'a'
+        result.integer == 1
+
+        when:
+        result = jsonMapper.readValue('{"type":"some-other-type","string":"a","integer":1}', baseArg)
+
+        then:
+        result.getClass().name != 'test.Sub'
+
+        when:
+        result = jsonMapper.readValue('{"type":"Sub","string":"a","integer":1}', baseArg)
+
+        then:
+        result.getClass().name != 'test.Sub'
+    }
+
+    void 'test json sub types using name deserialization with type name defined'() {
+        given:
+        def context = buildContext('test.Base', """
+package test;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(
+    @JsonSubTypes.Type(value = Sub.class)
+)
+class Base {
+    private String string;
+
+    public Base(String string) {
+        this.string = string;
+    }
+
+    public String getString() {
+        return string;
+    }
+}
+
+@Serdeable
+@JsonTypeName("sub-class")
+class Sub extends Base {
+    private Integer integer;
+
+    public Sub(String string, Integer integer) {
+        super(string);
+        this.integer = integer;
+    }
+
+    public Integer getInteger() {
+        return integer;
+    }
+}
+""")
+        when:
+        def baseArg = argumentOf(context, "test.Base")
+        def result = jsonMapper.readValue('{"type":"sub-class","string":"a","integer":1}', baseArg)
+
+        then:
+        result.getClass().name == 'test.Sub'
+        result.string == 'a'
+        result.integer == 1
+
+        when:
+        result = jsonMapper.readValue('{"type":"some-other-type","string":"a","integer":1}', baseArg)
+
+        then:
+        result.getClass().name != 'test.Sub'
+
+        when:
+        result = jsonMapper.readValue('{"type":"Sub","string":"a","integer":1}', baseArg)
+
+        then:
+        result.getClass().name != 'test.Sub'
+    }
+
+    void 'test json sub types using name deserialization with names defined'() {
+        given:
+        def context = buildContext('test.Base', """
+package test;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(
+    @JsonSubTypes.Type(value = Sub.class, names = {"subClass", "sub-class"})
+)
+class Base {
+    private String string;
+
+    public Base(String string) {
+        this.string = string;
+    }
+
+    public String getString() {
+        return string;
+    }
+}
+
+@Serdeable
+@JsonTypeName("SubClass")
+class Sub extends Base {
+    private Integer integer;
+
+    public Sub(String string, Integer integer) {
+        super(string);
+        this.integer = integer;
+    }
+
+    public Integer getInteger() {
+        return integer;
+    }
+}
+""")
+        when:
+        def baseArg = argumentOf(context, "test.Base")
+        def result = jsonMapper.readValue('{"type":"sub-class","string":"a","integer":1}', baseArg)
+
+        then:
+        result.getClass().name == 'test.Sub'
+
+        when:
+        result = jsonMapper.readValue('{"type":"subClass","string":"a","integer":1}', baseArg)
+
+        then:
+        result.getClass().name == 'test.Sub'
+
+        when:
+        result = jsonMapper.readValue('{"type":"SubClass","string":"a","integer":1}', baseArg)
+
+        then:
+        result.getClass().name == 'test.Sub'
+    }
+
+    void 'test json sub types using name deserialization with wrapper'() {
+        given:
+        def context = buildContext('test.Base', """
+package test;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
+@JsonSubTypes(
+    @JsonSubTypes.Type(value = Sub.class, name = "subClass")
+)
+class Base {
+    private String string;
+
+    public Base(String string) {
+        this.string = string;
+    }
+
+    public String getString() {
+        return string;
+    }
+}
+
+@Serdeable
+class Sub extends Base {
+    private Integer integer;
+
+    public Sub(String string, Integer integer) {
+        super(string);
+        this.integer = integer;
+    }
+
+    public Integer getInteger() {
+        return integer;
+    }
+}
+""")
+        when:
+        def baseArg = argumentOf(context, "test.Base")
+        def result = jsonMapper.readValue('{"subClass":{"string":"a","integer":1}}', baseArg)
+
+        then:
+        result.getClass().name == 'test.Sub'
+    }
+
+    void 'test json sub types using name serialization'() {
+        given:
+        def context = buildContext('test.Base', """
+package test;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Sub.class, name = "sub-class"),
+    @JsonSubTypes.Type(value = A.class, names = {"sub-class-a", "subClassA"}),
+    @JsonSubTypes.Type(value = B.class, name = "ignore", names = {"Ignore"})
+})
+class Base {
+    private String string;
+
+    public Base(String string) {
+        this.string = string;
+    }
+
+    public String getString() {
+        return string;
+    }
+}
+
+class Sub extends Base {
+    private Integer integer;
+
+    public Sub(String string, Integer integer) {
+        super(string);
+        this.integer = integer;
+    }
+
+    public Integer getInteger() {
+        return integer;
+    }
+}
+
+@Serdeable
+class A extends Sub {
+    public A(String string, Integer integer) {
+        super(string, integer);
+    }
+}
+
+@JsonTypeName("sub-class-b")
+class B extends Sub {
+    public B(String string, Integer integer) {
+        super(string, integer);
+    }
+}
+""")
+        when:
+        def sub = newInstance(context, "test.Sub", "a", 1)
+        def a = newInstance(context, "test.A", "hello", 2)
+        def b = newInstance(context, "test.B", "b", 3)
+
+        then:
+        jsonMapper.writeValueAsString(sub) == '{"type":"sub-class","integer":1,"string":"a"}'
+        jsonMapper.writeValueAsString(a) == '{"type":"sub-class-a","integer":2,"string":"hello"}'
+        jsonMapper.writeValueAsString(b) == '{"type":"sub-class-b","integer":3,"string":"b"}'
+    }
+}


### PR DESCRIPTION
- The `@JsonSubtypes.Type` names property is now used and merged with type name to be used for deserialization
- The name property is used even if the subtype has `@SerdeConfig` annotation (in previous behavior the subtype annotation wasn't visited and therefore name wasn't used)
- The `@JsonTypeName` is prioritized over `@JsonSubtypes.Type` name and names properties

Examples of jackson behavior in this tutorial: https://www.logicbig.com/tutorials/misc/jackson/json-type-info-with-logical-type-name.html