### PR TITLE
JSON value and builder annotations support for enums for 1.5.x

### DIFF
--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/object/EnumSerdeSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/object/EnumSerdeSpec.groovy
@@ -27,7 +27,8 @@ class Test {
 @Serdeable
 enum Foo {
   BAR("br"),
-  BAZ("bz");
+  BAZ("bz"),
+  BAT("BT");
 
   private final String value;
 
@@ -50,11 +51,17 @@ enum Foo {
 }
 ''')
         def test = newInstance(compiled, 'enumtest.Test')
-        def testClass = test.getClass()
+        def BAR = getEnum(compiled, 'enumtest.Foo.BAR')
+        def BAT = getEnum(compiled, 'enumtest.Foo.BAT')
 
         expect:
         jsonMapper.writeValueAsString(test) == '{"data":"bz"}'
+        jsonMapper.writeValueAsString(BAR) == '"br"'
+        jsonMapper.writeValueAsString(BAT) == '"BT"'
+
         jsonMapper.readValue('{"data":"bz"}', argumentOf(compiled, 'enumtest.Test')).data.name() == "BAZ"
+        jsonMapper.readValue('"br"', argumentOf(compiled, "enumtest.Foo")) == BAR
+        jsonMapper.readValue('"BT"', argumentOf(compiled, "enumtest.Foo")) == BAT
 
         cleanup:
         compiled.close()
@@ -93,11 +100,13 @@ enum Foo {
 }
 ''')
         def test = newInstance(compiled, 'enumtest.Test')
-        def testClass = test.getClass()
+        def BAR = getEnum(compiled, "enumtest.Foo.BAR")
 
         expect:
         jsonMapper.writeValueAsString(test) == '{"data":"BAZ"}'
-        jsonMapper.readValue('{"data":"BAR"}', argumentOf(compiled, 'enumtest.Test')).data.name() == "BAR"
+        jsonMapper.writeValueAsString(BAR) == '"BAR"'
+
+        jsonMapper.readValue('{"data":"BAR"}', argumentOf(compiled, 'enumtest.Test')).data == BAR
         jsonMapper.readValue('{"data":"baz"}', argumentOf(compiled, 'enumtest.Test')).data.name() == "BAZ"
 
         cleanup:

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/object/EnumSerdeSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/object/EnumSerdeSpec.groovy
@@ -1,0 +1,106 @@
+package io.micronaut.serde.jackson.object
+
+import io.micronaut.serde.AbstractJsonCompileSpec
+import spock.lang.Issue
+
+class EnumSerdeSpec extends AbstractJsonCompileSpec {
+    @Issue("https://github.com/micronaut-projects/micronaut-serialization/issues/360")
+    def "test enum with @JsonCreator"() {
+        given:
+        def compiled = buildContext('''
+package enumtest;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.List;
+import java.util.Arrays;
+import java.util.Objects;
+
+@Serdeable
+@Introspected(accessKind = Introspected.AccessKind.FIELD)
+class Test {
+    public Foo data = Foo.BAZ;
+}
+
+@Serdeable
+enum Foo {
+  BAR("br"),
+  BAZ("bz");
+
+  private final String value;
+
+  Foo(String value) {
+    this.value = value;
+  }
+
+  @JsonCreator
+  public static Foo fromValue(String value) {
+    return Arrays.stream(values())
+        .filter(foo -> Objects.equals(foo.toString(), value))
+        .findFirst().orElse(null);
+  }
+
+  @JsonValue
+  public String toString() {
+    return this.value;
+  }
+
+}
+''')
+        def test = newInstance(compiled, 'enumtest.Test')
+        def testClass = test.getClass()
+
+        expect:
+        jsonMapper.writeValueAsString(test) == '{"data":"bz"}'
+        jsonMapper.readValue('{"data":"bz"}', argumentOf(compiled, 'enumtest.Test')).data.name() == "BAZ"
+
+        cleanup:
+        compiled.close()
+    }
+
+
+    def "test default enum handling"() {
+        given:
+        def compiled = buildContext('''
+package enumtest;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.List;
+import java.util.Arrays;
+import java.util.Objects;
+
+@Serdeable
+@Introspected(accessKind = Introspected.AccessKind.FIELD)
+class Test {
+    public Foo data = Foo.BAZ;
+}
+
+@Serdeable
+enum Foo {
+  BAR("br"),
+  BAZ("bz");
+
+  private final String value;
+
+  Foo(String value) {
+    this.value = value;
+  }
+}
+''')
+        def test = newInstance(compiled, 'enumtest.Test')
+        def testClass = test.getClass()
+
+        expect:
+        jsonMapper.writeValueAsString(test) == '{"data":"BAZ"}'
+        jsonMapper.readValue('{"data":"BAR"}', argumentOf(compiled, 'enumtest.Test')).data.name() == "BAR"
+        jsonMapper.readValue('{"data":"baz"}', argumentOf(compiled, 'enumtest.Test')).data.name() == "BAZ"
+
+        cleanup:
+        compiled.close()
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/EnumSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/EnumSerde.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.serdes;
 
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.beans.BeanIntrospection;
 import io.micronaut.core.beans.BeanMethod;
 import io.micronaut.core.beans.exceptions.IntrospectionException;
@@ -51,6 +52,7 @@ final class EnumSerde<E extends Enum<E>> implements NullableSerde<E> {
     }
 
     @Override
+    @NonNull
     public E deserializeNonNull(Decoder decoder, DecoderContext decoderContext, Argument<? super E> type) throws IOException {
         @SuppressWarnings("rawtypes") final Class t = type.getType();
         String s = decoder.decodeString();
@@ -69,7 +71,8 @@ final class EnumSerde<E extends Enum<E>> implements NullableSerde<E> {
 
     @SuppressWarnings("unchecked")
     @Override
-    public Deserializer<E> createSpecific(DecoderContext context, Argument<? super E> type) {
+    @NonNull
+    public Deserializer<E> createSpecific(@NonNull DecoderContext context, @NonNull Argument<? super E> type) {
         try {
             BeanIntrospection<? super E> deserializableIntrospection = introspections.getDeserializableIntrospection(type);
             Argument<?>[] constructorArguments = deserializableIntrospection.getConstructorArguments();
@@ -79,32 +82,15 @@ final class EnumSerde<E extends Enum<E>> implements NullableSerde<E> {
             Argument<Object> argumentType = (Argument<Object>) constructorArguments[0];
             Deserializer<Object> argumentDeserializer = (Deserializer<Object>) context.findDeserializer(argumentType);
 
-            return (decoder, context1, type1) -> {
-                Object v = argumentDeserializer.deserialize(decoder, context1, argumentType);
-                try {
-                    return (E) deserializableIntrospection.instantiate(v);
-                } catch (IllegalArgumentException e) {
-                    if (v instanceof String) {
-                        String string = (String) v;
-                        try {
-                            return (E) deserializableIntrospection.instantiate(string.toUpperCase(Locale.ENGLISH));
-                        } catch (IllegalArgumentException ex) {
-                            // throw original
-                            throw e;
-                        }
-                    } else {
-                        // throw original
-                        throw e;
-                    }
-                }
-            };
+            return new EnumCreatorDeserializer<E>(argumentType, argumentDeserializer, deserializableIntrospection);
         } catch (IntrospectionException | SerdeException e) {
             return this;
         }
     }
 
     @Override
-    public Serializer<E> createSpecific(EncoderContext context, Argument<? extends E> type) throws SerdeException {
+    @NonNull
+    public Serializer<E> createSpecific(@NonNull EncoderContext context, @NonNull Argument<? extends E> type) throws SerdeException {
         try {
             BeanIntrospection<? extends E> si = introspections.getSerializableIntrospection(type);
             Collection<? extends BeanMethod<? extends E, Object>> beanMethods = si.getBeanMethods();
@@ -114,7 +100,11 @@ final class EnumSerde<E extends Enum<E>> implements NullableSerde<E> {
                     Serializer<? super Object> valueSerializer = context.findSerializer(valueType);
                     return (encoder, subContext, subType, value) -> {
                         @SuppressWarnings("unchecked") Object result = ((Executable) beanMethod).invoke(value);
-                        valueSerializer.serialize(encoder, subContext, subType, result);
+                        if (result == null) {
+                            encoder.encodeNull();
+                        } else {
+                            valueSerializer.serialize(encoder, subContext, subType, result);
+                        }
                     };
                 }
             }
@@ -125,8 +115,55 @@ final class EnumSerde<E extends Enum<E>> implements NullableSerde<E> {
     }
 
     @Override
-    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends E> type, E value) throws IOException {
+    public void serialize(Encoder encoder, @NonNull EncoderContext context, @NonNull Argument<? extends E> type, E value) throws IOException {
         encoder.encodeString(value.name());
+    }
+}
+
+/**
+ * Deserializer for enums with json creator.
+ * @param <E> The enum type
+ */
+final class EnumCreatorDeserializer<E extends Enum<E>> implements Deserializer<E> {
+
+    Argument<Object> argumentType;
+    Deserializer<Object> argumentDeserializer;
+    BeanIntrospection<? super E> deserializableIntrospection;
+
+    public EnumCreatorDeserializer(
+        Argument<Object> argumentType,
+        Deserializer<Object> argumentDeserializer,
+        BeanIntrospection<? super E> deserializableIntrospection
+    ) {
+        this.argumentType = argumentType;
+        this.argumentDeserializer = argumentDeserializer;
+        this.deserializableIntrospection = deserializableIntrospection;
+    }
+
+    @Override
+    public E deserialize(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super E> type) throws IOException {
+        Object v = argumentDeserializer.deserialize(decoder, context, argumentType);
+        try {
+            return (E) deserializableIntrospection.instantiate(v);
+        } catch (IllegalArgumentException e) {
+            if (v instanceof String) {
+                String string = (String) v;
+                try {
+                    return (E) deserializableIntrospection.instantiate(string.toUpperCase(Locale.ENGLISH));
+                } catch (IllegalArgumentException ex) {
+                    // throw original
+                    throw e;
+                }
+            } else {
+                // throw original
+                throw e;
+            }
+        }
+    }
+
+    @Override
+    public boolean allowNull() {
+        return argumentDeserializer.allowNull();
     }
 }
 

--- a/serde-tck/src/main/groovy/io/micronaut/serde/AbstractJsonCompileSpec.groovy
+++ b/serde-tck/src/main/groovy/io/micronaut/serde/AbstractJsonCompileSpec.groovy
@@ -89,6 +89,14 @@ abstract class AbstractJsonCompileSpec extends AbstractTypeElementSpec implement
         return context.classLoader.loadClass(name).newInstance(args)
     }
 
+    Object getEnum(ApplicationContext context, String name) {
+        String enumName = name.split('\\.').last()
+        String enumClassName = name.substring(0, name.length() - enumName.length() - 1)
+        return context.classLoader.loadClass(enumClassName)
+                .enumConstants
+                .find(c -> c.name() == enumName)
+    }
+
     Argument<Object> argumentOf(ApplicationContext context, String name) {
         return Argument.of(context.classLoader.loadClass(name))
     }


### PR DESCRIPTION
- Backport #368.
- Add support for `null` values in the json creator and json value with enums.
- Extend the tests.