### PR TITLE
Set OracleJdbcJsonTextObjectMapper higher priority than OracleJdbcJsonBinaryObjectMapper

### DIFF
--- a/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/OracleJdbcJsonTextObjectMapper.java
+++ b/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/OracleJdbcJsonTextObjectMapper.java
@@ -34,7 +34,7 @@ import java.io.OutputStream;
  */
 @Singleton
 @BootstrapContextCompatible
-@Order(200) // lower precedence than Jackson
+@Order(199) // lower precedence than Jackson but higher than OracleJdbcJsonBinaryObjectMapper
 public final class OracleJdbcJsonTextObjectMapper extends AbstractOracleJdbcJsonObjectMapper {
 
     public OracleJdbcJsonTextObjectMapper(SerdeRegistry registry) {


### PR DESCRIPTION
In situation when we have these two oracle json mappers `OracleJdbcJsonTextObjectMapper` and `OracleJdbcJsonBinaryObjectMapper` on the classpath and without micronaut-serde-jackson which defines primary `JsonMapper` then app is not able to resolve `JsonMapper` injection in some of the classes in micronaut-data so we can help this way, setting `OracleJdbcJsonTextObjectMapper` higher priority than `OracleJdbcJsonBinaryObjectMapper` and then make it default `JsonMapper`.
If there is some better solution for this case, please let me know and I will update this. Without this, in apps that include serde-oracle-jdbc-json we will have issues when single `JsonMapper` needs to be injected.