### PR TITLE
Rework numeric time handling

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/config/SerdeConfiguration.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/SerdeConfiguration.java
@@ -18,7 +18,6 @@ package io.micronaut.serde.config;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.bind.annotation.Bindable;
-import io.micronaut.core.util.StringUtils;
 
 import java.util.List;
 import java.util.Locale;
@@ -43,15 +42,21 @@ public interface SerdeConfiguration {
     Optional<String> getDateFormat();
 
     /**
-     * Whether to write dates as time stamps. Defaults to {@code true}.
+     * Shape for serializing dates.
      *
-     * <p>If set to {@code false} the default ISO formats will be used to format dates as strings.</p>
-     *
-     * @see java.time.format.DateTimeFormatter
-     * @return Whether to write dates as timestamps
+     * @return The date serialization shape
      */
-    @Bindable(defaultValue = StringUtils.TRUE)
-    boolean isWriteDatesAsTimestamps();
+    @Bindable(defaultValue = "STRING")
+    TimeShape getTimeWriteShape();
+
+    /**
+     * The unit to use for serializing and deserializing dates to or from numbers. Note that
+     * {@link java.time.LocalDate} always uses the epoch day, regardless of this setting.
+     *
+     * @return The time unit
+     */
+    @Bindable(defaultValue = "SECONDS")
+    NumericTimeUnit getNumericTimeUnit();
 
     /**
      * @return The default locale to use.
@@ -71,4 +76,53 @@ public interface SerdeConfiguration {
      */
     @Bindable(defaultValue = "io.micronaut")
     List<String> getIncludedIntrospectionPackages();
+
+    /**
+     * Shape to use for time serialization.
+     *
+     * @since 2.0.0
+     */
+    enum TimeShape {
+        /**
+         * Serialize as a string, either using {@link #getDateFormat()} or as an ISO timestamp.
+         */
+        STRING,
+        /**
+         * Serialize as an integer. This exists for compatibility, if possible prefer
+         * {@link #DECIMAL} so that no part of the time component is lost.
+         */
+        INTEGER,
+        /**
+         * Serialize as a decimal value with best possible precision.
+         */
+        DECIMAL,
+    }
+
+    /**
+     * Time unit to use when deserializing a numeric value, or when serializing to a numeric value
+     * as configured by {@link #getTimeWriteShape()}.
+     *
+     * @since 2.0.0
+     */
+    enum NumericTimeUnit {
+        /**
+         * Legacy unit for compatibility with documents created by micronaut-serialization 1.x
+         * (micronaut-core 3.x).
+         */
+        LEGACY,
+        /**
+         * Serialize as seconds, the default. Nanoseconds may still be represented as the
+         * fractional part.
+         */
+        SECONDS,
+        /**
+         * Serialize as milliseconds. Nanoseconds may still be represented as the fractional part.
+         */
+        MILLISECONDS,
+        /**
+         * Serialize as nanoseconds. Never has a fractional part (it's ignored if there is one
+         * while parsing).
+         */
+        NANOSECONDS,
+    }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/DefaultFormattedTemporalSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/DefaultFormattedTemporalSerde.java
@@ -39,7 +39,8 @@ public abstract class DefaultFormattedTemporalSerde<T extends TemporalAccessor> 
     /**
      * Allows configuring a default time format for temporal date/time types.
      *
-     * @param configuration The configuration
+     * @param configuration          The configuration
+     * @param defaultStringFormatter Default string formatter to use if the user hasn't configured one
      */
     protected DefaultFormattedTemporalSerde(
         @NonNull SerdeConfiguration configuration,
@@ -53,6 +54,12 @@ public abstract class DefaultFormattedTemporalSerde<T extends TemporalAccessor> 
         serialize0(encoder, value);
     }
 
+    /**
+     * Serialize method, can be overridden to support numeric serialization.
+     *
+     * @param encoder The encoder
+     * @param value   The value to serialize
+     */
     void serialize0(Encoder encoder, T value) throws IOException {
         encoder.encodeString(stringFormatter.format(value));
     }
@@ -67,6 +74,13 @@ public abstract class DefaultFormattedTemporalSerde<T extends TemporalAccessor> 
         }
     }
 
+    /**
+     * Fallback to try when parsing as a timestamp fails.
+     *
+     * @param exc The parse exception, for rethrowing
+     * @param s   The input value
+     * @return The parsed value
+     */
     T deserializeFallback(DateTimeException exc, String s) {
         throw exc;
     }
@@ -76,7 +90,7 @@ public abstract class DefaultFormattedTemporalSerde<T extends TemporalAccessor> 
         // Creates a pattern-based formatter if there is a date format configured
         return configuration.getDateFormat()
             .map(pattern -> configuration.getLocale()
-                    .map(locale -> DateTimeFormatter.ofPattern(pattern, locale))
+                .map(locale -> DateTimeFormatter.ofPattern(pattern, locale))
                     .orElseGet(() -> DateTimeFormatter.ofPattern(pattern)))
             .map(formatter -> configuration.getTimeZone()
                     .map(tz -> formatter.withZone(tz.toZoneId()))

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/DefaultFormattedTemporalSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/DefaultFormattedTemporalSerde.java
@@ -20,9 +20,9 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Encoder;
 import io.micronaut.serde.config.SerdeConfiguration;
-import io.micronaut.serde.exceptions.InvalidFormatException;
 
 import java.io.IOException;
+import java.time.DateTimeException;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.Optional;
@@ -34,75 +34,45 @@ import java.util.Optional;
  */
 public abstract class DefaultFormattedTemporalSerde<T extends TemporalAccessor> implements TemporalSerde<T> {
 
-    private final FormattedTemporalSerde<T> defaultFormat;
-    private final boolean treatDatesAsTimestamps;
+    private final DateTimeFormatter stringFormatter;
 
     /**
      * Allows configuring a default time format for temporal date/time types.
      *
      * @param configuration The configuration
      */
-    protected DefaultFormattedTemporalSerde(@NonNull SerdeConfiguration configuration) {
-        defaultFormat = new FormattedTemporalSerde<>(getFormatter(configuration), query());
-        treatDatesAsTimestamps = configuration.isWriteDatesAsTimestamps() && !configuration.getDateFormat().isPresent();
+    protected DefaultFormattedTemporalSerde(
+        @NonNull SerdeConfiguration configuration,
+        @NonNull DateTimeFormatter defaultStringFormatter
+    ) {
+        stringFormatter = createFormatter(configuration).orElse(defaultStringFormatter);
     }
-
-    /**
-     * @return The default formatter.
-     */
-    protected abstract @NonNull DateTimeFormatter getDefaultFormatter();
 
     @Override
     public final void serialize(Encoder encoder, EncoderContext context, Argument<? extends T> type, T value) throws IOException {
-        if (treatDatesAsTimestamps) {
-            serializeWithoutFormat(encoder, context, value, type);
-        } else {
-            defaultFormat.serialize(encoder, context, type, value);
-        }
+        serialize0(encoder, value);
+    }
+
+    void serialize0(Encoder encoder, T value) throws IOException {
+        encoder.encodeString(stringFormatter.format(value));
     }
 
     @Override
     public final T deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super T> type) throws IOException {
-        if (treatDatesAsTimestamps) {
-            try {
-                return deserializeNonNullWithoutFormat(decoder, decoderContext, type);
-            } catch (InvalidFormatException e) {
-                // The property was not serialized as a timestamp.
-                // We will ignore this error and try to deserialize it as a string.
-            }
+        String text = decoder.decodeString();
+        try {
+            return stringFormatter.parse(text, query());
+        } catch (DateTimeException e) {
+            return deserializeFallback(e, text);
         }
-        return defaultFormat.deserialize(decoder, decoderContext, type);
     }
 
-    /**
-     * Serializes the given value using the passed {@link Encoder}.
-     * @param encoder The encoder to use
-     * @param context The encoder context, never {@code null}
-     * @param value The value, can be {@code null}
-     * @param type Models the generic type of the value
-     * @throws IOException If an error occurs during serialization
-     */
-    protected abstract void serializeWithoutFormat(Encoder encoder, EncoderContext context, T value, Argument<? extends T> type) throws IOException;
-
-    /**
-     * A method that is invoked when the value is known not to be null.
-     * @param decoder The decoder
-     * @param decoderContext The decoder context
-     * @param type The type
-     * @return The value
-     * @throws IOException if something goes wrong during deserialization
-     */
-    protected abstract T deserializeNonNullWithoutFormat(Decoder decoder, DecoderContext decoderContext, Argument<? super T> type) throws IOException;
-
-    @NonNull
-    private DateTimeFormatter getFormatter(@NonNull SerdeConfiguration configuration) {
-        // Creates a custom formatter or returns the default one
-        return this.createFormatter(configuration)
-            .orElseGet(this::getDefaultFormatter);
+    T deserializeFallback(DateTimeException exc, String s) {
+        throw exc;
     }
 
     @NonNull
-    private Optional<DateTimeFormatter> createFormatter(@NonNull SerdeConfiguration configuration) {
+    private static Optional<DateTimeFormatter> createFormatter(@NonNull SerdeConfiguration configuration) {
         // Creates a pattern-based formatter if there is a date format configured
         return configuration.getDateFormat()
             .map(pattern -> configuration.getLocale()

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/FormattedTemporalSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/FormattedTemporalSerde.java
@@ -33,8 +33,8 @@ import java.util.Locale;
 
 @Internal
 final class FormattedTemporalSerde<T extends TemporalAccessor> implements TemporalSerde<T> {
-    private final DateTimeFormatter formatter;
-    private final TemporalQuery<T> query;
+    final DateTimeFormatter formatter;
+    final TemporalQuery<T> query;
 
     FormattedTemporalSerde(@NonNull String pattern,
                            @NonNull AnnotationMetadata annotationMetadata,
@@ -45,6 +45,7 @@ final class FormattedTemporalSerde<T extends TemporalAccessor> implements Tempor
                 .orElse(null);
         DateTimeFormatter f = locale != null ? DateTimeFormatter.ofPattern(pattern, locale) :
                 DateTimeFormatter.ofPattern(pattern);
+
         final ZoneId zone = annotationMetadata
                 .stringValue(SerdeConfig.class, SerdeConfig.TIMEZONE)
                 .map(ZoneId::of).orElse(UTC);

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/InstantSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/InstantSerde.java
@@ -15,16 +15,12 @@
  */
 package io.micronaut.serde.support.serdes;
 
-import java.io.IOException;
+import io.micronaut.serde.config.SerdeConfiguration;
+import jakarta.inject.Singleton;
+
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalQuery;
-
-import io.micronaut.core.type.Argument;
-import io.micronaut.serde.Decoder;
-import io.micronaut.serde.Encoder;
-import io.micronaut.serde.config.SerdeConfiguration;
-import jakarta.inject.Singleton;
 
 /**
  * Serde used for {@link java.time.Instant}.
@@ -32,17 +28,12 @@ import jakarta.inject.Singleton;
  * @since 1.0.0
  */
 @Singleton
-public class InstantSerde extends DefaultFormattedTemporalSerde<Instant> implements TemporalSerde<Instant> {
+public final class InstantSerde extends NumericSupportTemporalSerde<Instant> implements TemporalSerde<Instant> {
 
     private static final TemporalQuery<Instant> QUERY = Instant::from;
 
-    protected InstantSerde(SerdeConfiguration configuration) {
-        super(configuration);
-    }
-
-    @Override
-    protected DateTimeFormatter getDefaultFormatter() {
-        return DateTimeFormatter.ISO_INSTANT;
+    InstantSerde(SerdeConfiguration configuration) {
+        super(configuration, DateTimeFormatter.ISO_INSTANT, SerdeConfiguration.NumericTimeUnit.MILLISECONDS);
     }
 
     @Override
@@ -51,12 +42,17 @@ public class InstantSerde extends DefaultFormattedTemporalSerde<Instant> impleme
     }
 
     @Override
-    protected void serializeWithoutFormat(Encoder encoder, EncoderContext context, Instant value, Argument<? extends Instant> type) throws IOException {
-        encoder.encodeLong(value.toEpochMilli());
+    protected long getSecondPart(Instant value) {
+        return value.getEpochSecond();
     }
 
     @Override
-    protected Instant deserializeNonNullWithoutFormat(Decoder decoder, DecoderContext decoderContext, Argument<? super Instant> type) throws IOException {
-        return Instant.ofEpochMilli(decoder.decodeLong());
+    protected int getNanoPart(Instant value) {
+        return value.getNano();
+    }
+
+    @Override
+    protected Instant fromNanos(long seconds, int nanos) {
+        return Instant.ofEpochSecond(seconds, nanos);
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/LocalDateSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/LocalDateSerde.java
@@ -27,10 +27,8 @@ import java.time.temporal.TemporalQueries;
 import java.time.temporal.TemporalQuery;
 
 /**
- * Local date serde.
- *
- * @implNote Slightly different to {@link NumericSupportTemporalSerde}, we only support one unit
- * (epoch day)
+ * Local date serde. Slightly different to {@link NumericSupportTemporalSerde}, we only support one
+ * unit (epoch day)
  */
 @Singleton
 public final class LocalDateSerde extends DefaultFormattedTemporalSerde<LocalDate> implements TemporalSerde<LocalDate> {

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/LocalDateTimeSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/LocalDateTimeSerde.java
@@ -15,16 +15,12 @@
  */
 package io.micronaut.serde.support.serdes;
 
-import java.io.IOException;
+import io.micronaut.serde.config.SerdeConfiguration;
+import jakarta.inject.Singleton;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalQuery;
-
-import io.micronaut.core.type.Argument;
-import io.micronaut.serde.Decoder;
-import io.micronaut.serde.Encoder;
-import io.micronaut.serde.config.SerdeConfiguration;
-import jakarta.inject.Singleton;
 
 /**
  * Temporal serde for LocalDateTime.
@@ -32,30 +28,15 @@ import jakarta.inject.Singleton;
  * @since 1.0.0
  */
 @Singleton
-public class LocalDateTimeSerde extends DefaultFormattedTemporalSerde<LocalDateTime>
+public final class LocalDateTimeSerde extends DefaultFormattedTemporalSerde<LocalDateTime>
         implements TemporalSerde<LocalDateTime> {
 
-    protected LocalDateTimeSerde(SerdeConfiguration configuration) {
-        super(configuration);
-    }
-
-    @Override
-    protected DateTimeFormatter getDefaultFormatter() {
-        return DateTimeFormatter.ISO_DATE_TIME;
+    LocalDateTimeSerde(SerdeConfiguration configuration) {
+        super(configuration, DateTimeFormatter.ISO_DATE_TIME);
     }
 
     @Override
     public TemporalQuery<LocalDateTime> query() {
         return LocalDateTime::from;
-    }
-
-    @Override
-    protected void serializeWithoutFormat(Encoder encoder, EncoderContext context, LocalDateTime value, Argument<? extends LocalDateTime> type) throws IOException {
-        encoder.encodeString(getDefaultFormatter().format(value));
-    }
-
-    @Override
-    protected LocalDateTime deserializeNonNullWithoutFormat(Decoder decoder, DecoderContext decoderContext, Argument<? super LocalDateTime> type) throws IOException {
-        return getDefaultFormatter().parse(decoder.decodeString(), LocalDateTime::from);
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/LocalTimeSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/LocalTimeSerde.java
@@ -15,17 +15,13 @@
  */
 package io.micronaut.serde.support.serdes;
 
-import java.io.IOException;
+import io.micronaut.serde.config.SerdeConfiguration;
+import jakarta.inject.Singleton;
+
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalQueries;
 import java.time.temporal.TemporalQuery;
-
-import io.micronaut.core.type.Argument;
-import io.micronaut.serde.Decoder;
-import io.micronaut.serde.Encoder;
-import io.micronaut.serde.config.SerdeConfiguration;
-import jakarta.inject.Singleton;
 
 /**
  * LocalTime serde.
@@ -33,19 +29,14 @@ import jakarta.inject.Singleton;
  * @since 1.0.0
  */
 @Singleton
-public class LocalTimeSerde extends DefaultFormattedTemporalSerde<LocalTime> {
+public final class LocalTimeSerde extends NumericSupportTemporalSerde<LocalTime> {
     /**
      * Allows configuring a default time format for temporal date/time types.
      *
      * @param configuration The configuration
      */
-    protected LocalTimeSerde(SerdeConfiguration configuration) {
-        super(configuration);
-    }
-
-    @Override
-    protected DateTimeFormatter getDefaultFormatter() {
-        return DateTimeFormatter.ISO_LOCAL_TIME;
+    LocalTimeSerde(SerdeConfiguration configuration) {
+        super(configuration, DateTimeFormatter.ISO_LOCAL_TIME, SerdeConfiguration.NumericTimeUnit.NANOSECONDS);
     }
 
     @Override
@@ -54,12 +45,17 @@ public class LocalTimeSerde extends DefaultFormattedTemporalSerde<LocalTime> {
     }
 
     @Override
-    protected void serializeWithoutFormat(Encoder encoder, EncoderContext context, LocalTime value, Argument<? extends LocalTime> type) throws IOException {
-        encoder.encodeLong(value.toNanoOfDay());
+    protected LocalTime fromNanos(long seconds, int nanos) {
+        return LocalTime.ofSecondOfDay(seconds).withNano(nanos);
     }
 
     @Override
-    protected LocalTime deserializeNonNullWithoutFormat(Decoder decoder, DecoderContext decoderContext, Argument<? super LocalTime> type) throws IOException {
-        return LocalTime.ofNanoOfDay(decoder.decodeLong());
+    protected long getSecondPart(LocalTime value) {
+        return value.toSecondOfDay();
+    }
+
+    @Override
+    protected int getNanoPart(LocalTime value) {
+        return value.getNano();
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/NumericSupportTemporalSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/NumericSupportTemporalSerde.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.config.SerdeConfiguration;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+import java.time.DateTimeException;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+import java.util.concurrent.TimeUnit;
+
+abstract class NumericSupportTemporalSerde<T extends TemporalAccessor> extends DefaultFormattedTemporalSerde<T> {
+    private static final BigInteger NS_FACTOR = BigInteger.valueOf(1_000_000_000);
+
+    private final SerdeConfiguration.TimeShape writeShape;
+    private final SerdeConfiguration.NumericTimeUnit numericUnit;
+
+    NumericSupportTemporalSerde(
+        @NonNull SerdeConfiguration configuration,
+        @NonNull DateTimeFormatter defaultStringFormatter,
+        @NonNull SerdeConfiguration.NumericTimeUnit legacyUnit
+    ) {
+        super(configuration, defaultStringFormatter);
+        writeShape = configuration.getTimeWriteShape();
+        numericUnit = configuration.getNumericTimeUnit() == SerdeConfiguration.NumericTimeUnit.LEGACY ? legacyUnit : configuration.getNumericTimeUnit();
+    }
+
+    protected abstract T fromNanos(long seconds, int nanos);
+
+    protected abstract long getSecondPart(T value);
+
+    protected abstract int getNanoPart(T value);
+
+    @Override
+    final T deserializeFallback(DateTimeException exc, String str) {
+        BigDecimal raw;
+        try {
+            raw = new BigDecimal(str);
+        } catch (NumberFormatException e) {
+            exc.addSuppressed(e);
+            throw exc;
+        }
+        BigDecimal s = switch (numericUnit) {
+            case LEGACY -> throw new AssertionError("Should be replaced in constructor");
+            case SECONDS -> raw;
+            case MILLISECONDS -> raw.scaleByPowerOfTen(-3);
+            case NANOSECONDS -> raw.scaleByPowerOfTen(-9);
+        };
+        s = s.setScale(9, RoundingMode.DOWN);
+        return fromNanos(s.longValue(), s.remainder(BigDecimal.ONE).unscaledValue().intValueExact());
+    }
+
+    @Override
+    final void serialize0(Encoder encoder, T value) throws IOException {
+        switch (writeShape) {
+            case STRING -> super.serialize0(encoder, value);
+            case INTEGER -> {
+                switch (numericUnit) {
+                    case LEGACY -> throw new AssertionError("Should be replaced in constructor");
+                    case SECONDS -> encoder.encodeLong(getSecondPart(value));
+                    case MILLISECONDS -> encoder.encodeLong(getSecondPart(value) * 1000L + TimeUnit.NANOSECONDS.toMillis(getNanoPart(value)));
+                    // this can go out of bounds of long
+                    case NANOSECONDS -> encoder.encodeBigInteger(BigInteger.valueOf(getSecondPart(value)).multiply(NS_FACTOR).add(BigInteger.valueOf(getNanoPart(value))));
+                }
+            }
+            case DECIMAL -> {
+                BigDecimal s = BigDecimal.valueOf(getSecondPart(value)).add(BigDecimal.valueOf(getNanoPart(value), 9));
+                switch (numericUnit) {
+                    case LEGACY -> throw new AssertionError("Should be replaced in constructor");
+                    case SECONDS -> encoder.encodeBigDecimal(s);
+                    case MILLISECONDS -> encoder.encodeBigDecimal(s.scaleByPowerOfTen(3));
+                    case NANOSECONDS -> encoder.encodeBigInteger(s.unscaledValue());
+                }
+            }
+        }
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/NumericSupportTemporalSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/NumericSupportTemporalSerde.java
@@ -34,6 +34,11 @@ abstract class NumericSupportTemporalSerde<T extends TemporalAccessor> extends D
     private final SerdeConfiguration.TimeShape writeShape;
     private final SerdeConfiguration.NumericTimeUnit numericUnit;
 
+    /**
+     * @param configuration          The configuration
+     * @param defaultStringFormatter Default string formatter to use if the user hasn't configured one
+     * @param legacyUnit             The unit to use in place of {@link io.micronaut.serde.config.SerdeConfiguration.NumericTimeUnit#LEGACY}
+     */
     NumericSupportTemporalSerde(
         @NonNull SerdeConfiguration configuration,
         @NonNull DateTimeFormatter defaultStringFormatter,
@@ -79,7 +84,9 @@ abstract class NumericSupportTemporalSerde<T extends TemporalAccessor> extends D
                     case SECONDS -> encoder.encodeLong(getSecondPart(value));
                     case MILLISECONDS -> encoder.encodeLong(getSecondPart(value) * 1000L + TimeUnit.NANOSECONDS.toMillis(getNanoPart(value)));
                     // this can go out of bounds of long
-                    case NANOSECONDS -> encoder.encodeBigInteger(BigInteger.valueOf(getSecondPart(value)).multiply(NS_FACTOR).add(BigInteger.valueOf(getNanoPart(value))));
+                    case NANOSECONDS ->
+                        encoder.encodeBigInteger(BigInteger.valueOf(getSecondPart(value)).multiply(NS_FACTOR).add(BigInteger.valueOf(getNanoPart(value))));
+                    default -> throw new AssertionError();
                 }
             }
             case DECIMAL -> {
@@ -89,6 +96,7 @@ abstract class NumericSupportTemporalSerde<T extends TemporalAccessor> extends D
                     case SECONDS -> encoder.encodeBigDecimal(s);
                     case MILLISECONDS -> encoder.encodeBigDecimal(s.scaleByPowerOfTen(3));
                     case NANOSECONDS -> encoder.encodeBigInteger(s.unscaledValue());
+                    default -> throw new AssertionError();
                 }
             }
         }

--- a/serde-support/src/test/groovy/io/micronaut/serde/support/serdes/InstantSerdeSpec.groovy
+++ b/serde-support/src/test/groovy/io/micronaut/serde/support/serdes/InstantSerdeSpec.groovy
@@ -1,0 +1,70 @@
+package io.micronaut.serde.support.serdes
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.serde.ObjectMapper
+import io.micronaut.serde.config.SerdeConfiguration.NumericTimeUnit
+import io.micronaut.serde.config.SerdeConfiguration.TimeShape
+import spock.lang.Specification
+
+import java.time.Instant
+
+class InstantSerdeSpec extends Specification {
+    def 'serialization shapes'(
+            TimeShape shape,
+            NumericTimeUnit unit,
+            String expected
+    ) {
+        given:
+        def ctx = ApplicationContext.run([
+                'micronaut.serde.time-write-shape' : shape,
+                'micronaut.serde.numeric-time-unit': unit,
+        ])
+        when:
+        String json = ctx.getBean(ObjectMapper).writeValueAsString(Instant.ofEpochSecond(123, 456789123))
+
+        then:
+        json == expected
+
+        cleanup:
+        ctx.close()
+
+        where:
+        shape             | unit                         | expected
+        TimeShape.STRING  | NumericTimeUnit.SECONDS      | "\"1970-01-01T00:02:03.456789123Z\""
+        TimeShape.INTEGER | NumericTimeUnit.SECONDS      | "123"
+        TimeShape.INTEGER | NumericTimeUnit.LEGACY       | "123456"
+        TimeShape.INTEGER | NumericTimeUnit.MILLISECONDS | "123456"
+        TimeShape.INTEGER | NumericTimeUnit.NANOSECONDS  | "123456789123"
+        TimeShape.DECIMAL | NumericTimeUnit.SECONDS      | "123.456789123"
+        TimeShape.DECIMAL | NumericTimeUnit.LEGACY       | "123456.789123"
+        TimeShape.DECIMAL | NumericTimeUnit.MILLISECONDS | "123456.789123"
+        TimeShape.DECIMAL | NumericTimeUnit.NANOSECONDS  | "123456789123"
+    }
+
+    def 'deserialization shapes'(
+            NumericTimeUnit unit,
+            String input
+    ) {
+        given:
+        def ctx = ApplicationContext.run([
+                'micronaut.serde.numeric-time-unit': unit,
+        ])
+        when:
+        Instant parsed = ctx.getBean(ObjectMapper).readValue(input, Instant)
+
+        then:
+        parsed == Instant.ofEpochSecond(123, 456789123)
+
+        cleanup:
+        ctx.close()
+
+        where:
+        unit                         | input
+        NumericTimeUnit.SECONDS      | "\"1970-01-01T00:02:03.456789123Z\""
+        NumericTimeUnit.MILLISECONDS | "\"1970-01-01T00:02:03.456789123Z\""
+        NumericTimeUnit.NANOSECONDS  | "\"1970-01-01T00:02:03.456789123Z\""
+        NumericTimeUnit.SECONDS      | "123.456789123"
+        NumericTimeUnit.MILLISECONDS | "123456.789123"
+        NumericTimeUnit.NANOSECONDS  | "123456789123"
+    }
+}

--- a/serde-support/src/test/groovy/io/micronaut/serde/support/serdes/OffsetDateTimeSerdeSpec.groovy
+++ b/serde-support/src/test/groovy/io/micronaut/serde/support/serdes/OffsetDateTimeSerdeSpec.groovy
@@ -1,6 +1,6 @@
 package io.micronaut.serde.support.serdes
 
-
+import io.micronaut.context.ApplicationContext
 import io.micronaut.serde.ObjectMapper
 import io.micronaut.serde.annotation.Serdeable
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
@@ -44,20 +44,27 @@ class OffsetDateTimeSerdeSpec extends Specification {
         pojo.timeCreated == OffsetDateTime.parse('2022-01-01T12:30:00.123Z')
 
         where:
-        value << [1641040200123]
+        value << [1641040200.123]
     }
 
     @Unroll
-    void "OffsetDateTime by default is serialized as timestamp"() {
+    void "OffsetDateTime can be serialized as number"() {
         given:
+        def ctx = ApplicationContext.run([
+                'micronaut.serde.time-write-shape': 'integer',
+                'micronaut.serde.numeric-time-unit': 'legacy',
+        ])
         OffsetDateTimePojo pojo = new OffsetDateTimePojo()
         pojo.timeCreated = OffsetDateTime.parse('2022-01-01T12:30:00.123Z')
 
         when:
-        String json = objectMapper.writeValueAsString(pojo)
+        String json = ctx.getBean(ObjectMapper).writeValueAsString(pojo)
 
         then:
         '{"timeCreated":1641040200123}' == json
+
+        cleanup:
+        ctx.close()
     }
 
     @Serdeable.Deserializable

--- a/serde-tck/src/main/groovy/io/micronaut/serde/data/Users1.java
+++ b/serde-tck/src/main/groovy/io/micronaut/serde/data/Users1.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.serde.data;
 
 import io.micronaut.core.annotation.Introspected;

--- a/serde-tck/src/main/groovy/io/micronaut/serde/data/Users2.java
+++ b/serde-tck/src/main/groovy/io/micronaut/serde/data/Users2.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.serde.data;
 
 import io.micronaut.core.annotation.Introspected;

--- a/serde-tck/src/main/groovy/io/micronaut/serde/data/Users3.java
+++ b/serde-tck/src/main/groovy/io/micronaut/serde/data/Users3.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.serde.data;
 
 import io.micronaut.core.annotation.Introspected;


### PR DESCRIPTION
This PR reworks the handling for numeric values for parsing and writing java.time classes. The old handling was inconsistent (millis for Instant, ODT, ZDT, but nanos for LT), incomplete (no support for decimals), incompatible with jackson-databind (it uses seconds by default), and not configurable. It also used an "optimistic" decode pattern that broke #425.

These changes remove the old write-dates-as-timestamps setting and replace it with two new settings, time-write-shape and numeric-time-unit. The former controls the format to serialize as (number or string), the latter controls the time unit. The old behavior can be activated with:

```
micronaut.serde.time-write-shape=integer
micronaut.serde.numeric-time-unit=legacy
```

The defaults are to serialize as string by default, removing any unit ambiguity. The unit defaults to seconds, which is the default in jackson-databind.