### PR TITLE
Introduce nesting depth limits for encoders and decoders

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/LimitingStream.java
+++ b/serde-api/src/main/java/io/micronaut/serde/LimitingStream.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.config.SerdeConfiguration;
+import io.micronaut.serde.exceptions.SerdeException;
+
+/**
+ * Utility class to check data limits in encoders and decoders. Currently, the only limit that is
+ * checked is the nesting depth.
+ * <p>
+ * This class can be used in both implementation "patterns" for {@link Encoder} (and
+ * {@link Decoder}): For the same-object pattern, where {@link Encoder#encodeObject(Argument)}
+ * returns the same instance, the encoder should call {@link #increaseDepth()}, with a
+ * corresponding {@link #decreaseDepth()} call in {@link Encoder#finishStructure()}. Conversely, if
+ * the encoder is implemented using the child-object pattern, where
+ * {@link Encoder#encodeObject(Argument)} returns a child encoder responsible for the subtree, that
+ * child encoder should be instantiated using the new limits returned by {@link #childLimits()}.
+ * <p>
+ * If there is a limit violation, {@link #childLimits()} or {@link #increaseDepth()} will throw an
+ * exception.
+ *
+ * @author Jonas Konrad
+ * @since 2.0.0
+ */
+@Internal
+public abstract class LimitingStream {
+    /**
+     * Default nesting depth limit.
+     */
+    public static final int DEFAULT_MAXIMUM_DEPTH = 1024;
+    /**
+     * Default limits, only use this when no {@link SerdeConfiguration} is available.
+     */
+    public static final RemainingLimits DEFAULT_LIMITS = new RemainingLimits(DEFAULT_MAXIMUM_DEPTH);
+
+    private int remainingDepth;
+
+    public LimitingStream(@NonNull RemainingLimits remainingLimits) {
+        this.remainingDepth = remainingLimits.remainingDepth;
+    }
+
+    /**
+     * Get a snapshot of our current limits to be passed to the constructor. This can be used for
+     * buffering decoders, when a new decoder takes over but no change in depth takes place.
+     *
+     * @return The current limits
+     */
+    @NonNull
+    protected final RemainingLimits ourLimits() {
+        return new RemainingLimits(remainingDepth);
+    }
+
+    /**
+     * Get the limits of a new child encoder.
+     *
+     * @return The new limits
+     * @throws SerdeException If there is a nesting depth limit violation
+     */
+    @NonNull
+    protected final RemainingLimits childLimits() throws SerdeException {
+        if (remainingDepth == 0) {
+            reportMaxDepthExceeded();
+        }
+        return new RemainingLimits(remainingDepth - 1);
+    }
+
+    /**
+     * Increase the current depth.
+     *
+     * @throws SerdeException If there is a nesting depth limit violation
+     */
+    protected final void increaseDepth() throws SerdeException {
+        if (remainingDepth == 0) {
+            reportMaxDepthExceeded();
+        }
+        remainingDepth--;
+    }
+
+    /**
+     * Decrease the current depth, always needs a corresponding {@link #increaseDepth()} call.
+     */
+    protected final void decreaseDepth() {
+        remainingDepth++;
+    }
+
+    private void reportMaxDepthExceeded() throws SerdeException {
+        boolean encoder = this instanceof Encoder;
+        throw new SerdeException("Maximum depth exceeded while " + (encoder ? "serializing" : "deserializing") + ". The maximum nesting depth can be increased, if necessary, using the " + SerdeConfiguration.PREFIX + ".maximum-nesting-depth config property.");
+    }
+
+    /**
+     * Get the configured limits.
+     *
+     * @param configuration The serde configuration
+     * @return The configured limits
+     */
+    public static RemainingLimits limitsFromConfiguration(SerdeConfiguration configuration) {
+        return new RemainingLimits(configuration.getMaximumNestingDepth());
+    }
+
+    /**
+     * This data structure contains the limits for this stream.
+     */
+    public static class RemainingLimits {
+        final int remainingDepth;
+
+        private RemainingLimits(int remainingDepth) {
+            this.remainingDepth = remainingDepth;
+        }
+    }
+}

--- a/serde-api/src/main/java/io/micronaut/serde/config/SerdeConfiguration.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/SerdeConfiguration.java
@@ -18,6 +18,7 @@ package io.micronaut.serde.config;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.serde.LimitingStream;
 
 import java.util.List;
 import java.util.Locale;
@@ -76,6 +77,15 @@ public interface SerdeConfiguration {
      */
     @Bindable(defaultValue = "io.micronaut")
     List<String> getIncludedIntrospectionPackages();
+
+    /**
+     * The maximum nesting depth for serialization and deserialization.
+     *
+     * @return The maximum nesting depth for serialization and deserialization
+     * @since 2.0.0
+     */
+    @Bindable(defaultValue = LimitingStream.DEFAULT_MAXIMUM_DEPTH + "")
+    int getMaximumNestingDepth();
 
     /**
      * Shape to use for time serialization.

--- a/serde-bson/src/main/java/io/micronaut/serde/bson/BsonBinaryMapper.java
+++ b/serde-bson/src/main/java/io/micronaut/serde/bson/BsonBinaryMapper.java
@@ -18,6 +18,7 @@ package io.micronaut.serde.bson;
 import io.micronaut.core.annotation.Order;
 import io.micronaut.json.JsonMapper;
 import io.micronaut.serde.SerdeRegistry;
+import io.micronaut.serde.config.SerdeConfiguration;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.bson.AbstractBsonWriter;
@@ -41,17 +42,17 @@ import java.util.Objects;
 public final class BsonBinaryMapper extends AbstractBsonMapper {
 
     @Inject
-    public BsonBinaryMapper(SerdeRegistry registry) {
-        super(registry);
+    public BsonBinaryMapper(SerdeRegistry registry, SerdeConfiguration serdeConfiguration) {
+        super(registry, serdeConfiguration);
     }
 
-    public BsonBinaryMapper(SerdeRegistry registry, Class<?> view) {
-        super(registry, view);
+    public BsonBinaryMapper(SerdeRegistry registry, SerdeConfiguration serdeConfiguration, Class<?> view) {
+        super(registry, serdeConfiguration, view);
     }
 
     @Override
     public JsonMapper cloneWithViewClass(Class<?> viewClass) {
-        return new BsonBinaryMapper(registry, viewClass);
+        return new BsonBinaryMapper(registry, serdeConfiguration, viewClass);
     }
 
     @Override

--- a/serde-bson/src/main/java/io/micronaut/serde/bson/BsonJsonMapper.java
+++ b/serde-bson/src/main/java/io/micronaut/serde/bson/BsonJsonMapper.java
@@ -19,6 +19,7 @@ import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.core.annotation.Order;
 import io.micronaut.json.JsonMapper;
 import io.micronaut.serde.SerdeRegistry;
+import io.micronaut.serde.config.SerdeConfiguration;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import org.bson.AbstractBsonWriter;
@@ -43,18 +44,28 @@ import java.nio.charset.StandardCharsets;
 @Order(100) // lower precedence than Jackson
 public final class BsonJsonMapper extends AbstractBsonMapper {
 
-    @Inject
+    @Deprecated
     public BsonJsonMapper(SerdeRegistry registry) {
-        super(registry);
+        super(registry, null);
     }
 
+    @Deprecated
     public BsonJsonMapper(SerdeRegistry registry, Class<?> view) {
-        super(registry, view);
+        super(registry, null, view);
+    }
+
+    @Inject
+    public BsonJsonMapper(SerdeRegistry registry, SerdeConfiguration serdeConfiguration) {
+        super(registry, serdeConfiguration);
+    }
+
+    private BsonJsonMapper(SerdeRegistry registry, SerdeConfiguration serdeConfiguration, Class<?> view) {
+        super(registry, serdeConfiguration, view);
     }
 
     @Override
     public JsonMapper cloneWithViewClass(Class<?> viewClass) {
-        return new BsonJsonMapper(registry, viewClass);
+        return new BsonJsonMapper(registry, serdeConfiguration, viewClass);
     }
 
     @Override

--- a/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonMappingSpec.groovy
+++ b/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonMappingSpec.groovy
@@ -3,6 +3,7 @@ package io.micronaut.serde.bson
 
 import io.micronaut.core.type.Argument
 import io.micronaut.serde.Deserializer
+import io.micronaut.serde.LimitingStream
 import io.micronaut.serde.SerdeRegistry
 import io.micronaut.serde.annotation.Serdeable
 import io.micronaut.serde.bson.custom.CodecBsonDecoder
@@ -163,7 +164,7 @@ class BsonMappingSpec extends Specification implements BsonJsonSpec, BsonBinaryS
                 list.add(
                         serdeRegistry.findDeserializer(Person2)
                                 .createSpecific(context, argument)
-                                .deserialize(new BsonReaderDecoder(reader), context, argument)
+                                .deserialize(new BsonReaderDecoder(reader, LimitingStream.DEFAULT_LIMITS), context, argument)
                 )
             }
 
@@ -185,7 +186,7 @@ class BsonMappingSpec extends Specification implements BsonJsonSpec, BsonBinaryS
             def context = serdeRegistry.newDecoderContext(Person2)
             def argument = Argument.of(Person2)
             def readPerson = serdeRegistry.findDeserializer(Person2).createSpecific(context, argument)
-                    .deserialize(new BsonReaderDecoder(reader), context, argument)
+                    .deserialize(new BsonReaderDecoder(reader, LimitingStream.DEFAULT_LIMITS), context, argument)
 
             reader.readEndDocument()
         then:
@@ -290,7 +291,7 @@ class BsonMappingSpec extends Specification implements BsonJsonSpec, BsonBinaryS
 
             def bsonDocumentAddress = BsonDocument.parse("""{"address": "The home", "street": "Downstreet", "town": "Paris", "postcode": "123456"}""")
         when:
-            Address address = asDecoder.deserialize(new BsonReaderDecoder(bsonDocumentAddress.asBsonReader()), context, addressArgument)
+            Address address = asDecoder.deserialize(new BsonReaderDecoder(bsonDocumentAddress.asBsonReader(), LimitingStream.DEFAULT_LIMITS), context, addressArgument)
         then:
             address.address == "The home"
     }
@@ -315,7 +316,7 @@ class BsonMappingSpec extends Specification implements BsonJsonSpec, BsonBinaryS
                 }
             }
         when:
-            NestedObjAddress e = deserializer.deserialize(new BsonReaderDecoder(bsonDocumentAddress.asBsonReader()), decoderContext, Argument.of(NestedObjAddress))
+            NestedObjAddress e = deserializer.deserialize(new BsonReaderDecoder(bsonDocumentAddress.asBsonReader(), LimitingStream.DEFAULT_LIMITS), decoderContext, Argument.of(NestedObjAddress))
         then:
             e.address.address == "The home"
             e.lastName == "B"
@@ -342,7 +343,7 @@ class BsonMappingSpec extends Specification implements BsonJsonSpec, BsonBinaryS
                 }
             }
         when:
-            NestedObjAddress e = deserializer.deserialize(new BsonReaderDecoder(bsonDocumentAddress.asBsonReader()), decoderContext, Argument.of(NestedObjAddress))
+            NestedObjAddress e = deserializer.deserialize(new BsonReaderDecoder(bsonDocumentAddress.asBsonReader(), LimitingStream.DEFAULT_LIMITS), decoderContext, Argument.of(NestedObjAddress))
         then:
             e.address.address == "The home"
             e.lastName == null
@@ -369,7 +370,7 @@ class BsonMappingSpec extends Specification implements BsonJsonSpec, BsonBinaryS
                 }
             }
         when:
-            NestedObj2Address e = deserializer.deserialize(new BsonReaderDecoder(bsonDocumentAddress.asBsonReader()), decoderContext, Argument.of(NestedObj2Address))
+            NestedObj2Address e = deserializer.deserialize(new BsonReaderDecoder(bsonDocumentAddress.asBsonReader(), LimitingStream.DEFAULT_LIMITS), decoderContext, Argument.of(NestedObj2Address))
         then:
             e.address.address.address == "The home"
             e.address.lastName == "B"
@@ -396,7 +397,7 @@ class BsonMappingSpec extends Specification implements BsonJsonSpec, BsonBinaryS
                 }
             }
         when:
-            NestedArrayAddress e = deserializer.deserialize(new BsonReaderDecoder(bsonDocumentAddress.asBsonReader()), decoderContext, Argument.of(NestedArrayAddress))
+            NestedArrayAddress e = deserializer.deserialize(new BsonReaderDecoder(bsonDocumentAddress.asBsonReader(), LimitingStream.DEFAULT_LIMITS), decoderContext, Argument.of(NestedArrayAddress))
         then:
             e.lastName == "B"
             e.addresses[0].address == "The home"
@@ -548,7 +549,7 @@ class MappedCodec<T> implements Codec<T> {
     @Override
     T decode(BsonReader reader, DecoderContext decoderContext) {
         try {
-            T deserialize = deserializer.deserialize(new BsonReaderDecoder(reader), serdeRegistry.newDecoderContext(type), argument)
+            T deserialize = deserializer.deserialize(new BsonReaderDecoder(reader, LimitingStream.DEFAULT_LIMITS), serdeRegistry.newDecoderContext(type), argument)
             return deserialize
         } catch (IOException e) {
             throw new SerdeException("Cannot deserialize: " + type, e)

--- a/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonReaderDecoderJsonSpec.groovy
+++ b/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonReaderDecoderJsonSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.serde.bson
 
 
 import io.micronaut.serde.Decoder
+import io.micronaut.serde.LimitingStream
 import io.micronaut.serde.exceptions.SerdeException
 import org.bson.json.JsonReader
 import org.intellij.lang.annotations.Language
@@ -9,7 +10,7 @@ import spock.lang.Specification
 
 class BsonReaderDecoderJsonSpec extends Specification {
     private static Decoder createDecoder(@Language('json') String json) {
-        return new BsonReaderDecoder(new JsonReader(json))
+        return new BsonReaderDecoder(new JsonReader(json), LimitingStream.DEFAULT_LIMITS)
     }
 
     def "unwrap arrays normal"() {

--- a/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonWriterEncoderSpec.groovy
+++ b/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonWriterEncoderSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.serde.bson
 
 import io.micronaut.core.type.Argument
+import io.micronaut.serde.LimitingStream
 import org.bson.BsonDocument
 import org.bson.BsonDocumentWriter
 import spock.lang.Specification
@@ -8,7 +9,7 @@ import spock.lang.Specification
 class BsonWriterEncoderSpec extends Specification {
     def 'currentPath'() {
         given:
-        def encoder = new BsonWriterEncoder(new BsonDocumentWriter(new BsonDocument()))
+        def encoder = new BsonWriterEncoder(new BsonDocumentWriter(new BsonDocument()), LimitingStream.DEFAULT_LIMITS)
 
         when:
         def outer = encoder.encodeObject(Argument.VOID)

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/JacksonDecoderSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/JacksonDecoderSpec.groovy
@@ -2,13 +2,14 @@ package io.micronaut.serde.jackson
 
 import com.fasterxml.jackson.core.JsonFactoryBuilder
 import io.micronaut.serde.Decoder
+import io.micronaut.serde.LimitingStream
 import io.micronaut.serde.exceptions.SerdeException
 import org.intellij.lang.annotations.Language
 import spock.lang.Specification
 
 class JacksonDecoderSpec extends Specification {
     private static Decoder createDecoder(@Language('json') String json) {
-        return JacksonDecoder.create(new JsonFactoryBuilder().build().createParser(json))
+        return JacksonDecoder.create(new JsonFactoryBuilder().build().createParser(json), LimitingStream.DEFAULT_LIMITS)
     }
 
     def "unwrap arrays normal"() {

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/LimitSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/LimitSpec.groovy
@@ -1,0 +1,46 @@
+package io.micronaut.serde.jackson
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.json.JsonMapper
+import io.micronaut.serde.exceptions.SerdeException
+import spock.lang.Specification
+
+class LimitSpec extends Specification {
+    def 'depth limit while encoding'() {
+        given:
+        def ctx = ApplicationContext.run(['micronaut.serde.maximum-nesting-depth': 2])
+        def mapper = ctx.getBean(JsonMapper)
+
+        when:
+        def val = mapper.writeValueAsString(['foo': ['bar': 'baz']])
+        then:
+        val == '{"foo":{"bar":"baz"}}'
+
+        when:
+        mapper.writeValueAsString(['foo': ['bar': []]])
+        then:
+        thrown SerdeException
+
+        cleanup:
+        ctx.close()
+    }
+
+    def 'depth limit while decoding'() {
+        given:
+        def ctx = ApplicationContext.run(['micronaut.serde.maximum-nesting-depth': 2])
+        def mapper = ctx.getBean(JsonMapper)
+
+        when:
+        def val = mapper.readValue('{"foo":{"bar":"baz"}}', Map)
+        then:
+        val == ['foo': ['bar': 'baz']]
+
+        when:
+        mapper.readValue('{"foo":{"bar":[]}}', Map)
+        then:
+        thrown SerdeException
+
+        cleanup:
+        ctx.close()
+    }
+}

--- a/serde-jsonp/src/main/java/io/micronaut/serde/json/stream/JsonParserDecoder.java
+++ b/serde-jsonp/src/main/java/io/micronaut/serde/json/stream/JsonParserDecoder.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.json.stream;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.AbstractStreamDecoder;
 import jakarta.json.JsonNumber;
@@ -31,7 +32,14 @@ public class JsonParserDecoder extends AbstractStreamDecoder {
     private final JsonParser jsonParser;
     private JsonParser.Event currentEvent;
 
+
     public JsonParserDecoder(JsonParser jsonParser) {
+        this(jsonParser, DEFAULT_LIMITS);
+    }
+
+    @Internal
+    JsonParserDecoder(JsonParser jsonParser, RemainingLimits remainingLimits) {
+        super(remainingLimits);
         this.jsonParser = jsonParser;
         this.currentEvent = jsonParser.next();
     }

--- a/serde-jsonp/src/main/java/io/micronaut/serde/json/stream/JsonStreamEncoder.java
+++ b/serde-jsonp/src/main/java/io/micronaut/serde/json/stream/JsonStreamEncoder.java
@@ -15,27 +15,30 @@
  */
 package io.micronaut.serde.json.stream;
 
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.LimitingStream;
+import jakarta.json.stream.JsonGenerator;
+
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.type.Argument;
-import io.micronaut.serde.Encoder;
-import jakarta.json.stream.JsonGenerator;
-
-final class JsonStreamEncoder implements Encoder {
+final class JsonStreamEncoder extends LimitingStream implements Encoder {
     private final JsonGenerator jsonGenerator;
     private final JsonStreamEncoder parent;
     private String currentKey;
     private int currentIndex;
 
-    public JsonStreamEncoder(JsonGenerator jsonGenerator) {
+    public JsonStreamEncoder(JsonGenerator jsonGenerator, RemainingLimits remainingLimits) {
+        super(remainingLimits);
         this.jsonGenerator = jsonGenerator;
         this.parent = null;
     }
 
-    private JsonStreamEncoder(JsonStreamEncoder parent) {
+    private JsonStreamEncoder(JsonStreamEncoder parent, RemainingLimits remainingLimits) {
+        super(remainingLimits);
         this.jsonGenerator = parent.jsonGenerator;
         this.parent = parent;
     }
@@ -47,13 +50,13 @@ final class JsonStreamEncoder implements Encoder {
     @Override
     public Encoder encodeArray(Argument<?> type) throws IOException {
         jsonGenerator.writeStartArray();
-        return new JsonStreamEncoder(this);
+        return new JsonStreamEncoder(this, childLimits());
     }
 
     @Override
     public Encoder encodeObject(Argument<?> type) throws IOException {
         jsonGenerator.writeStartObject();
-        return new JsonStreamEncoder(this);
+        return new JsonStreamEncoder(this, childLimits());
     }
 
     @Override

--- a/serde-jsonp/src/test/groovy/io/micronaut/serde/json/stream/JsonStreamEncoderSpec.groovy
+++ b/serde-jsonp/src/test/groovy/io/micronaut/serde/json/stream/JsonStreamEncoderSpec.groovy
@@ -1,13 +1,14 @@
 package io.micronaut.serde.json.stream
 
 import io.micronaut.core.type.Argument
+import io.micronaut.serde.LimitingStream
 import jakarta.json.Json
 import spock.lang.Specification
 
 class JsonStreamEncoderSpec extends Specification {
     def 'currentPath'() {
         given:
-        def encoder = new JsonStreamEncoder(Json.createGenerator(new ByteArrayOutputStream()))
+        def encoder = new JsonStreamEncoder(Json.createGenerator(new ByteArrayOutputStream()), LimitingStream.DEFAULT_LIMITS)
 
         when:
         def outer = encoder.encodeObject(Argument.VOID)

--- a/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/AbstractOracleJdbcJsonObjectMapper.java
+++ b/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/AbstractOracleJdbcJsonObjectMapper.java
@@ -17,14 +17,17 @@ package io.micronaut.serde.oracle.jdbc.json;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
 import io.micronaut.json.JsonStreamConfig;
 import io.micronaut.json.tree.JsonNode;
 import io.micronaut.serde.Deserializer;
 import io.micronaut.serde.Encoder;
+import io.micronaut.serde.LimitingStream;
 import io.micronaut.serde.ObjectMapper;
 import io.micronaut.serde.SerdeRegistry;
 import io.micronaut.serde.Serializer;
+import io.micronaut.serde.config.SerdeConfiguration;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.util.BufferingJsonNodeProcessor;
 import io.micronaut.serde.support.util.JsonNodeDecoder;
@@ -53,16 +56,20 @@ import java.util.function.Consumer;
 @Internal
 abstract class AbstractOracleJdbcJsonObjectMapper implements ObjectMapper {
     protected final SerdeRegistry registry;
+    @Nullable
+    protected final SerdeConfiguration serdeConfiguration;
     protected final Class<?> view;
     protected final OracleJsonFactory oracleJsonFactory = new OracleJsonFactory();
 
-    protected AbstractOracleJdbcJsonObjectMapper(SerdeRegistry registry) {
+    protected AbstractOracleJdbcJsonObjectMapper(SerdeRegistry registry, SerdeConfiguration serdeConfiguration) {
         this.registry = registry;
+        this.serdeConfiguration = serdeConfiguration;
         this.view = null;
     }
 
-    protected AbstractOracleJdbcJsonObjectMapper(SerdeRegistry registry, Class<?> view) {
+    protected AbstractOracleJdbcJsonObjectMapper(SerdeRegistry registry, SerdeConfiguration serdeConfiguration, Class<?> view) {
         this.registry = registry;
+        this.serdeConfiguration = serdeConfiguration;
         this.view = view;
     }
 
@@ -75,7 +82,7 @@ abstract class AbstractOracleJdbcJsonObjectMapper implements ObjectMapper {
         Deserializer.DecoderContext context = registry.newDecoderContext(view);
         final Deserializer<? extends T> deserializer = this.registry.findDeserializer(type).createSpecific(context, type);
         return deserializer.deserialize(
-            JsonNodeDecoder.create(tree),
+            JsonNodeDecoder.create(tree, limits()),
             context,
             type
         );
@@ -123,7 +130,7 @@ abstract class AbstractOracleJdbcJsonObjectMapper implements ObjectMapper {
         Deserializer.DecoderContext context = registry.newDecoderContext(view);
         final Deserializer<? extends T> deserializer = this.registry.findDeserializer(type).createSpecific(context, type);
         return deserializer.deserialize(
-            new OracleJdbcJsonParserDecoder(parser),
+            new OracleJdbcJsonParserDecoder(parser, limits()),
             context,
             type
         );
@@ -137,7 +144,7 @@ abstract class AbstractOracleJdbcJsonObjectMapper implements ObjectMapper {
             @Override
             protected JsonNode parseOne(@NonNull InputStream is) throws IOException {
                 try (OracleJsonParser parser = getJsonParser(is)) {
-                    final OracleJdbcJsonParserDecoder decoder = new OracleJdbcJsonParserDecoder(parser);
+                    final OracleJdbcJsonParserDecoder decoder = new OracleJdbcJsonParserDecoder(parser, limits());
                     final Object o = decoder.decodeArbitrary();
                     return writeValueToTree(o);
                 }
@@ -145,16 +152,21 @@ abstract class AbstractOracleJdbcJsonObjectMapper implements ObjectMapper {
         };
     }
 
+    @NonNull
+    private LimitingStream.RemainingLimits limits() {
+        return serdeConfiguration == null ? LimitingStream.DEFAULT_LIMITS : LimitingStream.limitsFromConfiguration(serdeConfiguration);
+    }
+
     @Override
     public JsonNode writeValueToTree(Object value) throws IOException {
-        JsonNodeEncoder encoder = JsonNodeEncoder.create();
+        JsonNodeEncoder encoder = JsonNodeEncoder.create(limits());
         serialize(encoder, value);
         return encoder.getCompletedValue();
     }
 
     @Override
     public <T> JsonNode writeValueToTree(Argument<T> type, T value) throws IOException {
-        JsonNodeEncoder encoder = JsonNodeEncoder.create();
+        JsonNodeEncoder encoder = JsonNodeEncoder.create(limits());
         serialize(encoder, value, type);
         return encoder.getCompletedValue();
     }
@@ -169,7 +181,7 @@ abstract class AbstractOracleJdbcJsonObjectMapper implements ObjectMapper {
             } else if (object == null) {
                 generator.writeNull();
             } else {
-                OracleJdbcJsonGeneratorEncoder encoder = new OracleJdbcJsonGeneratorEncoder(generator);
+                OracleJdbcJsonGeneratorEncoder encoder = new OracleJdbcJsonGeneratorEncoder(generator, limits());
                 serialize(encoder, object);
             }
             generator.flush();
@@ -196,7 +208,7 @@ abstract class AbstractOracleJdbcJsonObjectMapper implements ObjectMapper {
         if (value == null) {
             generator.writeNull();
         } else {
-            OracleJdbcJsonGeneratorEncoder encoder = new OracleJdbcJsonGeneratorEncoder(generator);
+            OracleJdbcJsonGeneratorEncoder encoder = new OracleJdbcJsonGeneratorEncoder(generator, limits());
             serialize(encoder, value, type);
         }
         generator.flush();

--- a/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/OracleJdbcJsonBinaryObjectMapper.java
+++ b/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/OracleJdbcJsonBinaryObjectMapper.java
@@ -16,9 +16,12 @@
 package io.micronaut.serde.oracle.jdbc.json;
 
 import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Order;
 import io.micronaut.json.JsonMapper;
 import io.micronaut.serde.SerdeRegistry;
+import io.micronaut.serde.config.SerdeConfiguration;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import oracle.sql.json.OracleJsonGenerator;
 import oracle.sql.json.OracleJsonParser;
@@ -37,17 +40,29 @@ import java.io.OutputStream;
 @Order(200) // lower precedence than Jackson
 public final class OracleJdbcJsonBinaryObjectMapper extends AbstractOracleJdbcJsonObjectMapper {
 
+    @Deprecated
     public OracleJdbcJsonBinaryObjectMapper(SerdeRegistry registry) {
-        super(registry);
+        this(registry, (SerdeConfiguration) null);
     }
 
+    @Deprecated
     public OracleJdbcJsonBinaryObjectMapper(SerdeRegistry registry, Class<?> view) {
-        super(registry, view);
+        this(registry, null, view);
+    }
+
+    @Internal
+    @Inject
+    public OracleJdbcJsonBinaryObjectMapper(SerdeRegistry registry, SerdeConfiguration serdeConfiguration) {
+        super(registry, serdeConfiguration);
+    }
+
+    private OracleJdbcJsonBinaryObjectMapper(SerdeRegistry registry, SerdeConfiguration serdeConfiguration, Class<?> view) {
+        super(registry, serdeConfiguration, view);
     }
 
     @Override
     public JsonMapper cloneWithViewClass(Class<?> viewClass) {
-        return new OracleJdbcJsonBinaryObjectMapper(registry, viewClass);
+        return new OracleJdbcJsonBinaryObjectMapper(registry, serdeConfiguration, viewClass);
     }
 
     @Override

--- a/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/OracleJdbcJsonParserDecoder.java
+++ b/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/OracleJdbcJsonParserDecoder.java
@@ -46,7 +46,8 @@ public final class OracleJdbcJsonParserDecoder extends AbstractStreamDecoder {
     private final OracleJsonParser jsonParser;
     private OracleJsonParser.Event currentEvent;
 
-    OracleJdbcJsonParserDecoder(OracleJsonParser jsonParser) {
+    OracleJdbcJsonParserDecoder(OracleJsonParser jsonParser, RemainingLimits remainingLimits) {
+        super(remainingLimits);
         this.jsonParser = jsonParser;
         this.currentEvent = jsonParser.next();
     }

--- a/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/OracleJdbcJsonTextObjectMapper.java
+++ b/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/OracleJdbcJsonTextObjectMapper.java
@@ -16,9 +16,12 @@
 package io.micronaut.serde.oracle.jdbc.json;
 
 import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Order;
 import io.micronaut.json.JsonMapper;
 import io.micronaut.serde.SerdeRegistry;
+import io.micronaut.serde.config.SerdeConfiguration;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import oracle.sql.json.OracleJsonGenerator;
 import oracle.sql.json.OracleJsonParser;
@@ -37,17 +40,29 @@ import java.io.OutputStream;
 @Order(199) // lower precedence than Jackson but higher than OracleJdbcJsonBinaryObjectMapper
 public final class OracleJdbcJsonTextObjectMapper extends AbstractOracleJdbcJsonObjectMapper {
 
+    @Deprecated
     public OracleJdbcJsonTextObjectMapper(SerdeRegistry registry) {
-        super(registry);
+        this(registry, (SerdeConfiguration) null);
     }
 
+    @Deprecated
     public OracleJdbcJsonTextObjectMapper(SerdeRegistry registry, Class<?> view) {
-        super(registry, view);
+        this(registry, null, view);
+    }
+
+    @Internal
+    @Inject
+    public OracleJdbcJsonTextObjectMapper(SerdeRegistry registry, SerdeConfiguration serdeConfiguration) {
+        super(registry, serdeConfiguration);
+    }
+
+    private OracleJdbcJsonTextObjectMapper(SerdeRegistry registry, SerdeConfiguration serdeConfiguration, Class<?> view) {
+        super(registry, serdeConfiguration, view);
     }
 
     @Override
     public JsonMapper cloneWithViewClass(Class<?> viewClass) {
-        return new OracleJdbcJsonTextObjectMapper(registry, viewClass);
+        return new OracleJdbcJsonTextObjectMapper(registry, serdeConfiguration, viewClass);
     }
 
     @Override

--- a/serde-oracle-jdbc-json/src/test/groovy/io/micronaut/serde/oracle/jdbc/json/OracleJdbcJsonGeneratorEncoderSpec.groovy
+++ b/serde-oracle-jdbc-json/src/test/groovy/io/micronaut/serde/oracle/jdbc/json/OracleJdbcJsonGeneratorEncoderSpec.groovy
@@ -1,13 +1,14 @@
 package io.micronaut.serde.oracle.jdbc.json
 
 import io.micronaut.core.type.Argument
+import io.micronaut.serde.LimitingStream
 import oracle.sql.json.OracleJsonFactory
 import spock.lang.Specification
 
 class OracleJdbcJsonGeneratorEncoderSpec extends Specification {
     def 'currentPath'() {
         given:
-        def encoder = new OracleJdbcJsonGeneratorEncoder(new OracleJsonFactory().createJsonBinaryGenerator(new ByteArrayOutputStream()))
+        def encoder = new OracleJdbcJsonGeneratorEncoder(new OracleJsonFactory().createJsonBinaryGenerator(new ByteArrayOutputStream()), LimitingStream.DEFAULT_LIMITS)
 
         when:
         def outer = encoder.encodeObject(Argument.VOID)

--- a/serde-support/src/test/groovy/io/micronaut/serde/JsonNodeDecoderSpec.groovy
+++ b/serde-support/src/test/groovy/io/micronaut/serde/JsonNodeDecoderSpec.groovy
@@ -5,25 +5,29 @@ import io.micronaut.serde.support.util.JsonNodeDecoder
 import spock.lang.Specification
 
 class JsonNodeDecoderSpec extends Specification {
+    private static JsonNodeDecoder create(JsonNode jsonNode) {
+        return JsonNodeDecoder.create(jsonNode, LimitingStream.DEFAULT_LIMITS)
+    }
+
     def 'scalar decode'() {
         expect:
-        JsonNodeDecoder.create(JsonNode.createNumberNode(42)).decodeByte() == (byte) 42
-        JsonNodeDecoder.create(JsonNode.createNumberNode(42)).decodeShort() == (short) 42
-        JsonNodeDecoder.create(JsonNode.createNumberNode(42)).decodeInt() == 42
-        JsonNodeDecoder.create(JsonNode.createNumberNode(42)).decodeLong() == 42L
-        JsonNodeDecoder.create(JsonNode.createNumberNode(42)).decodeFloat() == 42.0F
-        JsonNodeDecoder.create(JsonNode.createNumberNode(42)).decodeDouble() == 42.0D
-        JsonNodeDecoder.create(JsonNode.createNumberNode(42)).decodeBigInteger() == BigInteger.valueOf(42)
-        JsonNodeDecoder.create(JsonNode.createNumberNode(42)).decodeBigDecimal() == BigDecimal.valueOf(42)
+        create(JsonNode.createNumberNode(42)).decodeByte() == (byte) 42
+        create(JsonNode.createNumberNode(42)).decodeShort() == (short) 42
+        create(JsonNode.createNumberNode(42)).decodeInt() == 42
+        create(JsonNode.createNumberNode(42)).decodeLong() == 42L
+        create(JsonNode.createNumberNode(42)).decodeFloat() == 42.0F
+        create(JsonNode.createNumberNode(42)).decodeDouble() == 42.0D
+        create(JsonNode.createNumberNode(42)).decodeBigInteger() == BigInteger.valueOf(42)
+        create(JsonNode.createNumberNode(42)).decodeBigDecimal() == BigDecimal.valueOf(42)
 
-        JsonNodeDecoder.create(JsonNode.createStringNode('foo')).decodeString() == 'foo'
-        JsonNodeDecoder.create(JsonNode.createBooleanNode(true)).decodeBoolean()
-        JsonNodeDecoder.create(JsonNode.nullNode()).decodeNull()
+        create(JsonNode.createStringNode('foo')).decodeString() == 'foo'
+        create(JsonNode.createBooleanNode(true)).decodeBoolean()
+        create(JsonNode.nullNode()).decodeNull()
     }
 
     def 'array decode'() {
         given:
-        def decoder = JsonNodeDecoder.create(JsonNode.createArrayNode([
+        def decoder = create(JsonNode.createArrayNode([
                 JsonNode.createNumberNode(42),
                 JsonNode.createStringNode('foo'),
                 JsonNode.createBooleanNode(true),
@@ -55,7 +59,7 @@ class JsonNodeDecoderSpec extends Specification {
 
     def 'object decode'() {
         given:
-        def decoder = JsonNodeDecoder.create(JsonNode.createObjectNode([
+        def decoder = create(JsonNode.createObjectNode([
                 f1: JsonNode.createNumberNode(42),
                 f2: JsonNode.createStringNode('foo'),
                 f3: JsonNode.createBooleanNode(true),
@@ -87,7 +91,7 @@ class JsonNodeDecoderSpec extends Specification {
 
     def 'arbitrary decode'() {
         given:
-        def decoder = JsonNodeDecoder.create(JsonNode.createObjectNode([
+        def decoder = create(JsonNode.createObjectNode([
                 f1: JsonNode.createNumberNode(42),
                 f2: JsonNode.createStringNode('foo'),
                 f3: JsonNode.createBooleanNode(true),


### PR DESCRIPTION
Create a new base class LimitingStream for all Decoder and Encoder implementations that checks the nesting depth. The nesting depth is configured using a new configuration property.

The purpose of this is to harden against issues like https://github.com/FasterXML/jackson-databind/issues/3972 . Another benefit is that accidental recursive data structures made by developers won't lead to a stack overflow but will be caught earlier with a nicer error message.

This patch changes many classes, mostly because the new limit has to be propagated from the serde configuration to the encoders/decoders. To simplify addition of other limits in the future, I've wrapped the depth limit into an opaque data structure. Other possible limits would be e.g. on total output size or on array sizes.

I've tried to keep this patch as compatible as possible even though it's only going into a major version, to make the release process easier. Methods that need the new limit parameter and were not internal I've deprecated.