### PR TITLE
Fix for JacksonDecoder.decodeKey returning key when there is none

### DIFF
--- a/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonDecoder.java
+++ b/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonDecoder.java
@@ -130,6 +130,9 @@ public final class JacksonDecoder extends LimitingStream implements Decoder {
     @Override
     public String decodeKey() throws IOException {
         if (peekedToken != null) {
+            if (peekedToken == JsonToken.END_OBJECT) {
+                return null;
+            }
             String fieldName = parser.currentName();
             if (fieldName != null) {
                 peekedToken = null;


### PR DESCRIPTION
The `JacksonDecoder.decodeKey` method relies on the `parser.currenName()` method. However, when reaching the end of a nested object, it seems to return the root key instead of `null` (for JSON `{"nested":{"a":"b"}}` after reading key `a` it would return `nested`). 

This only seems to happen when the next token was peeked and therefore happens in a specific test with `@JsonAnySetter`. (When the next toke is not peeked,  `JacksonDecoder.decodeKey` uses `parser.nextFieldName()` which has the desired behavior.

The issue is solved by explicitly verifying that we haven't parsed the whole object (next token is not `END_OBJECT`).