### PR TITLE
Field marked as READ_ONLY in JsonUnwrapped should not be writable

### DIFF
--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBean.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBean.java
@@ -231,7 +231,8 @@ final class SerBean<T> {
                                             argument.getAnnotationMetadata(),
                                             unwrappedProperty.getAnnotationMetadata()
                                         );
-                                    if (!combinedMetadata.booleanValue(SerdeConfig.class, SerdeConfig.IGNORED).orElse(false)) {
+                                    if (!combinedMetadata.booleanValue(SerdeConfig.class, SerdeConfig.IGNORED).orElse(false) &&
+                                        !combinedMetadata.booleanValue(SerdeConfig.class, SerdeConfig.READ_ONLY).orElse(false)) {
                                         CustomSerProperty<T, Object> prop = new CustomSerProperty<>(SerBean.this, n,
                                             unwrappedPropertyArgument,
                                             combinedMetadata,


### PR DESCRIPTION
I think this was missed, we should not add prop to write properties if it belongs to `@JsonUnwrapped` and was marked as read only.