### PR TITLE
Test case for private builder constructor method

### DIFF
--- a/doc-examples/example-java/src/main/java/example/BuilderBean.java
+++ b/doc-examples/example-java/src/main/java/example/BuilderBean.java
@@ -1,0 +1,64 @@
+package example;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.micronaut.core.annotation.Introspected;
+
+import java.util.Objects;
+
+@JsonDeserialize(builder = BuilderBean.Builder.class)
+@Introspected(builder = @Introspected.IntrospectionBuilder(builderMethod = "builder"))
+public class BuilderBean {
+    private final String foo;
+
+    private BuilderBean(String foo) {
+        this.foo = foo;
+    }
+
+    public String getFoo() {
+        return foo;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        BuilderBean bean = (BuilderBean) o;
+        return Objects.equals(foo, bean.foo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(foo);
+    }
+
+    @Override
+    public String toString() {
+        return "BuilderBean{" +
+            "foo='" + foo + '\'' +
+            '}';
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String foo;
+
+        private Builder() {
+        }
+
+        public Builder foo(String foo) {
+            this.foo = foo;
+            return this;
+        }
+
+        public BuilderBean build() {
+            return new BuilderBean(foo);
+        }
+    }
+}

--- a/doc-examples/example-java/src/main/java/example/ImportBuilders2.java
+++ b/doc-examples/example-java/src/main/java/example/ImportBuilders2.java
@@ -1,0 +1,5 @@
+package example;
+
+//@SerdeImport(BuilderBean.class)
+public class ImportBuilders2 {
+}

--- a/doc-examples/example-java/src/test/java/example/SerdeImportBuilder2Test.java
+++ b/doc-examples/example-java/src/test/java/example/SerdeImportBuilder2Test.java
@@ -1,0 +1,23 @@
+package example;
+
+import io.micronaut.serde.ObjectMapper;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+@MicronautTest
+class SerdeImportBuilder2Test {
+
+    @Inject ObjectMapper mapper;
+
+    @Test
+    void testImportedSerializers() throws IOException {
+        BuilderBean bean = BuilderBean.builder().foo("bar").build();
+        String json = mapper.writeValueAsString(bean);
+        Assertions.assertEquals("{\"foo\":\"bar\"}", json);
+        Assertions.assertEquals(bean, mapper.readValue(json, BuilderBean.class));
+    }
+}


### PR DESCRIPTION
Unfortunately this test case is a bit removed from my original issue.

In the original issue, I have a third-party bean with a builder and jackson annotations. The builder is generated by lombok and has an inaccessible constructor, I think package-private. I want to import that bean with `@SerdeImport`, with the additional qualification of `@Introspected(builder = @Introspected.IntrospectionBuilder(builderMethod = "builder"))` in order to use the builder method instead of the default constructor of the builder class.

The problem is that serde seems to be ignoring my custom `@Introspected` and replacing it with `@Introspected` with `builderClass` instead of `builderMethod`. In the original project, this leads to a runtime illegal access of the builder constructor.

This test case is modified a bunch, because I wanted to restrict it to one module where the processor is already running. Since the class needs to be annotated with `@JsonDeserialize`, and that triggers serde processing, I can't build this test with `@SerdeImport` anymore. I instead moved the `@Introspected` to the actual bean class. I also made the builder class constructor private, to trigger the error: package-private is not enough since the introspection will be placed in the same package.

In the test case, the bug manifests as a compile-time error:

```
/home/yawkat/dev/mn/micronaut-serialization/doc-examples/example-java/src/main/java/example/BuilderBean.java:12: error: No accessible constructor found for builder: example.BuilderBean$Builder
public class BuilderBean {
```