### PR TITLE
Respect JsonProperty on outer property for builders

### DIFF
--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/builder/BuilderSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/builder/BuilderSpec.groovy
@@ -68,4 +68,15 @@ class BuilderSpec extends Specification {
         value.getClass() == TestBuildSupertype2
         value.foo == 'fizz'
     }
+
+    void "test deserialize builder with JsonProperty on outer class"() {
+        given:
+        def json = '{"bar":"baz"}'
+
+        when:
+        def value = objectMapper.readValue(json, TestBuildName)
+
+        then:
+        value.foo == 'baz'
+    }
 }

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/builder/TestBuildName.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/builder/TestBuildName.java
@@ -1,0 +1,31 @@
+package io.micronaut.serde.jackson.builder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize(builder = TestBuildName.Builder.class)
+public class TestBuildName {
+    @JsonProperty("bar")
+    private final String foo;
+
+    private TestBuildName(String foo) {
+        this.foo = foo;
+    }
+
+    public String getFoo() {
+        return foo;
+    }
+
+    public static class Builder {
+        private String foo;
+
+        public Builder foo(String foo) {
+            this.foo = foo;
+            return this;
+        }
+
+        public TestBuildName build() {
+            return new TestBuildName(foo);
+        }
+    }
+}


### PR DESCRIPTION
If JsonProperty on a bean property changes its serialization name, also consider that name for the builder properties.