### PR TITLE
serialization TCK and InetAddress Serde

### DIFF
--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.serde-tck-suite.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.serde-tck-suite.gradle
@@ -1,0 +1,15 @@
+plugins {
+    id("io.micronaut.build.internal.serde-base")
+    id("java-library")
+}
+dependencies {
+    testImplementation(platform(mn.micronaut.core.bom))
+    testImplementation(projects.micronautSerdeTckTests)
+    testImplementation(platform(mnTest.micronaut.test.bom))
+    testImplementation(libs.junit.platform.engine)
+    testImplementation(libs.junit.jupiter.engine)
+    testRuntimeOnly(mnLogging.logback.classic)
+}
+tasks.named("test") {
+    useJUnitPlatform()
+}

--- a/buildSrc/src/main/groovy/io.micronaut.build.internal.serde-tck-suite.gradle
+++ b/buildSrc/src/main/groovy/io.micronaut.build.internal.serde-tck-suite.gradle
@@ -2,6 +2,7 @@ plugins {
     id("io.micronaut.build.internal.serde-base")
     id("java-library")
 }
+
 dependencies {
     testImplementation(platform(mn.micronaut.core.bom))
     testImplementation(projects.micronautSerdeTckTests)
@@ -10,6 +11,7 @@ dependencies {
     testImplementation(libs.junit.jupiter.engine)
     testRuntimeOnly(mnLogging.logback.classic)
 }
+
 tasks.named("test") {
     useJUnitPlatform()
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ graal-svm = { module = "org.graalvm.nativeimage:svm", version.ref = "graal-svm" 
 microstream-storage-restclient = { module = "one.microstream:microstream-storage-restclient", version.ref = "microstream-storage-restclient" }
 junit-jupiter-engine = { module = 'org.junit.jupiter:junit-jupiter-engine' }
 junit-jupiter-api = { module = 'org.junit.jupiter:junit-jupiter-api' }
+junit-platform-engine = { module = "org.junit.platform:junit-platform-suite-engine" }
 
 jmh-core = { module = "org.openjdk.jmh:jmh-core", version.ref = "jmh" }
 jmh-generator-annprocess = { module = "org.openjdk.jmh:jmh-generator-annprocess", version.ref = "jmh" }

--- a/serde-api/src/main/java/io/micronaut/serde/config/DefaultSerdeConfiguration.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/DefaultSerdeConfiguration.java
@@ -43,6 +43,7 @@ final class DefaultSerdeConfiguration implements SerdeConfiguration {
     private final Optional<TimeZone> timeZone;
     private final List<String> includedIntrospectionPackages;
     private final int maximumNestingDepth;
+    private final boolean inetAddressAsNumeric;
 
     @ConfigurationInject
     DefaultSerdeConfiguration(Optional<String> dateFormat,
@@ -52,7 +53,8 @@ final class DefaultSerdeConfiguration implements SerdeConfiguration {
                               Optional<Locale> locale,
                               Optional<TimeZone> timeZone,
                               @Bindable(defaultValue = "io.micronaut") List<String> includedIntrospectionPackages,
-                              @Bindable(defaultValue = LimitingStream.DEFAULT_MAXIMUM_DEPTH + "") int maximumNestingDepth) {
+                              @Bindable(defaultValue = LimitingStream.DEFAULT_MAXIMUM_DEPTH + "") int maximumNestingDepth,
+                              @Bindable(defaultValue = DEFAULT_INET_ADDRESS_AS_NUMERIC + "") boolean inetAddressAsNumeric) {
         this.dateFormat = dateFormat;
         this.timeWriteShape = timeWriteShape;
         this.numericTimeUnit = numericTimeUnit;
@@ -61,6 +63,7 @@ final class DefaultSerdeConfiguration implements SerdeConfiguration {
         this.timeZone = timeZone;
         this.includedIntrospectionPackages = includedIntrospectionPackages;
         this.maximumNestingDepth = maximumNestingDepth;
+        this.inetAddressAsNumeric = inetAddressAsNumeric;
     }
 
     @Override
@@ -101,5 +104,10 @@ final class DefaultSerdeConfiguration implements SerdeConfiguration {
     @Override
     public int getMaximumNestingDepth() {
         return maximumNestingDepth;
+    }
+
+    @Override
+    public boolean isInetAddressAsNumeric() {
+        return inetAddressAsNumeric;
     }
 }

--- a/serde-api/src/main/java/io/micronaut/serde/config/SerdeConfiguration.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/SerdeConfiguration.java
@@ -18,6 +18,7 @@ package io.micronaut.serde.config;
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.serde.LimitingStream;
 
+import java.net.InetAddress;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -37,6 +38,16 @@ public interface SerdeConfiguration {
      * @return the date format to use
      */
     Optional<String> getDateFormat();
+
+    boolean DEFAULT_INET_ADDRESS_AS_NUMERIC = false;
+
+    /**
+     *
+     * @return Whether to use {@link InetAddress#getHostAddress()} when serializing {@link InetAddress}.
+     */
+    default boolean isInetAddressAsNumeric() {
+        return DEFAULT_INET_ADDRESS_AS_NUMERIC;
+    }
 
     /**
      * Shape for serializing dates.

--- a/serde-api/src/test/groovy/io/micronaut/serde/config/SerdeConfigurationSpec.groovy
+++ b/serde-api/src/test/groovy/io/micronaut/serde/config/SerdeConfigurationSpec.groovy
@@ -14,5 +14,4 @@ class SerdeConfigurationSpec extends Specification {
         expect:
         !serdeConfiguration.isInetAddressAsNumeric()
     }
-
 }

--- a/serde-api/src/test/groovy/io/micronaut/serde/config/SerdeConfigurationSpec.groovy
+++ b/serde-api/src/test/groovy/io/micronaut/serde/config/SerdeConfigurationSpec.groovy
@@ -1,0 +1,18 @@
+package io.micronaut.serde.config
+
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest(startApplication = false)
+class SerdeConfigurationSpec extends Specification {
+
+    @Inject
+    SerdeConfiguration serdeConfiguration
+
+    void  "inet address as numeric defaults to false" () {
+        expect:
+        !serdeConfiguration.isInetAddressAsNumeric()
+    }
+
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/InetAddressSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/InetAddressSerde.java
@@ -33,6 +33,7 @@ import java.net.InetAddress;
  */
 @Singleton
 public class InetAddressSerde implements Serde<InetAddress> {
+
     private final boolean asNumeric;
 
     public InetAddressSerde(SerdeConfiguration serdeConfiguration) {

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/InetAddressSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/InetAddressSerde.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.Serde;
+import io.micronaut.serde.config.SerdeConfiguration;
+import jakarta.inject.Singleton;
+
+import java.io.IOException;
+import java.net.InetAddress;
+
+/**
+ * {@link Serde} implementation of {@link InetAddress}.
+ * This is a based on `com.fasterxml.jackson.databind.ser.std.InetAddressSerializer` which is licenced under the Apache 2.0 licence.
+ */
+@Singleton
+public class InetAddressSerde implements Serde<InetAddress> {
+    private final boolean asNumeric;
+
+    public InetAddressSerde(SerdeConfiguration serdeConfiguration) {
+        this.asNumeric = serdeConfiguration.isInetAddressAsNumeric();
+    }
+
+    @Override
+    public @Nullable InetAddress deserialize(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super InetAddress> type) throws IOException {
+        return InetAddress.getByName(decoder.decodeString());
+    }
+
+    @Override
+    public void serialize(@NonNull Encoder encoder, @NonNull EncoderContext context, @NonNull Argument<? extends InetAddress> type, @NonNull InetAddress value) throws IOException {
+        String str;
+        if (asNumeric) {
+            str = value.getHostAddress();
+        } else {
+            str = value.toString().trim();
+            int ix = str.indexOf('/');
+            if (ix >= 0) {
+                if (ix == 0) { // missing host name; use address
+                    str = str.substring(1);
+                } else { // otherwise use name
+                    str = str.substring(0, ix);
+                }
+            }
+        }
+        encoder.encodeString(str);
+    }
+}

--- a/serde-support/src/test/groovy/io/micronaut/serde/support/serdes/InetAddressSerdeSpec.groovy
+++ b/serde-support/src/test/groovy/io/micronaut/serde/support/serdes/InetAddressSerdeSpec.groovy
@@ -1,0 +1,27 @@
+package io.micronaut.serde.support.serdes
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.core.util.StringUtils
+import io.micronaut.json.JsonMapper
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@Property(name = "micronaut.serde.inet-address-as-numeric", value = StringUtils.TRUE)
+@Property(name = "spec.name", value = "InetAddressSerdeSpec")
+@MicronautTest(startApplication = false)
+class InetAddressSerdeSpec extends Specification {
+
+    @Inject
+    JsonMapper jsonMapper
+    void "if you set micronaut.serde.inet-address-as-numeric getHostAddress is used"() {
+        given:
+        InetAddress input = InetAddress.getByName("google.com");
+
+        when:
+        String ip = jsonMapper.writeValueAsString(input)
+
+        then:
+        ip =~  (/([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})/)
+    }
+}

--- a/serde-tck-tests/build.gradle.kts
+++ b/serde-tck-tests/build.gradle.kts
@@ -1,15 +1,18 @@
 plugins {
     id("io.micronaut.build.internal.serde-module")
 }
+
 dependencies {
     api(mnTest.micronaut.test.junit5)
     api(mn.micronaut.json.core)
 }
+
 micronautBuild {
     binaryCompatibility {
         enabled.set(false)
     }
 }
+
 tasks.named("checkstyleMain").configure {
     enabled = false
 }

--- a/serde-tck-tests/build.gradle.kts
+++ b/serde-tck-tests/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    id("io.micronaut.build.internal.serde-module")
+}
+dependencies {
+    api(mnTest.micronaut.test.junit5)
+    api(mn.micronaut.json.core)
+}
+micronautBuild {
+    binaryCompatibility {
+        enabled.set(false)
+    }
+}
+tasks.named("checkstyleMain").configure {
+    enabled = false
+}

--- a/serde-tck-tests/src/main/java/io/micronaut/serde/tck/tests/InetAddressTest.java
+++ b/serde-tck-tests/src/main/java/io/micronaut/serde/tck/tests/InetAddressTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @MicronautTest
 public class InetAddressTest {
+
     @Test
     public void inetAddressSerialization(JsonMapper jsonMapper) throws IOException {
         assertEquals(q("127.0.0.1"), jsonMapper.writeValueAsString(InetAddress.getByName("127.0.0.1")));

--- a/serde-tck-tests/src/main/java/io/micronaut/serde/tck/tests/InetAddressTest.java
+++ b/serde-tck-tests/src/main/java/io/micronaut/serde/tck/tests/InetAddressTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.tck.tests;
+
+import io.micronaut.json.JsonMapper;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest
+public class InetAddressTest {
+    @Test
+    public void inetAddressSerialization(JsonMapper jsonMapper) throws IOException {
+        assertEquals(q("127.0.0.1"), jsonMapper.writeValueAsString(InetAddress.getByName("127.0.0.1")));
+        InetAddress input = InetAddress.getByName("google.com");
+        assertEquals(q("google.com"), jsonMapper.writeValueAsString(input));
+
+        InetAddress address = jsonMapper.readValue(q("127.0.0.1"), InetAddress.class);
+        assertEquals("127.0.0.1", address.getHostAddress());
+
+        final String HOST = "google.com";
+        address = jsonMapper.readValue(q(HOST), InetAddress.class);
+        assertEquals(HOST, address.getHostName());
+    }
+
+    public static String q(String str) {
+        return '"'+str+'"';
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,7 @@ include("serde-jsonp")
 include("serde-support")
 include("serde-bson")
 include("serde-tck")
+include("serde-tck-tests")
 include("serde-oracle-jdbc-json")
 
 include("doc-examples:example-bson-java")
@@ -30,6 +31,9 @@ include("doc-examples:example-jsonb-java")
 include("doc-examples:example-kotlin")
 
 include("benchmarks")
+
+include("test-suite-tck-jackson-databind")
+include("test-suite-tck-serde")
 
 val micronautVersion = providers.gradleProperty("micronautVersion")
 

--- a/test-suite-tck-jackson-databind/build.gradle.kts
+++ b/test-suite-tck-jackson-databind/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("io.micronaut.build.internal.serde-tck-suite")
 }
+
 dependencies {
     testImplementation(mn.micronaut.jackson.databind)
 }

--- a/test-suite-tck-jackson-databind/build.gradle.kts
+++ b/test-suite-tck-jackson-databind/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    id("io.micronaut.build.internal.serde-tck-suite")
+}
+dependencies {
+    testImplementation(mn.micronaut.jackson.databind)
+}

--- a/test-suite-tck-jackson-databind/src/test/java/io/micronaut/serde/tck/tests/jacksondatabind/SerializationJacksonDatabindSuite.java
+++ b/test-suite-tck-jackson-databind/src/test/java/io/micronaut/serde/tck/tests/jacksondatabind/SerializationJacksonDatabindSuite.java
@@ -1,4 +1,5 @@
 package io.micronaut.serde.tck.tests.jacksondatabind;
+
 import org.junit.platform.suite.api.Suite;
 import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.SuiteDisplayName;

--- a/test-suite-tck-jackson-databind/src/test/java/io/micronaut/serde/tck/tests/jacksondatabind/SerializationJacksonDatabindSuite.java
+++ b/test-suite-tck-jackson-databind/src/test/java/io/micronaut/serde/tck/tests/jacksondatabind/SerializationJacksonDatabindSuite.java
@@ -1,0 +1,10 @@
+package io.micronaut.serde.tck.tests.jacksondatabind;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.SuiteDisplayName;
+
+@Suite
+@SelectPackages("io.micronaut.serde.tck.tests")
+@SuiteDisplayName("Serialization TCK Jackson Databind")
+public class SerializationJacksonDatabindSuite {
+}

--- a/test-suite-tck-serde/build.gradle.kts
+++ b/test-suite-tck-serde/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("io.micronaut.build.internal.serde-tck-suite")
 }
+
 dependencies {
     implementation(projects.micronautSerdeJackson)
 }

--- a/test-suite-tck-serde/build.gradle.kts
+++ b/test-suite-tck-serde/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    id("io.micronaut.build.internal.serde-tck-suite")
+}
+dependencies {
+    implementation(projects.micronautSerdeJackson)
+}

--- a/test-suite-tck-serde/src/test/java/io/micronaut/serde/tck/tests/serde/SerializationSerdeSuite.java
+++ b/test-suite-tck-serde/src/test/java/io/micronaut/serde/tck/tests/serde/SerializationSerdeSuite.java
@@ -1,0 +1,10 @@
+package io.micronaut.serde.tck.tests.serde;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.SuiteDisplayName;
+
+@Suite
+@SelectPackages("io.micronaut.serde.tck.tests")
+@SuiteDisplayName("Serialization TCK Serde")
+public class SerializationSerdeSuite {
+}

--- a/test-suite-tck-serde/src/test/java/io/micronaut/serde/tck/tests/serde/SerializationSerdeSuite.java
+++ b/test-suite-tck-serde/src/test/java/io/micronaut/serde/tck/tests/serde/SerializationSerdeSuite.java
@@ -1,4 +1,5 @@
 package io.micronaut.serde.tck.tests.serde;
+
 import org.junit.platform.suite.api.Suite;
 import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.SuiteDisplayName;


### PR DESCRIPTION
This PR adds a tck so that we can compare Micronaut Serialization against Micronaut Jackson Databind

It adds a InetAddressSerde porting Jackson logic https://github.com/FasterXML/jackson-databind/blob/2.15/src/main/java/com/fasterxml/jackson/databind/ser/std/InetAddressSerializer.java

This is related to: https://github.com/micronaut-projects/micronaut-discovery-client/issues/517