### PR TITLE
Support `@JsonTypeInfo(visible=true)`

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
@@ -280,7 +280,7 @@ public @interface SerdeConfig {
         /**
          * Is discriminator visible.
          */
-        String DISCRIMINATOR_VISIBLE = "dvisible";
+        String DISCRIMINATOR_VISIBLE = "discriminatorVisible";
 
         /**
          * The discriminator to use.

--- a/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
@@ -120,6 +120,11 @@ public @interface SerdeConfig {
     String TYPE_PROPERTY = "typeProperty";
 
     /**
+     * If the type property should be visible.
+     */
+    String TYPE_PROPERTY_VISIBLE = "typePropertyVisible";
+
+    /**
      * A property that should be used to wrap this value when serializing.
      */
     String WRAPPER_PROPERTY = "wrapperProperty";
@@ -266,10 +271,17 @@ public @interface SerdeConfig {
      */
     @Internal
     @interface SerSubtyped {
+
         /**
          * @return the subtypes
          */
         SerSubtype[] value() default {};
+
+        /**
+         * Is discriminator visible.
+         */
+        String DISCRIMINATOR_VISIBLE = "dvisible";
+
         /**
          * The discriminator to use.
          */

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/SerdeAnnotationVisitor.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/SerdeAnnotationVisitor.java
@@ -728,7 +728,7 @@ public class SerdeAnnotationVisitor implements TypeElementVisitor<SerdeConfig, S
             default -> allNames.add(subtype.getName());
         }
 
-        subtype.annotate(SerdeConfig.class, (builder) -> {
+        subtype.annotate(SerdeConfig.class, builder -> {
             builder.member(SerdeConfig.TYPE_NAME, allNames.get(0));
             builder.member(SerdeConfig.TYPE_NAMES, allNames.toArray(new String[0]));
 
@@ -736,6 +736,10 @@ public class SerdeAnnotationVisitor implements TypeElementVisitor<SerdeConfig, S
                 builder.member(SerdeConfig.WRAPPER_PROPERTY, allNames.get(0));
             } else {
                 builder.member(SerdeConfig.TYPE_PROPERTY, typeProperty);
+            }
+
+            if (supertype.booleanValue(SerdeConfig.SerSubtyped.class, SerdeConfig.SerSubtyped.DISCRIMINATOR_VISIBLE).orElse(false)) {
+                builder.member(SerdeConfig.TYPE_PROPERTY_VISIBLE, true);
             }
         });
     }

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/jackson/JsonTypeInfoMapper.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/jackson/JsonTypeInfoMapper.java
@@ -42,12 +42,14 @@ public class JsonTypeInfoMapper extends ValidatingAnnotationMapper {
                 "defaultImpl",
                 "property",
                 "include",
-                "use"
+                "use",
+                "visible"
         );
     }
 
     @Override
     protected List<AnnotationValue<?>> mapValid(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        boolean discriminatorVisible = annotation.booleanValue("visible").orElse(false);
         String use = annotation.stringValue("use").orElse(null);
         String include = annotation.stringValue("include").orElse("PROPERTY");
         AnnotationClassValue<?> defaultImpl = annotation.annotationClassValue("defaultImpl").orElse(null);
@@ -65,6 +67,7 @@ public class JsonTypeInfoMapper extends ValidatingAnnotationMapper {
         }
 
         AnnotationValueBuilder<SerdeConfig.SerSubtyped> builder = AnnotationValue.builder(SerdeConfig.SerSubtyped.class);
+        builder.member(SerdeConfig.SerSubtyped.DISCRIMINATOR_VISIBLE, discriminatorVisible);
         if ("PROPERTY".equals(include) || "WRAPPER_OBJECT".equals(include)) {
             builder.member(SerdeConfig.SerSubtyped.DISCRIMINATOR_TYPE, include);
         } else {

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DemuxingObjectDecoder.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DemuxingObjectDecoder.java
@@ -19,8 +19,11 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
+import io.micronaut.json.tree.JsonNode;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.DelegatingDecoder;
+import io.micronaut.serde.LimitingStream;
+import io.micronaut.serde.support.util.JsonNodeDecoder;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -70,11 +73,10 @@ final class DemuxingObjectDecoder extends DelegatingDecoder {
      *
      * @param decoder The input to read from. The primed decoder will call {@link #decodeObject()}
      *                on this input exactly once
-     * @param consumeValues If decoder should consume value or not
      * @return The primed decoder
      */
-    public static Decoder prime(Decoder decoder, boolean consumeValues) {
-        return new PrimedDecoder(decoder, consumeValues);
+    public static PrimedDecoder prime(Decoder decoder) {
+        return new PrimedDecoder(decoder);
     }
 
     @Override
@@ -104,12 +106,15 @@ final class DemuxingObjectDecoder extends DelegatingDecoder {
 
     @Override
     protected Decoder delegate() throws IOException {
-        DemuxerState.Entry e = entryForValue();
-        if (consumeValues) {
-            return e.consume();
-        } else {
-            return e.buffer();
+        DemuxerState.Entry entry = entryForValue();
+        Decoder delegate = entry.consume();
+        if (!consumeValues) {
+            JsonNode node = delegate.decodeNode();
+            entry.consumed = false;
+            entry.buffer = JsonNodeDecoder.create(node, LimitingStream.DEFAULT_LIMITS);
+            delegate = JsonNodeDecoder.create(node, LimitingStream.DEFAULT_LIMITS);
         }
+        return delegate;
     }
 
     @Override
@@ -220,15 +225,6 @@ final class DemuxingObjectDecoder extends DelegatingDecoder {
                 }
             }
 
-            Decoder buffer() throws IOException {
-                if (buffer != null) {
-                    return buffer;
-                } else {
-                    buffer = delegate.decodeBuffer();
-                }
-                return buffer;
-            }
-
             boolean decodeNull() throws IOException {
                 // this call has the expectation that a proper consume() will follow
                 if (consumed) {
@@ -243,15 +239,13 @@ final class DemuxingObjectDecoder extends DelegatingDecoder {
         }
     }
 
-    private static class PrimedDecoder extends DelegatingDecoder {
+    static final class PrimedDecoder extends DelegatingDecoder {
         private final Decoder delegate;
-        private final boolean absorbValues;
         @Nullable
         private DemuxerState state;
 
-        PrimedDecoder(Decoder delegate, boolean absorbValues) {
+        private PrimedDecoder(Decoder delegate) {
             this.delegate = delegate;
-            this.absorbValues = absorbValues;
         }
 
         @Override
@@ -260,7 +254,7 @@ final class DemuxingObjectDecoder extends DelegatingDecoder {
                 state = new DemuxerState(delegate.decodeObject());
                 state.outputCount++;
             }
-            return new DemuxingObjectDecoder(state, absorbValues);
+            return new DemuxingObjectDecoder(state, true);
         }
 
         @Override
@@ -269,7 +263,24 @@ final class DemuxingObjectDecoder extends DelegatingDecoder {
                 state = new DemuxerState(delegate.decodeObject(type));
                 state.outputCount++;
             }
-            return new DemuxingObjectDecoder(state, absorbValues);
+            return new DemuxingObjectDecoder(state, true);
+        }
+
+        /**
+         * Decode this object in a "non-consuming" fashion. Values read by the returned decoder can
+         * still be read by other decoders, though possibly in a degraded state (e.g. decreased
+         * numerical precision).
+         *
+         * @param type See {@link #decodeObject(Argument)}
+         * @return The object decoder
+         * @throws IOException If an unrecoverable error occurs
+         */
+        public @NonNull DemuxingObjectDecoder decodeObjectNonConsuming(@NonNull Argument<?> type) throws IOException {
+            if (state == null) {
+                state = new DemuxerState(delegate.decodeObject(type));
+                state.outputCount++;
+            }
+            return new DemuxingObjectDecoder(state, false);
         }
 
         @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/ObjectDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/ObjectDeserializer.java
@@ -86,7 +86,7 @@ public class ObjectDeserializer implements CustomizableDeserializer<Object>, Des
                 );
             }
             if (subtypeInfo.discriminatorType() == SerdeConfig.SerSubtyped.DiscriminatorType.PROPERTY) {
-                return new SubtypedPropertyObjectDeserializer(deserBean, subtypeDeserializers, supertypeDeserializer);
+                return new SubtypedPropertyObjectDeserializer(deserBean, subtypeDeserializers, supertypeDeserializer, subtypeInfo.discriminatorVisible());
             }
             throw new IllegalStateException("Unrecognized discriminator type: " + subtypeInfo.discriminatorType());
         }

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SubtypedPropertyObjectDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SubtypedPropertyObjectDeserializer.java
@@ -35,13 +35,16 @@ final class SubtypedPropertyObjectDeserializer implements Deserializer<Object> {
     private final DeserBean<? super Object> deserBean;
     private final Map<String, Deserializer<Object>> deserializers;
     private final Deserializer<Object> supertypeDeserializer;
+    private final boolean discriminatorVisible;
 
     public SubtypedPropertyObjectDeserializer(DeserBean<? super Object> deserBean,
                                               Map<String, Deserializer<Object>> deserializers,
-                                              Deserializer<Object> supertypeDeserializer) {
+                                              Deserializer<Object> supertypeDeserializer,
+                                              boolean discriminatorVisible) {
         this.deserBean = deserBean;
         this.deserializers = deserializers;
         this.supertypeDeserializer = supertypeDeserializer;
+        this.discriminatorVisible = discriminatorVisible;
         if (deserBean.subtypeInfo.discriminatorType() != SerdeConfig.SerSubtyped.DiscriminatorType.PROPERTY) {
             throw new IllegalStateException("Unsupported discriminator type: " + deserBean.subtypeInfo.discriminatorType());
         }
@@ -50,7 +53,7 @@ final class SubtypedPropertyObjectDeserializer implements Deserializer<Object> {
     @Override
     public Object deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super Object> type)
         throws IOException {
-        try (Decoder primed = DemuxingObjectDecoder.prime(decoder)) {
+        try (Decoder primed = DemuxingObjectDecoder.prime(decoder, !discriminatorVisible)) {
             Decoder typeFinder = primed.decodeObject(type);
             Deserializer<Object> deserializer = findDeserializer(typeFinder);
             typeFinder.finishStructure(true);

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SubtypedPropertyObjectDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SubtypedPropertyObjectDeserializer.java
@@ -53,8 +53,13 @@ final class SubtypedPropertyObjectDeserializer implements Deserializer<Object> {
     @Override
     public Object deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super Object> type)
         throws IOException {
-        try (Decoder primed = DemuxingObjectDecoder.prime(decoder, !discriminatorVisible)) {
-            Decoder typeFinder = primed.decodeObject(type);
+        try (DemuxingObjectDecoder.PrimedDecoder primed = DemuxingObjectDecoder.prime(decoder)) {
+            Decoder typeFinder;
+            if (discriminatorVisible) {
+                typeFinder = primed.decodeObjectNonConsuming(type);
+            } else {
+                typeFinder = primed.decodeObject(type);
+            }
             Deserializer<Object> deserializer = findDeserializer(typeFinder);
             typeFinder.finishStructure(true);
 

--- a/serde-support/src/main/java/io/micronaut/serde/support/util/JsonNodeDecoder.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/util/JsonNodeDecoder.java
@@ -270,6 +270,7 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
 
     static final class Buffered extends JsonNodeDecoder {
         private final JsonNode node;
+        private boolean complete = false;
 
         Buffered(JsonNode node, RemainingLimits remainingLimits) {
             super(remainingLimits);
@@ -288,7 +289,10 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
 
         @Override
         public void skipValue() {
-            // No-op: Allow to read multiple times
+            if (complete) {
+                throw new IllegalStateException("Already drained");
+            }
+            complete = true;
         }
 
         @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/util/JsonNodeDecoder.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/util/JsonNodeDecoder.java
@@ -270,7 +270,6 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
 
     static final class Buffered extends JsonNodeDecoder {
         private final JsonNode node;
-        private boolean complete = false;
 
         Buffered(JsonNode node, RemainingLimits remainingLimits) {
             super(remainingLimits);
@@ -289,10 +288,7 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
 
         @Override
         public void skipValue() {
-            if (complete) {
-                throw new IllegalStateException("Already drained");
-            }
-            complete = true;
+            // No-op: Allow to read multiple times
         }
 
         @Override

--- a/serde-support/src/test/groovy/io/micronaut/serde/support/deserializers/DemuxingObjectDecoderSpec.groovy
+++ b/serde-support/src/test/groovy/io/micronaut/serde/support/deserializers/DemuxingObjectDecoderSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.serde.support.deserializers
 
 import io.micronaut.context.ApplicationContext
+import io.micronaut.core.type.Argument
 import io.micronaut.json.JsonMapper
 import io.micronaut.json.tree.JsonNode
 import io.micronaut.serde.Decoder
@@ -15,7 +16,7 @@ class DemuxingObjectDecoderSpec extends Specification {
         def ctx = ApplicationContext.run()
         def outerDecoder = createDecoder(ctx, """{"a": 1, "b": 2, "c": 3}""")
 
-        def primed = DemuxingObjectDecoder.prime(outerDecoder, true)
+        def primed = DemuxingObjectDecoder.prime(outerDecoder)
         def demux1 = primed.decodeObject()
         def demux2 = primed.decodeObject()
 
@@ -42,7 +43,7 @@ class DemuxingObjectDecoderSpec extends Specification {
         def ctx = ApplicationContext.run()
         def outerDecoder = createDecoder(ctx, """{"a": [1], "b": {"foo": "bar"}, "c": {"fizz": "buzz"}}""")
 
-        def primed = DemuxingObjectDecoder.prime(outerDecoder, true)
+        def primed = DemuxingObjectDecoder.prime(outerDecoder)
         def demux1 = primed.decodeObject()
         def demux2 = primed.decodeObject()
 
@@ -77,7 +78,7 @@ class DemuxingObjectDecoderSpec extends Specification {
         def ctx = ApplicationContext.run()
         def outerDecoder = createDecoder(ctx, """{"a": 1, "b": 2, "c": 3}""")
 
-        def primed = DemuxingObjectDecoder.prime(outerDecoder, true)
+        def primed = DemuxingObjectDecoder.prime(outerDecoder)
         def demux1 = primed.decodeObject()
         def demux2 = primed.decodeObject()
 
@@ -87,6 +88,34 @@ class DemuxingObjectDecoderSpec extends Specification {
         demux2.decodeKey() == "b"
         !demux2.decodeNull()
         demux2.decodeInt() == 2
+        demux1.decodeKey() == "c"
+        demux1.decodeInt() == 3
+        demux1.decodeKey() == null
+        demux1.finishStructure()
+        demux2.decodeKey() == null
+        demux2.finishStructure()
+
+        cleanup:
+        ctx.close()
+    }
+
+    def 'interleaved non consuming'() {
+        given:
+        def ctx = ApplicationContext.run()
+        def outerDecoder = createDecoder(ctx, """{"a": 1, "b": 2, "c": 3}""")
+
+        def primed = DemuxingObjectDecoder.prime(outerDecoder)
+        def demux1 = primed.decodeObject()
+        def demux2 = primed.decodeObjectNonConsuming(Argument.OBJECT_ARGUMENT)
+
+        expect:
+        demux1.decodeKey() == "a"
+        demux1.decodeInt() == 1
+        demux2.decodeKey() == "b"
+        !demux2.decodeNull()
+        demux2.decodeInt() == 2
+        demux1.decodeKey() == "b"
+        demux1.decodeInt() == 2
         demux1.decodeKey() == "c"
         demux1.decodeInt() == 3
         demux1.decodeKey() == null

--- a/serde-support/src/test/groovy/io/micronaut/serde/support/deserializers/DemuxingObjectDecoderSpec.groovy
+++ b/serde-support/src/test/groovy/io/micronaut/serde/support/deserializers/DemuxingObjectDecoderSpec.groovy
@@ -15,7 +15,7 @@ class DemuxingObjectDecoderSpec extends Specification {
         def ctx = ApplicationContext.run()
         def outerDecoder = createDecoder(ctx, """{"a": 1, "b": 2, "c": 3}""")
 
-        def primed = DemuxingObjectDecoder.prime(outerDecoder)
+        def primed = DemuxingObjectDecoder.prime(outerDecoder, true)
         def demux1 = primed.decodeObject()
         def demux2 = primed.decodeObject()
 
@@ -42,7 +42,7 @@ class DemuxingObjectDecoderSpec extends Specification {
         def ctx = ApplicationContext.run()
         def outerDecoder = createDecoder(ctx, """{"a": [1], "b": {"foo": "bar"}, "c": {"fizz": "buzz"}}""")
 
-        def primed = DemuxingObjectDecoder.prime(outerDecoder)
+        def primed = DemuxingObjectDecoder.prime(outerDecoder, true)
         def demux1 = primed.decodeObject()
         def demux2 = primed.decodeObject()
 
@@ -77,7 +77,7 @@ class DemuxingObjectDecoderSpec extends Specification {
         def ctx = ApplicationContext.run()
         def outerDecoder = createDecoder(ctx, """{"a": 1, "b": 2, "c": 3}""")
 
-        def primed = DemuxingObjectDecoder.prime(outerDecoder)
+        def primed = DemuxingObjectDecoder.prime(outerDecoder, true)
         def demux1 = primed.decodeObject()
         def demux2 = primed.decodeObject()
 


### PR DESCRIPTION
- which allows for the deserializer to set the type discriminator as an ordinary property