### PR TITLE
Fix requirement to access `ObjectSerializer` and incorrect caching argument `DeserBean`/`SerBean`

### DIFF
--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBeanKey.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBeanKey.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.deserializers;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.type.Argument;
+
+import java.util.Objects;
+
+/**
+ * The {@link DeserBean} caching key.
+ */
+@Internal
+final class DeserBeanKey {
+    private final Argument<?> type;
+    @Nullable
+    private final DeserializationSerdeArgumentConf serdeArgumentConf;
+    private final int hashCode;
+
+    public DeserBeanKey(@NonNull Argument<?> type, @Nullable DeserializationSerdeArgumentConf serdeArgumentConf) {
+        this.type = type;
+        this.serdeArgumentConf = serdeArgumentConf;
+        this.hashCode = type.typeHashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DeserBeanKey that = (DeserBeanKey) o;
+        return type.equalsType(that.type) && Objects.equals(serdeArgumentConf, that.serdeArgumentConf);
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+
+    public @NonNull Argument<?> getType() {
+        return type;
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserializationSerdeArgumentConf.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserializationSerdeArgumentConf.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 original authors
+ * Copyright 2017-2023 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,13 +15,18 @@
  */
 package io.micronaut.serde.support.deserializers;
 
-import io.micronaut.core.annotation.Internal;
-import io.micronaut.core.type.Argument;
-import io.micronaut.serde.Deserializer;
-import io.micronaut.serde.exceptions.SerdeException;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.serde.support.util.SerdeArgumentConf;
 
-@Internal
-interface DeserBeanRegistry {
-    <T> DeserBean<T> getDeserializableBean(Argument<T> type, Deserializer.DecoderContext decoderContext) throws SerdeException;
+/**
+ * Extra deserialization configuration placed at the argument.
+ *
+ * @author Denis Stepanov
+ * @since 2.3.2
+ */
+public final class DeserializationSerdeArgumentConf extends SerdeArgumentConf {
 
+    public DeserializationSerdeArgumentConf(AnnotationMetadata annotationMetadata) {
+        super(annotationMetadata);
+    }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SpecificObjectDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SpecificObjectDeserializer.java
@@ -859,7 +859,7 @@ final class SpecificObjectDeserializer implements Deserializer<Object>, Updating
 
         @Nullable
         private final DeserBean<? super Object> db;
-        private final DeserBean.SubtypeInfo<? super Object> subtypeInfo;
+        private final SubtypeInfo<? super Object> subtypeInfo;
         private final Conf conf;
         private final Argument<? super Object> argument;
 
@@ -957,7 +957,7 @@ final class SpecificObjectDeserializer implements Deserializer<Object>, Updating
 
         @Nullable
         private final DeserBean<? super Object> db;
-        private final DeserBean.SubtypeInfo<? super Object> subtypeInfo;
+        private final SubtypeInfo<? super Object> subtypeInfo;
         private final Argument<? super Object> argument;
         private final Conf conf;
 

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SubtypeInfo.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SubtypeInfo.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.deserializers;
+
+import io.micronaut.context.annotation.DefaultImplementation;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.config.annotation.SerdeConfig;
+import io.micronaut.serde.exceptions.SerdeException;
+
+import java.util.Collection;
+import java.util.Map;
+
+import static io.micronaut.serde.config.annotation.SerdeConfig.SerSubtyped.DiscriminatorValueKind.CLASS_NAME;
+
+/**
+ * The subtype info.
+ *
+ * @param subtypes             The subtypes
+ * @param discriminatorType    The discriminator type
+ * @param discriminatorName    The discriminator name
+ * @param defaultImpl          The default impl
+ * @param discriminatorVisible The discriminator visible
+ * @param <T>                  The bean type
+ * @author Denis Stepanov
+ */
+@Internal
+record SubtypeInfo<T>(
+    @NonNull
+    Map<String, DeserBean<? extends T>> subtypes,
+    @NonNull
+    SerdeConfig.SerSubtyped.DiscriminatorType discriminatorType,
+    @NonNull
+    String discriminatorName,
+    @Nullable
+    String defaultImpl,
+    boolean discriminatorVisible
+) {
+
+    static <T> SubtypeInfo<T> create(AnnotationMetadata annotationMetadata,
+                                     BeanIntrospection<T> introspection,
+                                     Deserializer.DecoderContext decoderContext,
+                                     DeserBeanRegistry deserBeanRegistry) throws SerdeException {
+
+        if (!annotationMetadata.hasAnnotation(SerdeConfig.SerSubtyped.class)) {
+            return null;
+        }
+
+        SerdeConfig.SerSubtyped.DiscriminatorType discriminatorType = annotationMetadata.enumValue(
+            SerdeConfig.SerSubtyped.class,
+            SerdeConfig.SerSubtyped.DISCRIMINATOR_TYPE,
+            SerdeConfig.SerSubtyped.DiscriminatorType.class
+        ).orElse(SerdeConfig.SerSubtyped.DiscriminatorType.PROPERTY);
+        SerdeConfig.SerSubtyped.DiscriminatorValueKind discriminatorValue = annotationMetadata.enumValue(
+            SerdeConfig.SerSubtyped.class,
+            SerdeConfig.SerSubtyped.DISCRIMINATOR_VALUE,
+            SerdeConfig.SerSubtyped.DiscriminatorValueKind.class
+        ).orElse(CLASS_NAME);
+        String discriminatorName = annotationMetadata.stringValue(
+            SerdeConfig.SerSubtyped.class,
+            SerdeConfig.SerSubtyped.DISCRIMINATOR_PROP
+        ).orElse(discriminatorValue == CLASS_NAME ? "@class" : "@type");
+
+        final Class<T> superType = introspection.getBeanType();
+        final Collection<BeanIntrospection<? extends T>> subtypeIntrospections =
+            decoderContext.getDeserializableSubtypes(superType);
+        Map<String, DeserBean<? extends T>> subtypes = CollectionUtils.newHashMap(subtypeIntrospections.size());
+        Class<?> defaultType = annotationMetadata.classValue(DefaultImplementation.class).orElse(null);
+        String defaultDiscriminator = null;
+        for (BeanIntrospection<? extends T> subtypeIntrospection : subtypeIntrospections) {
+            Class<? extends T> subBeanType = subtypeIntrospection.getBeanType();
+            final DeserBean<? extends T> deserBean = deserBeanRegistry.getDeserializableBean(
+                Argument.of(subBeanType),
+                decoderContext
+            );
+            if (defaultType != null && defaultType.equals(subBeanType)) {
+                defaultDiscriminator = subtypeIntrospection.stringValue(SerdeConfig.class, SerdeConfig.TYPE_NAME).orElseThrow();
+            }
+
+            subtypeIntrospection.stringValue(SerdeConfig.class, SerdeConfig.TYPE_NAME).ifPresent(name -> subtypes.put(name, deserBean));
+            String[] names = subtypeIntrospection.stringValues(SerdeConfig.class, SerdeConfig.TYPE_NAMES);
+            for (String name : names) {
+                subtypes.put(name, deserBean);
+            }
+        }
+
+        return new SubtypeInfo<>(
+            subtypes,
+            discriminatorType,
+            discriminatorName,
+            defaultDiscriminator,
+            annotationMetadata.booleanValue(SerdeConfig.SerSubtyped.class, SerdeConfig.SerSubtyped.DISCRIMINATOR_VISIBLE).orElse(false)
+        );
+    }
+
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/RuntimeTypeSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/RuntimeTypeSerializer.java
@@ -100,7 +100,6 @@ final class RuntimeTypeSerializer implements ObjectSerializer<Object> {
         return new SerdeException("Serializer for type: " + type + " doesn't support serializing into an existing object");
     }
 
-
     @Override
     public boolean isEmpty(EncoderContext context, Object value) {
         if (value == null) {

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBeanKey.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBeanKey.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serializers;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.support.util.SerdeArgumentConf;
+
+import java.util.Objects;
+
+/**
+ * The {@link SerBean} caching key.
+ */
+@Internal
+final class SerBeanKey {
+    private final Argument<?> type;
+    @Nullable
+    private final SerdeArgumentConf serdeArgumentConf;
+    private final int hashCode;
+
+    public SerBeanKey(@NonNull Argument<?> type, @Nullable SerdeArgumentConf serdeArgumentConf) {
+        this.type = type;
+        this.serdeArgumentConf = serdeArgumentConf;
+        this.hashCode = type.typeHashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SerBeanKey that = (SerBeanKey) o;
+        return type.equalsType(that.type) && Objects.equals(serdeArgumentConf, that.serdeArgumentConf);
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+
+    public @NonNull Argument<?> getType() {
+        return type;
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/util/SerdeArgumentConf.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/util/SerdeArgumentConf.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.util;
+
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.CollectionUtils;
+import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
+import io.micronaut.inject.annotation.MutableAnnotationMetadata;
+import io.micronaut.serde.config.annotation.SerdeConfig;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * Extra configuration placed at the argument.
+ *
+ * @author Denis Stepanov
+ * @since 2.3.2
+ */
+@Internal
+public class SerdeArgumentConf {
+
+    @Nullable
+    private final String prefix;
+    @Nullable
+    private final String suffix;
+    @Nullable
+    private final String[] ignored;
+    @Nullable
+    private final String[] included;
+    @Nullable
+    private final String[] order;
+
+    public SerdeArgumentConf(AnnotationMetadata annotationMetadata) {
+        prefix = annotationMetadata.stringValue(SerdeConfig.SerUnwrapped.class, SerdeConfig.SerUnwrapped.PREFIX).orElse(null);
+        suffix = annotationMetadata.stringValue(SerdeConfig.SerUnwrapped.class, SerdeConfig.SerUnwrapped.SUFFIX).orElse(null);
+        String[] ignored = null;
+        String[] included = null;
+        String[] order = null;
+        if (annotationMetadata.isAnnotationPresent(SerdeConfig.SerIgnored.class)) {
+            ignored = annotationMetadata.stringValues(SerdeConfig.SerIgnored.class);
+            if (ignored.length == 0) {
+                ignored = null;
+            }
+        }
+        this.ignored = ignored;
+        if (annotationMetadata.isAnnotationPresent(SerdeConfig.SerIncluded.class)) {
+            included = annotationMetadata.stringValues(SerdeConfig.SerIncluded.class);
+            if (included.length == 0) {
+                included = null;
+            }
+        }
+        this.included = included;
+        if (annotationMetadata.isAnnotationPresent(SerdeConfig.META_ANNOTATION_PROPERTY_ORDER)) {
+            order = annotationMetadata.stringValues(SerdeConfig.META_ANNOTATION_PROPERTY_ORDER);
+            if (order.length == 0) {
+                order = null;
+            }
+        }
+        this.order = order;
+    }
+
+    /**
+     * Apply prefix/suffix.
+     *
+     * @param name The name
+     * @return The name with applied prefix/suffix
+     */
+    public String applyPrefixSuffix(String name) {
+        if (prefix != null) {
+            name = prefix + name;
+        }
+        if (suffix != null) {
+            name = name + suffix;
+        }
+        return name;
+    }
+
+    /**
+     * Extend existing argument annotation metadata to include a new prefix/suffix.
+     *
+     * @param argument           The argument
+     * @param <Z>                The argument type
+     * @return The new argument or the previous one if not changes
+     */
+    public <Z> Argument<Z> extendArgumentWithPrefixSuffix(Argument<Z> argument) {
+        AnnotationMetadata annotationMetadata = argument.getAnnotationMetadata();
+        if (annotationMetadata.isEmpty()) {
+            return argument;
+        }
+        String extraPrefix = annotationMetadata.stringValue(SerdeConfig.SerUnwrapped.class, SerdeConfig.SerUnwrapped.PREFIX).orElse(null);
+        String extraSuffix = annotationMetadata.stringValue(SerdeConfig.SerUnwrapped.class, SerdeConfig.SerUnwrapped.SUFFIX).orElse(null);
+        if (prefix == null && suffix == null) {
+            return argument;
+        }
+        if (prefix != null) {
+            extraPrefix = extraPrefix == null ? prefix : prefix + extraPrefix;
+        }
+        if (suffix != null) {
+            extraSuffix = extraSuffix == null ? suffix : extraSuffix + suffix;
+        }
+        MutableAnnotationMetadata mutableAnnotationMetadata = new MutableAnnotationMetadata();
+        Map<CharSequence, Object> newValues = new LinkedHashMap<>();
+        if (extraPrefix != null) {
+            newValues.put(SerdeConfig.SerUnwrapped.PREFIX, extraPrefix);
+        }
+        if (extraSuffix != null) {
+            newValues.put(SerdeConfig.SerUnwrapped.SUFFIX, extraSuffix);
+        }
+        mutableAnnotationMetadata.addDeclaredAnnotation(SerdeConfig.SerUnwrapped.class.getName(), newValues);
+        return Argument.of(
+            argument.getType(),
+            argument.getName(),
+            new AnnotationMetadataHierarchy(
+                argument.getAnnotationMetadata(),
+                mutableAnnotationMetadata
+            ),
+            argument.getTypeParameters());
+    }
+
+    /**
+     * @param allowIgnoredProperties Should allow ignored properties
+     * @return The predicate or null to include all
+     */
+    @Nullable
+    public Predicate<String> resolveAllowPropertyPredicate(boolean allowIgnoredProperties) {
+        Set<String> ignoreSet = ignored != null && !allowIgnoredProperties ? CollectionUtils.setOf(ignored) : null;
+        Set<String> includedSet = included != null ? CollectionUtils.setOf(included) : null;
+        if (ignoreSet != null || includedSet != null) {
+            return propertyName -> {
+                if (ignoreSet != null && ignoreSet.contains(propertyName)) {
+                    return false;
+                }
+                if (includedSet != null && !includedSet.contains(propertyName)) {
+                    return false;
+                }
+                return true;
+            };
+        }
+        return null;
+    }
+
+    // Include equals for better performance
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SerdeArgumentConf that = (SerdeArgumentConf) o;
+        return Objects.equals(prefix, that.prefix)
+            && Objects.equals(suffix, that.suffix)
+            && Arrays.equals(ignored, that.ignored)
+            && Arrays.equals(included, that.included)
+            && Arrays.equals(order, that.order);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(prefix, suffix);
+        result = 31 * result + Arrays.hashCode(ignored);
+        result = 31 * result + Arrays.hashCode(included);
+        result = 31 * result + Arrays.hashCode(order);
+        return result;
+    }
+
+    /**
+     * @return The order
+     */
+    @Nullable
+    public String[] order() {
+        return order;
+    }
+
+    /**
+     * @return The ignored properties
+     */
+    @Nullable
+    public String[] getIgnored() {
+        return ignored;
+    }
+
+    /**
+     * @return The included properties
+     */
+    @Nullable
+    public String[] getIncluded() {
+        return included;
+    }
+}


### PR DESCRIPTION
Now, the leveled prefix/suffix are passed by extending the argument metadata. 

While fixing it, I discovered our key for maps of `DeserBean`/`SerBean` doesn't include annotations, and that can lead to one argument configuration being used for another one.