### PR TITLE
Problem with `Must access entries in sequence`

### DIFF
--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/JsonTypeInfoSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/JsonTypeInfoSpec.groovy
@@ -1,11 +1,20 @@
 package io.micronaut.serde.jackson.annotation
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import io.micronaut.context.ApplicationContextBuilder
 import io.micronaut.core.type.Argument
 import io.micronaut.serde.jackson.JsonCompileSpec
 import spock.lang.Unroll
 
 class JsonTypeInfoSpec extends JsonCompileSpec {
+
+    @Override
+    protected void configureContext(ApplicationContextBuilder contextBuilder) {
+        super.configureContext(contextBuilder.properties(
+                Map.of("micronaut.serde.deserialization.ignore-unknown", "false")
+        ))
+    }
+
     void "test default implementation - with @DefaultImplementation"() {
         given:
         def context = buildContext("""


### PR DESCRIPTION
@yawkat Can you please take a look at this case? I think we should allow multiple called to `decodeKey` after it returns null.