### PR TITLE
Apply micronaut.serde.time-zone for ISO-8601 DateTimeFromatter in DefaultFormattedTemporalSerde

### DIFF
--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/DefaultFormattedTemporalSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/DefaultFormattedTemporalSerde.java
@@ -46,7 +46,7 @@ public abstract class DefaultFormattedTemporalSerde<T extends TemporalAccessor> 
         @NonNull SerdeConfiguration configuration,
         @NonNull DateTimeFormatter defaultStringFormatter
     ) {
-        stringFormatter = createFormatter(configuration).orElse(defaultStringFormatter);
+        stringFormatter = createFormatter(configuration, defaultStringFormatter);
     }
 
     @Override
@@ -86,14 +86,15 @@ public abstract class DefaultFormattedTemporalSerde<T extends TemporalAccessor> 
     }
 
     @NonNull
-    private static Optional<DateTimeFormatter> createFormatter(@NonNull SerdeConfiguration configuration) {
+    private static DateTimeFormatter createFormatter(@NonNull SerdeConfiguration configuration, @NonNull DateTimeFormatter defaultStringFormatter) {
         // Creates a pattern-based formatter if there is a date format configured
-        return configuration.getDateFormat()
+        final DateTimeFormatter formatter = configuration.getDateFormat()
             .map(pattern -> configuration.getLocale()
                 .map(locale -> DateTimeFormatter.ofPattern(pattern, locale))
-                    .orElseGet(() -> DateTimeFormatter.ofPattern(pattern)))
-            .map(formatter -> configuration.getTimeZone()
-                    .map(tz -> formatter.withZone(tz.toZoneId()))
-                    .orElse(formatter));
+                .orElseGet(() -> DateTimeFormatter.ofPattern(pattern)))
+            .orElse(defaultStringFormatter);
+        return configuration.getTimeZone()
+            .map(tz -> formatter.withZone(tz.toZoneId()))
+            .orElse(formatter);
     }
 }

--- a/serde-support/src/test/groovy/io/micronaut/serde/support/serdes/OffsetDateTimeSerdeSpec.groovy
+++ b/serde-support/src/test/groovy/io/micronaut/serde/support/serdes/OffsetDateTimeSerdeSpec.groovy
@@ -67,6 +67,25 @@ class OffsetDateTimeSerdeSpec extends Specification {
         ctx.close()
     }
 
+    @Unroll
+    void "deserialization should apply timezone config for serializing"() {
+        given:
+        def ctx = ApplicationContext.run([
+                'micronaut.serde.time-zone': 'UTC',
+        ])
+        OffsetDateTimePojo pojo = new OffsetDateTimePojo()
+        pojo.timeCreated = OffsetDateTime.parse('2022-01-01T14:30:00.123+02:00')
+
+        when:
+        String json = ctx.getBean(ObjectMapper).writeValueAsString(pojo)
+
+        then:
+        '{"timeCreated":"2022-01-01T12:30:00.123Z"}' == json
+
+        cleanup:
+        ctx.close()
+    }
+
     @Serdeable.Deserializable
     static class OffsetDateTimePojo {
         private OffsetDateTime timeCreated;


### PR DESCRIPTION
Hi everyone, this is my PR to any open-source project ever.
I believe this change more like QoL.
Problem:
`micronaut.serde.time-zone` configuration only applies to custom configured `DateTimeFormatter` which can be created only with: `micronaut.serde.date-format`.