### PR TITLE
Add ObjectMapper.cloneWithConfiguration

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/Deserializer.java
+++ b/serde-api/src/main/java/io/micronaut/serde/Deserializer.java
@@ -148,14 +148,18 @@ public interface Deserializer<T> {
          * Get the {@link SerdeConfiguration} for this context.
          *
          * @return The {@link SerdeConfiguration}
+         * @since 2.6.0
          */
+        @NonNull
         SerdeConfiguration getSerdeConfiguration();
 
         /**
          * Get the {@link DeserializationConfiguration} for this context.
          *
          * @return The {@link DeserializationConfiguration}
+         * @since 2.6.0
          */
+        @NonNull
         DeserializationConfiguration getDeserializationConfiguration();
     }
 }

--- a/serde-api/src/main/java/io/micronaut/serde/Deserializer.java
+++ b/serde-api/src/main/java/io/micronaut/serde/Deserializer.java
@@ -149,7 +149,7 @@ public interface Deserializer<T> {
          * Get the {@link SerdeConfiguration} for this context.
          *
          * @return The {@link SerdeConfiguration}, or an empty optional if the default should be used
-         * @since 2.6.0
+         * @since 2.7.0
          */
         @NonNull
         default Optional<SerdeConfiguration> getSerdeConfiguration() {

--- a/serde-api/src/main/java/io/micronaut/serde/Deserializer.java
+++ b/serde-api/src/main/java/io/micronaut/serde/Deserializer.java
@@ -160,7 +160,7 @@ public interface Deserializer<T> {
          * Get the {@link DeserializationConfiguration} for this context.
          *
          * @return The {@link DeserializationConfiguration}, or an empty optional if the default should be used
-         * @since 2.6.0
+         * @since 2.7.0
          */
         @NonNull
         default Optional<DeserializationConfiguration> getDeserializationConfiguration() {

--- a/serde-api/src/main/java/io/micronaut/serde/Deserializer.java
+++ b/serde-api/src/main/java/io/micronaut/serde/Deserializer.java
@@ -28,6 +28,7 @@ import io.micronaut.serde.reference.PropertyReference;
 import io.micronaut.serde.reference.PropertyReferenceManager;
 
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * Interface that represents a deserializer.
@@ -147,19 +148,23 @@ public interface Deserializer<T> {
         /**
          * Get the {@link SerdeConfiguration} for this context.
          *
-         * @return The {@link SerdeConfiguration}
+         * @return The {@link SerdeConfiguration}, or an empty optional if the default should be used
          * @since 2.6.0
          */
         @NonNull
-        SerdeConfiguration getSerdeConfiguration();
+        default Optional<SerdeConfiguration> getSerdeConfiguration() {
+            return Optional.empty();
+        }
 
         /**
          * Get the {@link DeserializationConfiguration} for this context.
          *
-         * @return The {@link DeserializationConfiguration}
+         * @return The {@link DeserializationConfiguration}, or an empty optional if the default should be used
          * @since 2.6.0
          */
         @NonNull
-        DeserializationConfiguration getDeserializationConfiguration();
+        default Optional<DeserializationConfiguration> getDeserializationConfiguration() {
+            return Optional.empty();
+        }
     }
 }

--- a/serde-api/src/main/java/io/micronaut/serde/Deserializer.java
+++ b/serde-api/src/main/java/io/micronaut/serde/Deserializer.java
@@ -21,6 +21,8 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.type.Argument;
+import io.micronaut.serde.config.DeserializationConfiguration;
+import io.micronaut.serde.config.SerdeConfiguration;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.reference.PropertyReference;
 import io.micronaut.serde.reference.PropertyReferenceManager;
@@ -141,5 +143,19 @@ public interface Deserializer<T> {
         <B, P> PropertyReference<B, P> resolveReference(
                 @NonNull PropertyReference<B, P> reference
         );
+
+        /**
+         * Get the {@link SerdeConfiguration} for this context.
+         *
+         * @return The {@link SerdeConfiguration}
+         */
+        SerdeConfiguration getSerdeConfiguration();
+
+        /**
+         * Get the {@link DeserializationConfiguration} for this context.
+         *
+         * @return The {@link DeserializationConfiguration}
+         */
+        DeserializationConfiguration getDeserializationConfiguration();
     }
 }

--- a/serde-api/src/main/java/io/micronaut/serde/ObjectMapper.java
+++ b/serde-api/src/main/java/io/micronaut/serde/ObjectMapper.java
@@ -56,7 +56,7 @@ public interface ObjectMapper extends JsonMapper {
      * @param serializationConfiguration The {@link SerializationConfiguration}
      * @param deserializationConfiguration The {@link DeserializationConfiguration}
      * @return A new {@link JsonMapper} with the updated config
-     * @since 2.6.0
+     * @since 2.7.0
      */
     @NonNull
     default ObjectMapper cloneWithConfiguration(

--- a/serde-api/src/main/java/io/micronaut/serde/ObjectMapper.java
+++ b/serde-api/src/main/java/io/micronaut/serde/ObjectMapper.java
@@ -16,8 +16,12 @@
 package io.micronaut.serde;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.json.JsonFeatures;
 import io.micronaut.json.JsonMapper;
+import io.micronaut.serde.config.DeserializationConfiguration;
+import io.micronaut.serde.config.SerdeConfiguration;
+import io.micronaut.serde.config.SerializationConfiguration;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -41,6 +45,23 @@ public interface ObjectMapper extends JsonMapper {
 
     @Override
     default JsonMapper cloneWithFeatures(JsonFeatures features) {
+        return this;
+    }
+
+    /**
+     * Optional feature. Create a new {@link ObjectMapper} with the given configuration values. A
+     * {@code null} parameter indicates the old configuration should be used.
+     *
+     * @param configuration The {@link SerdeConfiguration}
+     * @param serializationConfiguration The {@link SerializationConfiguration}
+     * @param deserializationConfiguration The {@link DeserializationConfiguration}
+     * @return A new {@link JsonMapper} with the updated config
+     */
+    default ObjectMapper cloneWithConfiguration(
+        @Nullable SerdeConfiguration configuration,
+        @Nullable SerializationConfiguration serializationConfiguration,
+        @Nullable DeserializationConfiguration deserializationConfiguration
+    ) {
         return this;
     }
 

--- a/serde-api/src/main/java/io/micronaut/serde/ObjectMapper.java
+++ b/serde-api/src/main/java/io/micronaut/serde/ObjectMapper.java
@@ -56,7 +56,9 @@ public interface ObjectMapper extends JsonMapper {
      * @param serializationConfiguration The {@link SerializationConfiguration}
      * @param deserializationConfiguration The {@link DeserializationConfiguration}
      * @return A new {@link JsonMapper} with the updated config
+     * @since 2.6.0
      */
+    @NonNull
     default ObjectMapper cloneWithConfiguration(
         @Nullable SerdeConfiguration configuration,
         @Nullable SerializationConfiguration serializationConfiguration,

--- a/serde-api/src/main/java/io/micronaut/serde/SerdeRegistry.java
+++ b/serde-api/src/main/java/io/micronaut/serde/SerdeRegistry.java
@@ -18,6 +18,9 @@ package io.micronaut.serde;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.ConversionServiceProvider;
+import io.micronaut.serde.config.DeserializationConfiguration;
+import io.micronaut.serde.config.SerdeConfiguration;
+import io.micronaut.serde.config.SerializationConfiguration;
 
 /**
  * Represents a registry where specific serializers can be looked up.
@@ -27,6 +30,23 @@ import io.micronaut.core.convert.ConversionServiceProvider;
  *
  */
 public interface SerdeRegistry extends SerializerLocator, DeserializerLocator, NamingStrategyLocator, ConversionServiceProvider {
+
+    /**
+     * Optional feature. Create a new {@link SerdeRegistry} with the given configuration values. A
+     * {@code null} parameter indicates the old configuration should be used.
+     *
+     * @param configuration The {@link SerdeConfiguration}
+     * @param serializationConfiguration The {@link SerializationConfiguration}
+     * @param deserializationConfiguration The {@link DeserializationConfiguration}
+     * @return A new {@link SerdeRegistry} with the updated config
+     */
+    default SerdeRegistry cloneWithConfiguration(
+        @Nullable SerdeConfiguration configuration,
+        @Nullable SerializationConfiguration serializationConfiguration,
+        @Nullable DeserializationConfiguration deserializationConfiguration
+    ) {
+        return this;
+    }
 
     /**
      * Creates a new encoder context.

--- a/serde-api/src/main/java/io/micronaut/serde/SerdeRegistry.java
+++ b/serde-api/src/main/java/io/micronaut/serde/SerdeRegistry.java
@@ -39,7 +39,7 @@ public interface SerdeRegistry extends SerializerLocator, DeserializerLocator, N
      * @param serializationConfiguration The {@link SerializationConfiguration}
      * @param deserializationConfiguration The {@link DeserializationConfiguration}
      * @return A new {@link SerdeRegistry} with the updated config
-     * @since 2.6.0
+     * @since 2.7.0
      */
     @NonNull
     default SerdeRegistry cloneWithConfiguration(

--- a/serde-api/src/main/java/io/micronaut/serde/SerdeRegistry.java
+++ b/serde-api/src/main/java/io/micronaut/serde/SerdeRegistry.java
@@ -39,7 +39,9 @@ public interface SerdeRegistry extends SerializerLocator, DeserializerLocator, N
      * @param serializationConfiguration The {@link SerializationConfiguration}
      * @param deserializationConfiguration The {@link DeserializationConfiguration}
      * @return A new {@link SerdeRegistry} with the updated config
+     * @since 2.6.0
      */
+    @NonNull
     default SerdeRegistry cloneWithConfiguration(
         @Nullable SerdeConfiguration configuration,
         @Nullable SerializationConfiguration serializationConfiguration,

--- a/serde-api/src/main/java/io/micronaut/serde/Serializer.java
+++ b/serde-api/src/main/java/io/micronaut/serde/Serializer.java
@@ -139,7 +139,7 @@ public interface Serializer<T> {
          * Get the {@link SerializationConfiguration} for this context.
          *
          * @return The {@link SerializationConfiguration}, or an empty optional if the default should be used
-         * @since 2.6.0
+         * @since 2.7.0
          */
         @NonNull
         default Optional<SerializationConfiguration> getSerializationConfiguration() {

--- a/serde-api/src/main/java/io/micronaut/serde/Serializer.java
+++ b/serde-api/src/main/java/io/micronaut/serde/Serializer.java
@@ -15,17 +15,19 @@
  */
 package io.micronaut.serde;
 
-import java.io.IOException;
-
 import io.micronaut.core.annotation.Indexed;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.type.Argument;
+import io.micronaut.serde.config.SerdeConfiguration;
+import io.micronaut.serde.config.SerializationConfiguration;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.reference.PropertyReferenceManager;
 import io.micronaut.serde.reference.SerializationReference;
+
+import java.io.IOException;
 
 /**
  * Models a build time serializer. That is a class computed at build-time that can
@@ -120,5 +122,19 @@ public interface Serializer<T> {
         <B, P> SerializationReference<B, P> resolveReference(
                 @NonNull SerializationReference<B, P> reference
         );
+
+        /**
+         * Get the {@link SerdeConfiguration} for this context.
+         *
+         * @return The {@link SerdeConfiguration}
+         */
+        SerdeConfiguration getSerdeConfiguration();
+
+        /**
+         * Get the {@link SerializationConfiguration} for this context.
+         *
+         * @return The {@link SerializationConfiguration}
+         */
+        SerializationConfiguration getSerializationConfiguration();
     }
 }

--- a/serde-api/src/main/java/io/micronaut/serde/Serializer.java
+++ b/serde-api/src/main/java/io/micronaut/serde/Serializer.java
@@ -127,14 +127,18 @@ public interface Serializer<T> {
          * Get the {@link SerdeConfiguration} for this context.
          *
          * @return The {@link SerdeConfiguration}
+         * @since 2.6.0
          */
+        @NonNull
         SerdeConfiguration getSerdeConfiguration();
 
         /**
          * Get the {@link SerializationConfiguration} for this context.
          *
          * @return The {@link SerializationConfiguration}
+         * @since 2.6.0
          */
+        @NonNull
         SerializationConfiguration getSerializationConfiguration();
     }
 }

--- a/serde-api/src/main/java/io/micronaut/serde/Serializer.java
+++ b/serde-api/src/main/java/io/micronaut/serde/Serializer.java
@@ -128,7 +128,7 @@ public interface Serializer<T> {
          * Get the {@link SerdeConfiguration} for this context.
          *
          * @return The {@link SerdeConfiguration}, or an empty optional if the default should be used
-         * @since 2.6.0
+         * @since 2.7.0
          */
         @NonNull
         default Optional<SerdeConfiguration> getSerdeConfiguration() {

--- a/serde-api/src/main/java/io/micronaut/serde/Serializer.java
+++ b/serde-api/src/main/java/io/micronaut/serde/Serializer.java
@@ -28,6 +28,7 @@ import io.micronaut.serde.reference.PropertyReferenceManager;
 import io.micronaut.serde.reference.SerializationReference;
 
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * Models a build time serializer. That is a class computed at build-time that can
@@ -126,19 +127,23 @@ public interface Serializer<T> {
         /**
          * Get the {@link SerdeConfiguration} for this context.
          *
-         * @return The {@link SerdeConfiguration}
+         * @return The {@link SerdeConfiguration}, or an empty optional if the default should be used
          * @since 2.6.0
          */
         @NonNull
-        SerdeConfiguration getSerdeConfiguration();
+        default Optional<SerdeConfiguration> getSerdeConfiguration() {
+            return Optional.empty();
+        }
 
         /**
          * Get the {@link SerializationConfiguration} for this context.
          *
-         * @return The {@link SerializationConfiguration}
+         * @return The {@link SerializationConfiguration}, or an empty optional if the default should be used
          * @since 2.6.0
          */
         @NonNull
-        SerializationConfiguration getSerializationConfiguration();
+        default Optional<SerializationConfiguration> getSerializationConfiguration() {
+            return Optional.empty();
+        }
     }
 }

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/ConfigCloneSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/ConfigCloneSpec.groovy
@@ -1,0 +1,52 @@
+package io.micronaut.serde.jackson
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Bean
+import io.micronaut.context.annotation.ConfigurationProperties
+import io.micronaut.core.bind.annotation.Bindable
+import io.micronaut.serde.ObjectMapper
+import io.micronaut.serde.annotation.Serdeable
+import io.micronaut.serde.config.SerdeConfiguration
+import io.micronaut.serde.config.SerializationConfiguration
+import io.micronaut.serde.config.annotation.SerdeConfig
+import spock.lang.Specification
+
+class ConfigCloneSpec extends Specification {
+    def 'clone'() {
+        given:
+        def ctx = ApplicationContext.run()
+        def original = ctx.getBean(ObjectMapper)
+        def modified = original.cloneWithConfiguration(ctx.getBean(OciSerdeConfiguration), ctx.getBean(OciSerializationConfiguration), null)
+        def testBean = new TestBean(empty: [], bytes: new byte[] {1, 2})
+
+        expect:
+        original.writeValueAsString(testBean) == '{"bytes":[1,2]}'
+        modified.writeValueAsString(testBean) == '{"empty":[],"bytes":"AQI="}'
+        original.writeValueAsString(testBean) == '{"bytes":[1,2]}' // double-check the old one wasn't broken
+
+        cleanup:
+        ctx.close()
+    }
+
+    @Serdeable
+    static class TestBean {
+        List<String> empty
+        byte[] bytes
+    }
+
+    @ConfigurationProperties("oci.serde")
+    @Bean(typed = OciSerdeConfiguration.class)
+    static interface OciSerdeConfiguration extends SerdeConfiguration {
+        @Override
+        @Bindable(defaultValue = "false")
+        boolean isWriteBinaryAsArray();
+    }
+
+    @ConfigurationProperties("oci.serde.serialization")
+    @Bean(typed = OciSerializationConfiguration.class)
+    static interface OciSerializationConfiguration extends SerializationConfiguration {
+        @Bindable(defaultValue = "NON_NULL")
+        @Override
+        SerdeConfig.SerInclude getInclusion();
+    }
+}

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/ConfigCloneSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/ConfigCloneSpec.groovy
@@ -6,9 +6,11 @@ import io.micronaut.context.annotation.ConfigurationProperties
 import io.micronaut.core.bind.annotation.Bindable
 import io.micronaut.serde.ObjectMapper
 import io.micronaut.serde.annotation.Serdeable
+import io.micronaut.serde.config.DeserializationConfiguration
 import io.micronaut.serde.config.SerdeConfiguration
 import io.micronaut.serde.config.SerializationConfiguration
 import io.micronaut.serde.config.annotation.SerdeConfig
+import io.micronaut.serde.exceptions.SerdeException
 import spock.lang.Specification
 
 class ConfigCloneSpec extends Specification {
@@ -16,13 +18,30 @@ class ConfigCloneSpec extends Specification {
         given:
         def ctx = ApplicationContext.run()
         def original = ctx.getBean(ObjectMapper)
-        def modified = original.cloneWithConfiguration(ctx.getBean(OciSerdeConfiguration), ctx.getBean(OciSerializationConfiguration), null)
+        def modified = original.cloneWithConfiguration(ctx.getBean(OciSerdeConfiguration), ctx.getBean(OciSerializationConfiguration), ctx.getBean(OciDeserializationConfiguration))
         def testBean = new TestBean(empty: [], bytes: new byte[] {1, 2})
 
         expect:
         original.writeValueAsString(testBean) == '{"bytes":[1,2]}'
         modified.writeValueAsString(testBean) == '{"empty":[],"bytes":"AQI="}'
         original.writeValueAsString(testBean) == '{"bytes":[1,2]}' // double-check the old one wasn't broken
+
+        original.writeValueAsString(testBean) == '{"bytes":[1,2]}'
+        modified.writeValueAsString(testBean) == '{"empty":[],"bytes":"AQI="}'
+        original.writeValueAsString(testBean) == '{"bytes":[1,2]}' // double-check the old one wasn't broken
+
+        when:
+        original.readValue('{"missing":"foo"}', TestBean)
+        then:
+        noExceptionThrown()
+        when:
+        modified.readValue('{"missing":"foo"}', TestBean)
+        then:
+        thrown SerdeException
+        when:
+        original.readValue('{"missing":"foo"}', TestBean)
+        then:
+        noExceptionThrown()
 
         cleanup:
         ctx.close()
@@ -48,5 +67,14 @@ class ConfigCloneSpec extends Specification {
         @Bindable(defaultValue = "NON_NULL")
         @Override
         SerdeConfig.SerInclude getInclusion();
+    }
+
+    // micronaut-oraclecloud doesn't do this but we need some deser test
+    @ConfigurationProperties("oci.serde.deserialization")
+    @Bean(typed = OciDeserializationConfiguration.class)
+    static interface OciDeserializationConfiguration extends DeserializationConfiguration {
+        @Bindable(defaultValue = "false")
+        @Override
+        boolean isIgnoreUnknown()
     }
 }

--- a/serde-jsonp/src/main/java/io/micronaut/serde/json/stream/JsonStreamMapper.java
+++ b/serde-jsonp/src/main/java/io/micronaut/serde/json/stream/JsonStreamMapper.java
@@ -29,7 +29,9 @@ import io.micronaut.serde.LimitingStream;
 import io.micronaut.serde.ObjectMapper;
 import io.micronaut.serde.SerdeRegistry;
 import io.micronaut.serde.Serializer;
+import io.micronaut.serde.config.DeserializationConfiguration;
 import io.micronaut.serde.config.SerdeConfiguration;
+import io.micronaut.serde.config.SerializationConfiguration;
 import io.micronaut.serde.support.util.BufferingJsonNodeProcessor;
 import io.micronaut.serde.support.util.JsonNodeDecoder;
 import io.micronaut.serde.support.util.JsonNodeEncoder;
@@ -79,6 +81,11 @@ public class JsonStreamMapper implements ObjectMapper {
         this.registry = registry;
         this.serdeConfiguration = serdeConfiguration;
         this.view = view;
+    }
+
+    @Override
+    public ObjectMapper cloneWithConfiguration(@Nullable SerdeConfiguration configuration, @Nullable SerializationConfiguration serializationConfiguration, @Nullable DeserializationConfiguration deserializationConfiguration) {
+        return new JsonStreamMapper(registry.cloneWithConfiguration(configuration, serializationConfiguration, deserializationConfiguration), configuration == null ? serdeConfiguration : configuration, view);
     }
 
     @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/DefaultDecoderContext.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/DefaultDecoderContext.java
@@ -20,7 +20,8 @@ import io.micronaut.core.beans.BeanIntrospection;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Deserializer;
-import io.micronaut.serde.SerdeRegistry;
+import io.micronaut.serde.config.DeserializationConfiguration;
+import io.micronaut.serde.config.SerdeConfiguration;
 import io.micronaut.serde.config.naming.PropertyNamingStrategy;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.reference.AbstractPropertyReferenceManager;
@@ -35,9 +36,9 @@ import java.util.Collection;
  */
 @Internal
 class DefaultDecoderContext extends AbstractPropertyReferenceManager implements Deserializer.DecoderContext {
-    private final SerdeRegistry registry;
+    private final DefaultSerdeRegistry registry;
 
-    DefaultDecoderContext(SerdeRegistry registry) {
+    DefaultDecoderContext(DefaultSerdeRegistry registry) {
         this.registry = registry;
     }
 
@@ -81,5 +82,15 @@ class DefaultDecoderContext extends AbstractPropertyReferenceManager implements 
             }
         }
         return reference;
+    }
+
+    @Override
+    public SerdeConfiguration getSerdeConfiguration() {
+        return registry.getSerdeConfiguration();
+    }
+
+    @Override
+    public DeserializationConfiguration getDeserializationConfiguration() {
+        return registry.getDeserializationConfiguration();
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/DefaultDecoderContext.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/DefaultDecoderContext.java
@@ -28,6 +28,7 @@ import io.micronaut.serde.reference.AbstractPropertyReferenceManager;
 import io.micronaut.serde.reference.PropertyReference;
 
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * Default implementation of {@link io.micronaut.serde.Deserializer.DecoderContext}.
@@ -85,12 +86,12 @@ class DefaultDecoderContext extends AbstractPropertyReferenceManager implements 
     }
 
     @Override
-    public SerdeConfiguration getSerdeConfiguration() {
-        return registry.getSerdeConfiguration();
+    public Optional<SerdeConfiguration> getSerdeConfiguration() {
+        return Optional.of(registry.getSerdeConfiguration());
     }
 
     @Override
-    public DeserializationConfiguration getDeserializationConfiguration() {
-        return registry.getDeserializationConfiguration();
+    public Optional<DeserializationConfiguration> getDeserializationConfiguration() {
+        return Optional.of(registry.getDeserializationConfiguration());
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/DefaultEncoderContext.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/DefaultEncoderContext.java
@@ -27,6 +27,8 @@ import io.micronaut.serde.reference.AbstractPropertyReferenceManager;
 import io.micronaut.serde.reference.PropertyReference;
 import io.micronaut.serde.reference.SerializationReference;
 
+import java.util.Optional;
+
 /**
  * Default implementation of {@link io.micronaut.serde.Serializer.EncoderContext}.
  *
@@ -76,12 +78,12 @@ class DefaultEncoderContext extends AbstractPropertyReferenceManager implements 
     }
 
     @Override
-    public SerdeConfiguration getSerdeConfiguration() {
-        return registry.getSerdeConfiguration();
+    public Optional<SerdeConfiguration> getSerdeConfiguration() {
+        return Optional.of(registry.getSerdeConfiguration());
     }
 
     @Override
-    public SerializationConfiguration getSerializationConfiguration() {
-        return registry.getSerializationConfiguration();
+    public Optional<SerializationConfiguration> getSerializationConfiguration() {
+        return Optional.of(registry.getSerializationConfiguration());
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/DefaultEncoderContext.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/DefaultEncoderContext.java
@@ -18,8 +18,9 @@ package io.micronaut.serde.support;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.type.Argument;
-import io.micronaut.serde.SerdeRegistry;
 import io.micronaut.serde.Serializer;
+import io.micronaut.serde.config.SerdeConfiguration;
+import io.micronaut.serde.config.SerializationConfiguration;
 import io.micronaut.serde.config.naming.PropertyNamingStrategy;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.reference.AbstractPropertyReferenceManager;
@@ -33,9 +34,9 @@ import io.micronaut.serde.reference.SerializationReference;
  */
 @Internal
 class DefaultEncoderContext extends AbstractPropertyReferenceManager implements Serializer.EncoderContext {
-    private final SerdeRegistry registry;
+    private final DefaultSerdeRegistry registry;
 
-    DefaultEncoderContext(SerdeRegistry registry) {
+    DefaultEncoderContext(DefaultSerdeRegistry registry) {
         this.registry = registry;
     }
 
@@ -72,5 +73,15 @@ class DefaultEncoderContext extends AbstractPropertyReferenceManager implements 
             }
         }
         return reference;
+    }
+
+    @Override
+    public SerdeConfiguration getSerdeConfiguration() {
+        return registry.getSerdeConfiguration();
+    }
+
+    @Override
+    public SerializationConfiguration getSerializationConfiguration() {
+        return registry.getSerializationConfiguration();
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeRegistry.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeRegistry.java
@@ -50,6 +50,7 @@ import io.micronaut.serde.support.serdes.NumberSerde;
 import io.micronaut.serde.support.serializers.ObjectSerializer;
 import io.micronaut.serde.support.util.TypeKey;
 import io.micronaut.serde.util.BinaryCodecUtil;
+import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
 import java.io.IOException;
@@ -172,6 +173,7 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
      * @param serializationConfiguration The {@link SerializationConfiguration}
      * @param deserializationConfiguration The {@link DeserializationConfiguration}
      */
+    @Inject
     public DefaultSerdeRegistry(
             BeanContext beanContext,
             ObjectSerializer objectSerializer,

--- a/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeRegistry.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeRegistry.java
@@ -40,7 +40,9 @@ import io.micronaut.serde.Serde;
 import io.micronaut.serde.SerdeIntrospections;
 import io.micronaut.serde.SerdeRegistry;
 import io.micronaut.serde.Serializer;
+import io.micronaut.serde.config.DeserializationConfiguration;
 import io.micronaut.serde.config.SerdeConfiguration;
+import io.micronaut.serde.config.SerializationConfiguration;
 import io.micronaut.serde.config.naming.PropertyNamingStrategy;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.deserializers.ObjectDeserializer;
@@ -144,16 +146,19 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
         BOOLEAN_ARRAY_SERDE,
         CHAR_ARRAY_SERDE
     );
-    private final Serializer<Object> objectSerializer;
+    private final ObjectSerializer objectSerializer;
     private final Map<Class<?>, List<BeanDefinition<Serializer>>> serializerDefMap;
     private final Map<Class<?>, List<BeanDefinition<Deserializer>>> deserializerDefMap;
     private final Map<TypeKey, Serializer<?>> serializerMap = new ConcurrentHashMap<>(50);
     private final Map<TypeKey, Deserializer<?>> deserializerMap = new ConcurrentHashMap<>(50);
     private final BeanContext beanContext;
     private final SerdeIntrospections introspections;
-    private final Deserializer<Object> objectDeserializer;
+    private final ObjectDeserializer objectDeserializer;
     private final Serde<Object[]> objectArraySerde;
     private final ConversionService conversionService;
+    private final SerdeConfiguration serdeConfiguration;
+    private final SerializationConfiguration serializationConfiguration;
+    private final DeserializationConfiguration deserializationConfiguration;
 
     /**
      * Default constructor.
@@ -165,12 +170,18 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
      * @param conversionService The conversion service
      */
     public DefaultSerdeRegistry(
-        BeanContext beanContext,
-        ObjectSerializer objectSerializer,
-        ObjectDeserializer objectDeserializer,
-        Serde<Object[]> objectArraySerde,
-        SerdeIntrospections introspections,
-        ConversionService conversionService) {
+            BeanContext beanContext,
+            ObjectSerializer objectSerializer,
+            ObjectDeserializer objectDeserializer,
+            Serde<Object[]> objectArraySerde,
+            SerdeIntrospections introspections,
+            ConversionService conversionService,
+            SerdeConfiguration serdeConfiguration,
+            SerializationConfiguration serializationConfiguration,
+            DeserializationConfiguration deserializationConfiguration) {
+        this.serdeConfiguration = serdeConfiguration;
+        this.serializationConfiguration = serializationConfiguration;
+        this.deserializationConfiguration = deserializationConfiguration;
         final Collection<BeanDefinition<Serializer>> serializers =
                 beanContext.getBeanDefinitions(Serializer.class);
         final Collection<BeanDefinition<Deserializer>> deserializers =
@@ -225,6 +236,21 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
         this.objectSerializer = objectSerializer;
         this.objectDeserializer = objectDeserializer;
         this.conversionService = conversionService;
+    }
+
+    @Override
+    public SerdeRegistry cloneWithConfiguration(@Nullable SerdeConfiguration configuration, @Nullable SerializationConfiguration serializationConfiguration, @Nullable DeserializationConfiguration deserializationConfiguration) {
+        return new DefaultSerdeRegistry(
+            beanContext,
+            objectSerializer,
+            objectDeserializer,
+            objectArraySerde,
+            introspections,
+            conversionService,
+            configuration == null ? this.serdeConfiguration : configuration,
+            serializationConfiguration == null ? this.serializationConfiguration : serializationConfiguration,
+            deserializationConfiguration == null ? this.deserializationConfiguration : deserializationConfiguration
+        );
     }
 
     private void registerBuiltInSerdes() {
@@ -492,6 +518,18 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
     @Override
     public ConversionService getConversionService() {
         return this.conversionService;
+    }
+
+    public SerdeConfiguration getSerdeConfiguration() {
+        return serdeConfiguration;
+    }
+
+    public SerializationConfiguration getSerializationConfiguration() {
+        return serializationConfiguration;
+    }
+
+    public DeserializationConfiguration getDeserializationConfiguration() {
+        return deserializationConfiguration;
     }
 
     private static final class ByteSerde extends SerdeRegistrar<Byte> implements NumberSerde<Byte> {
@@ -1133,6 +1171,16 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
         @Internal
         public ByteArraySerde(boolean writeLegacyByteArrays) {
             this.writeLegacyByteArrays = writeLegacyByteArrays;
+        }
+
+        @Override
+        public @NonNull Serializer<byte[]> createSpecific(@NonNull EncoderContext context, @NonNull Argument<? extends byte[]> type) throws SerdeException {
+            return new ByteArraySerde(context.getSerdeConfiguration());
+        }
+
+        @Override
+        public @NonNull Deserializer<byte[]> createSpecific(@NonNull DecoderContext context, @NonNull Argument<? super byte[]> type) throws SerdeException {
+            return new ByteArraySerde(context.getSerdeConfiguration());
         }
 
         @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeRegistry.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeRegistry.java
@@ -1201,12 +1201,12 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
 
         @Override
         public @NonNull Serializer<byte[]> createSpecific(@NonNull EncoderContext context, @NonNull Argument<? extends byte[]> type) throws SerdeException {
-            return new ByteArraySerde(context.getSerdeConfiguration());
+            return context.getSerdeConfiguration().map(ByteArraySerde::new).orElse(this);
         }
 
         @Override
         public @NonNull Deserializer<byte[]> createSpecific(@NonNull DecoderContext context, @NonNull Argument<? super byte[]> type) throws SerdeException {
-            return new ByteArraySerde(context.getSerdeConfiguration());
+            return context.getSerdeConfiguration().map(ByteArraySerde::new).orElse(this);
         }
 
         @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeRegistry.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeRegistry.java
@@ -168,6 +168,9 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
      * @param objectArraySerde The object array Serde
      * @param introspections The introspections
      * @param conversionService The conversion service
+     * @param serdeConfiguration The {@link SerdeConfiguration}
+     * @param serializationConfiguration The {@link SerializationConfiguration}
+     * @param deserializationConfiguration The {@link DeserializationConfiguration}
      */
     public DefaultSerdeRegistry(
             BeanContext beanContext,
@@ -236,6 +239,26 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
         this.objectSerializer = objectSerializer;
         this.objectDeserializer = objectDeserializer;
         this.conversionService = conversionService;
+    }
+
+    /**
+     * @param beanContext The bean context
+     * @param objectSerializer  The object serializer
+     * @param objectDeserializer The object deserializer
+     * @param objectArraySerde The object array Serde
+     * @param introspections The introspections
+     * @param conversionService The conversion service
+     * @deprecated Use {@link #DefaultSerdeRegistry(BeanContext, ObjectSerializer, ObjectDeserializer, Serde, SerdeIntrospections, ConversionService, SerdeConfiguration, SerializationConfiguration, DeserializationConfiguration)} instead
+     */
+    @Deprecated
+    public DefaultSerdeRegistry(
+        BeanContext beanContext,
+        ObjectSerializer objectSerializer,
+        ObjectDeserializer objectDeserializer,
+        Serde<Object[]> objectArraySerde,
+        SerdeIntrospections introspections,
+        ConversionService conversionService) {
+        this(beanContext, objectSerializer, objectDeserializer, objectArraySerde, introspections, conversionService, beanContext.getBean(SerdeConfiguration.class), beanContext.getBean(SerializationConfiguration.class), beanContext.getBean(DeserializationConfiguration.class));
     }
 
     @Override
@@ -520,15 +543,18 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
         return this.conversionService;
     }
 
-    public SerdeConfiguration getSerdeConfiguration() {
+    @Internal
+    public final SerdeConfiguration getSerdeConfiguration() {
         return serdeConfiguration;
     }
 
-    public SerializationConfiguration getSerializationConfiguration() {
+    @Internal
+    public final SerializationConfiguration getSerializationConfiguration() {
         return serializationConfiguration;
     }
 
-    public DeserializationConfiguration getDeserializationConfiguration() {
+    @Internal
+    public final DeserializationConfiguration getDeserializationConfiguration() {
         return deserializationConfiguration;
     }
 

--- a/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeRegistry.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeRegistry.java
@@ -549,12 +549,12 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
     }
 
     @Internal
-    public final SerializationConfiguration getSerializationConfiguration() {
+    final SerializationConfiguration getSerializationConfiguration() {
         return serializationConfiguration;
     }
 
     @Internal
-    public final DeserializationConfiguration getDeserializationConfiguration() {
+    final DeserializationConfiguration getDeserializationConfiguration() {
         return deserializationConfiguration;
     }
 

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBean.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBean.java
@@ -35,6 +35,7 @@ import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.config.DeserializationConfiguration;
 import io.micronaut.serde.config.annotation.SerdeConfig;
 import io.micronaut.serde.config.naming.PropertyNamingStrategy;
 import io.micronaut.serde.exceptions.InvalidFormatException;
@@ -111,7 +112,8 @@ final class DeserBean<T> {
 
     // CHECKSTYLE:ON
 
-    public DeserBean(Argument<T> type,
+    public DeserBean(DeserializationConfiguration defaultDeserializationConfiguration,
+                     Argument<T> type,
                      BeanIntrospection<T> introspection,
                      Deserializer.DecoderContext decoderContext,
                      DeserBeanRegistry deserBeanRegistry,
@@ -147,7 +149,7 @@ final class DeserBean<T> {
         boolean hasIncludedProperties = serdeArgumentConf != null && serdeArgumentConf.getIncluded() != null
             || introspection.isAnnotationPresent(SerdeConfig.SerIncluded.class);
         this.ignoreUnknown = hasIncludedProperties || introspection.booleanValue(SerdeConfig.SerIgnored.class, SerdeConfig.SerIgnored.IGNORE_UNKNOWN)
-            .orElse(decoderContext.getDeserializationConfiguration().isIgnoreUnknown());
+            .orElse(decoderContext.getDeserializationConfiguration().orElse(defaultDeserializationConfiguration).isIgnoreUnknown());
         final PropertiesBag.Builder<T> creatorPropertiesBuilder = new PropertiesBag.Builder<>(introspection, constructorArguments.length);
 
         BeanMethod<T, Object> jsonValueMethod = null;

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBean.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBean.java
@@ -35,7 +35,6 @@ import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Deserializer;
-import io.micronaut.serde.config.DeserializationConfiguration;
 import io.micronaut.serde.config.annotation.SerdeConfig;
 import io.micronaut.serde.config.naming.PropertyNamingStrategy;
 import io.micronaut.serde.exceptions.InvalidFormatException;
@@ -112,8 +111,7 @@ final class DeserBean<T> {
 
     // CHECKSTYLE:ON
 
-    public DeserBean(DeserializationConfiguration deserializationConfiguration,
-                     Argument<T> type,
+    public DeserBean(Argument<T> type,
                      BeanIntrospection<T> introspection,
                      Deserializer.DecoderContext decoderContext,
                      DeserBeanRegistry deserBeanRegistry,
@@ -149,7 +147,7 @@ final class DeserBean<T> {
         boolean hasIncludedProperties = serdeArgumentConf != null && serdeArgumentConf.getIncluded() != null
             || introspection.isAnnotationPresent(SerdeConfig.SerIncluded.class);
         this.ignoreUnknown = hasIncludedProperties || introspection.booleanValue(SerdeConfig.SerIgnored.class, SerdeConfig.SerIgnored.IGNORE_UNKNOWN)
-            .orElse(deserializationConfiguration.isIgnoreUnknown());
+            .orElse(decoderContext.getDeserializationConfiguration().isIgnoreUnknown());
         final PropertiesBag.Builder<T> creatorPropertiesBuilder = new PropertiesBag.Builder<>(introspection, constructorArguments.length);
 
         BeanMethod<T, Object> jsonValueMethod = null;

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBeanKey.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBeanKey.java
@@ -19,6 +19,8 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
+import io.micronaut.serde.config.DeserializationConfiguration;
+import io.micronaut.serde.config.SerdeConfiguration;
 import io.micronaut.serde.support.util.SerdeArgumentConf;
 
 import java.util.Objects;
@@ -28,12 +30,16 @@ import java.util.Objects;
  */
 @Internal
 final class DeserBeanKey {
+    private final SerdeConfiguration serdeConfiguration;
+    private final DeserializationConfiguration deserializationConfiguration;
     private final Argument<?> type;
     @Nullable
     private final SerdeArgumentConf serdeArgumentConf;
     private final int hashCode;
 
-    public DeserBeanKey(@NonNull Argument<?> type, @Nullable SerdeArgumentConf serdeArgumentConf) {
+    public DeserBeanKey(SerdeConfiguration serdeConfiguration, DeserializationConfiguration deserializationConfiguration, @NonNull Argument<?> type, @Nullable SerdeArgumentConf serdeArgumentConf) {
+        this.serdeConfiguration = serdeConfiguration;
+        this.deserializationConfiguration = deserializationConfiguration;
         this.type = type;
         this.serdeArgumentConf = serdeArgumentConf;
         this.hashCode = type.typeHashCode();
@@ -48,7 +54,7 @@ final class DeserBeanKey {
             return false;
         }
         DeserBeanKey that = (DeserBeanKey) o;
-        return type.equalsType(that.type) && Objects.equals(serdeArgumentConf, that.serdeArgumentConf);
+        return type.equalsType(that.type) && Objects.equals(serdeArgumentConf, that.serdeArgumentConf) && deserializationConfiguration == that.deserializationConfiguration && serdeConfiguration == that.serdeConfiguration;
     }
 
     @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/ObjectDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/ObjectDeserializer.java
@@ -48,7 +48,6 @@ import java.util.function.Supplier;
 @BootstrapContextCompatible
 public class ObjectDeserializer implements CustomizableDeserializer<Object>, DeserBeanRegistry {
     private final SerdeIntrospections introspections;
-    private final DeserializationConfiguration deserializationConfiguration;
     private final Map<DeserBeanKey, Supplier<DeserBean<?>>> deserBeanMap = new ConcurrentHashMap<>(50);
     @Nullable
     private final SerdeDeserializationPreInstantiateCallback preInstantiateCallback;
@@ -57,7 +56,6 @@ public class ObjectDeserializer implements CustomizableDeserializer<Object>, Des
                               DeserializationConfiguration deserializationConfiguration,
                               @Nullable SerdeDeserializationPreInstantiateCallback preInstantiateCallback) {
         this.introspections = introspections;
-        this.deserializationConfiguration = deserializationConfiguration;
         this.preInstantiateCallback = preInstantiateCallback;
     }
 
@@ -77,10 +75,10 @@ public class ObjectDeserializer implements CustomizableDeserializer<Object>, Des
             for (Map.Entry<String, DeserBean<?>> e : subtypeInfo.subtypes().entrySet()) {
                 subtypeDeserializers.put(
                     e.getKey(),
-                    findDeserializer((DeserBean<? super Object>) e.getValue(), disallowUnwrap)
+                    findDeserializer(context.getDeserializationConfiguration(), (DeserBean<? super Object>) e.getValue(), disallowUnwrap)
                 );
             }
-            Deserializer<Object> supertypeDeserializer = findDeserializer(deserBean, false);
+            Deserializer<Object> supertypeDeserializer = findDeserializer(context.getDeserializationConfiguration(), deserBean, false);
             return switch (discriminatorType) {
                 case WRAPPER_OBJECT -> new WrappedObjectSubtypedDeserializer(
                     subtypeDeserializers,
@@ -100,10 +98,10 @@ public class ObjectDeserializer implements CustomizableDeserializer<Object>, Des
             };
         }
 
-        return findDeserializer(deserBean, false);
+        return findDeserializer(context.getDeserializationConfiguration(), deserBean, false);
     }
 
-    private Deserializer<Object> findDeserializer(DeserBean<? super Object> deserBean, boolean disallowUnwrap) {
+    private Deserializer<Object> findDeserializer(DeserializationConfiguration deserializationConfiguration, DeserBean<? super Object> deserBean, boolean disallowUnwrap) {
         Deserializer<Object> deserializer;
         if (deserBean.simpleBean) {
             deserializer = new SimpleObjectDeserializer(deserializationConfiguration.isStrictNullable(), deserBean, preInstantiateCallback);
@@ -130,7 +128,7 @@ public class ObjectDeserializer implements CustomizableDeserializer<Object>, Des
     public <T> DeserBean<T> getDeserializableBean(Argument<T> type, DecoderContext decoderContext) throws SerdeException {
         SerdeArgumentConf serdeArgumentConf = type.getAnnotationMetadata().isEmpty() ?
             null : new SerdeArgumentConf(type.getAnnotationMetadata());
-        DeserBeanKey key = new DeserBeanKey(type, serdeArgumentConf);
+        DeserBeanKey key = new DeserBeanKey(decoderContext.getSerdeConfiguration(), decoderContext.getDeserializationConfiguration(), type, serdeArgumentConf);
         // Use suppliers to prevent recursive update because the lambda can call the same method again
         Supplier<DeserBean<?>> deserBeanSupplier = deserBeanMap.computeIfAbsent(key, ignore -> SupplierUtil.memoizedNonEmpty(() -> createDeserBean(type, serdeArgumentConf, decoderContext)));
         DeserBean<?> deserBean = deserBeanSupplier.get();
@@ -143,7 +141,7 @@ public class ObjectDeserializer implements CustomizableDeserializer<Object>, Des
                                              DecoderContext decoderContext) {
         try {
             final BeanIntrospection<T> deserializableIntrospection = introspections.getDeserializableIntrospection(type);
-            return new DeserBean<>(deserializationConfiguration, type, deserializableIntrospection, decoderContext, this, serdeArgumentConf);
+            return new DeserBean<>(type, deserializableIntrospection, decoderContext, this, serdeArgumentConf);
         } catch (SerdeException e) {
             throw new IntrospectionException("Error creating deserializer for type [" + type + "]: " + e.getMessage(), e);
         }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/DefaultFormattedTemporalSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/DefaultFormattedTemporalSerde.java
@@ -62,6 +62,12 @@ public abstract class DefaultFormattedTemporalSerde<T extends TemporalAccessor> 
         return TemporalSerde.super.createSpecific(decoderContext, context);
     }
 
+    /**
+     * Create the same serde with new configuration.
+     *
+     * @param configuration The new configuration
+     * @return The updated serde
+     */
     protected DefaultFormattedTemporalSerde<T> createSpecific(SerdeConfiguration configuration) {
         return this;
     }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/DefaultFormattedTemporalSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/DefaultFormattedTemporalSerde.java
@@ -58,7 +58,7 @@ public abstract class DefaultFormattedTemporalSerde<T extends TemporalAccessor> 
         if (specific != this) {
             return specific;
         }
-        return createSpecific(context.getSerdeConfiguration());
+        return context.getSerdeConfiguration().map(this::createSpecific).orElse(this);
     }
 
     @Override
@@ -67,7 +67,7 @@ public abstract class DefaultFormattedTemporalSerde<T extends TemporalAccessor> 
         if (specific != this) {
             return specific;
         }
-        return createSpecific(decoderContext.getSerdeConfiguration());
+        return decoderContext.getSerdeConfiguration().map(this::createSpecific).orElse(this);
     }
 
     /**

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/DefaultFormattedTemporalSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/DefaultFormattedTemporalSerde.java
@@ -54,12 +54,12 @@ public abstract class DefaultFormattedTemporalSerde<T extends TemporalAccessor> 
 
     @Override
     public Serializer<T> createSpecific(EncoderContext context, Argument<? extends T> type) {
-        return TemporalSerde.super.createSpecific(context, type);
+        return createSpecific(context.getSerdeConfiguration());
     }
 
     @Override
     public Deserializer<T> createSpecific(DecoderContext decoderContext, Argument<? super T> context) throws SerdeException {
-        return TemporalSerde.super.createSpecific(decoderContext, context);
+        return createSpecific(decoderContext.getSerdeConfiguration());
     }
 
     /**

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/DefaultFormattedTemporalSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/DefaultFormattedTemporalSerde.java
@@ -54,11 +54,19 @@ public abstract class DefaultFormattedTemporalSerde<T extends TemporalAccessor> 
 
     @Override
     public Serializer<T> createSpecific(EncoderContext context, Argument<? extends T> type) {
+        Serializer<T> specific = TemporalSerde.super.createSpecific(context, type);
+        if (specific != this) {
+            return specific;
+        }
         return createSpecific(context.getSerdeConfiguration());
     }
 
     @Override
     public Deserializer<T> createSpecific(DecoderContext decoderContext, Argument<? super T> context) throws SerdeException {
+        Deserializer<T> specific = TemporalSerde.super.createSpecific(decoderContext, context);
+        if (specific != this) {
+            return specific;
+        }
         return createSpecific(decoderContext.getSerdeConfiguration());
     }
 

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/DefaultFormattedTemporalSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/DefaultFormattedTemporalSerde.java
@@ -18,8 +18,11 @@ package io.micronaut.serde.support.serdes;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Deserializer;
 import io.micronaut.serde.Encoder;
+import io.micronaut.serde.Serializer;
 import io.micronaut.serde.config.SerdeConfiguration;
+import io.micronaut.serde.exceptions.SerdeException;
 
 import java.io.IOException;
 import java.time.DateTimeException;
@@ -47,6 +50,20 @@ public abstract class DefaultFormattedTemporalSerde<T extends TemporalAccessor> 
         @NonNull DateTimeFormatter defaultStringFormatter
     ) {
         stringFormatter = createFormatter(configuration).orElse(defaultStringFormatter);
+    }
+
+    @Override
+    public Serializer<T> createSpecific(EncoderContext context, Argument<? extends T> type) {
+        return TemporalSerde.super.createSpecific(context, type);
+    }
+
+    @Override
+    public Deserializer<T> createSpecific(DecoderContext decoderContext, Argument<? super T> context) throws SerdeException {
+        return TemporalSerde.super.createSpecific(decoderContext, context);
+    }
+
+    protected DefaultFormattedTemporalSerde<T> createSpecific(SerdeConfiguration configuration) {
+        return this;
     }
 
     @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/InetAddressSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/InetAddressSerde.java
@@ -45,12 +45,12 @@ public class InetAddressSerde implements Serde<InetAddress> {
 
     @Override
     public @NonNull Deserializer<InetAddress> createSpecific(@NonNull DecoderContext context, @NonNull Argument<? super InetAddress> type) throws SerdeException {
-        return new InetAddressSerde(context.getSerdeConfiguration());
+        return context.getSerdeConfiguration().map(InetAddressSerde::new).orElse(this);
     }
 
     @Override
     public @NonNull Serializer<InetAddress> createSpecific(@NonNull EncoderContext context, @NonNull Argument<? extends InetAddress> type) throws SerdeException {
-        return new InetAddressSerde(context.getSerdeConfiguration());
+        return context.getSerdeConfiguration().map(InetAddressSerde::new).orElse(this);
     }
 
     @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/InetAddressSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/InetAddressSerde.java
@@ -19,9 +19,12 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Deserializer;
 import io.micronaut.serde.Encoder;
 import io.micronaut.serde.Serde;
+import io.micronaut.serde.Serializer;
 import io.micronaut.serde.config.SerdeConfiguration;
+import io.micronaut.serde.exceptions.SerdeException;
 import jakarta.inject.Singleton;
 
 import java.io.IOException;
@@ -38,6 +41,16 @@ public class InetAddressSerde implements Serde<InetAddress> {
 
     public InetAddressSerde(SerdeConfiguration serdeConfiguration) {
         this.asNumeric = serdeConfiguration.isInetAddressAsNumeric();
+    }
+
+    @Override
+    public @NonNull Deserializer<InetAddress> createSpecific(@NonNull DecoderContext context, @NonNull Argument<? super InetAddress> type) throws SerdeException {
+        return new InetAddressSerde(context.getSerdeConfiguration());
+    }
+
+    @Override
+    public @NonNull Serializer<InetAddress> createSpecific(@NonNull EncoderContext context, @NonNull Argument<? extends InetAddress> type) throws SerdeException {
+        return new InetAddressSerde(context.getSerdeConfiguration());
     }
 
     @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/InstantSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/InstantSerde.java
@@ -55,4 +55,9 @@ public final class InstantSerde extends NumericSupportTemporalSerde<Instant> imp
     protected Instant fromNanos(long seconds, int nanos) {
         return Instant.ofEpochSecond(seconds, nanos);
     }
+
+    @Override
+    protected DefaultFormattedTemporalSerde<Instant> createSpecific(SerdeConfiguration configuration) {
+        return new InstantSerde(configuration);
+    }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/LocalDateSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/LocalDateSerde.java
@@ -50,6 +50,11 @@ public final class LocalDateSerde extends DefaultFormattedTemporalSerde<LocalDat
     }
 
     @Override
+    protected DefaultFormattedTemporalSerde<LocalDate> createSpecific(SerdeConfiguration configuration) {
+        return new LocalDateSerde(configuration);
+    }
+
+    @Override
     void serialize0(Encoder encoder, LocalDate value) throws IOException {
         if (writeNumeric) {
             encoder.encodeLong(value.toEpochDay());

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/LocalDateTimeSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/LocalDateTimeSerde.java
@@ -39,4 +39,9 @@ public final class LocalDateTimeSerde extends DefaultFormattedTemporalSerde<Loca
     public TemporalQuery<LocalDateTime> query() {
         return LocalDateTime::from;
     }
+
+    @Override
+    protected DefaultFormattedTemporalSerde<LocalDateTime> createSpecific(SerdeConfiguration configuration) {
+        return new LocalDateTimeSerde(configuration);
+    }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/LocalTimeSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/LocalTimeSerde.java
@@ -58,4 +58,9 @@ public final class LocalTimeSerde extends NumericSupportTemporalSerde<LocalTime>
     protected int getNanoPart(LocalTime value) {
         return value.getNano();
     }
+
+    @Override
+    protected DefaultFormattedTemporalSerde<LocalTime> createSpecific(SerdeConfiguration configuration) {
+        return new LocalTimeSerde(configuration);
+    }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/OffsetDateTimeSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/OffsetDateTimeSerde.java
@@ -63,4 +63,9 @@ public final class OffsetDateTimeSerde extends NumericSupportTemporalSerde<Offse
     protected int getNanoPart(OffsetDateTime value) {
         return value.toInstant().getNano();
     }
+
+    @Override
+    protected DefaultFormattedTemporalSerde<OffsetDateTime> createSpecific(SerdeConfiguration configuration) {
+        return new OffsetDateTimeSerde(configuration);
+    }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/ZonedDateTimeSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/ZonedDateTimeSerde.java
@@ -56,4 +56,9 @@ public final class ZonedDateTimeSerde
     protected int getNanoPart(ZonedDateTime value) {
         return value.toInstant().getNano();
     }
+
+    @Override
+    protected DefaultFormattedTemporalSerde<ZonedDateTime> createSpecific(SerdeConfiguration configuration) {
+        return new ZonedDateTimeSerde(configuration);
+    }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/ObjectSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/ObjectSerializer.java
@@ -27,7 +27,6 @@ import io.micronaut.core.type.GenericPlaceholder;
 import io.micronaut.core.util.SupplierUtil;
 import io.micronaut.serde.SerdeIntrospections;
 import io.micronaut.serde.Serializer;
-import io.micronaut.serde.config.SerializationConfiguration;
 import io.micronaut.serde.config.annotation.SerdeConfig;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.util.SerdeArgumentConf;
@@ -57,13 +56,11 @@ import java.util.function.Supplier;
 @BootstrapContextCompatible
 public final class ObjectSerializer implements CustomizableSerializer<Object> {
     private final SerdeIntrospections introspections;
-    private final SerializationConfiguration configuration;
     private final BeanContext beanContext;
     private final Map<SerBeanKey, Supplier<SerBean<?>>> serBeanMap = new ConcurrentHashMap<>(50);
 
-    public ObjectSerializer(SerdeIntrospections introspections, SerializationConfiguration configuration, BeanContext beanContext) {
+    public ObjectSerializer(SerdeIntrospections introspections, BeanContext beanContext) {
         this.introspections = introspections;
-        this.configuration = configuration;
         this.beanContext = beanContext;
     }
 
@@ -129,11 +126,11 @@ public final class ObjectSerializer implements CustomizableSerializer<Object> {
                                                EncoderContext context) throws SerdeException {
         AnnotationMetadata annotationMetadata = type.getAnnotationMetadata();
         SerdeArgumentConf serdeArgumentConf = annotationMetadata.isEmpty() ? null : new SerdeArgumentConf(annotationMetadata);
-        SerBeanKey key = new SerBeanKey(type, serdeArgumentConf);
+        SerBeanKey key = new SerBeanKey(context.getSerdeConfiguration(), context.getSerializationConfiguration(), type, serdeArgumentConf);
         // Use suppliers to prevent recursive update because the lambda will call the same method again
         Supplier<SerBean<?>> serBeanSupplier = serBeanMap.computeIfAbsent(key, ignore -> SupplierUtil.memoizedNonEmpty(() -> {
             try {
-                return new SerBean<>(type, introspections, context, configuration, serdeArgumentConf, beanContext);
+                return new SerBean<>(type, introspections, context, serdeArgumentConf, beanContext);
             } catch (SerdeException e) {
                 throw new IntrospectionException("Error creating deserializer for type [" + type + "]: " + e.getMessage(), e);
             }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/ObjectSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/ObjectSerializer.java
@@ -27,6 +27,8 @@ import io.micronaut.core.type.GenericPlaceholder;
 import io.micronaut.core.util.SupplierUtil;
 import io.micronaut.serde.SerdeIntrospections;
 import io.micronaut.serde.Serializer;
+import io.micronaut.serde.config.SerdeConfiguration;
+import io.micronaut.serde.config.SerializationConfiguration;
 import io.micronaut.serde.config.annotation.SerdeConfig;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.util.SerdeArgumentConf;
@@ -126,7 +128,12 @@ public final class ObjectSerializer implements CustomizableSerializer<Object> {
                                                EncoderContext context) throws SerdeException {
         AnnotationMetadata annotationMetadata = type.getAnnotationMetadata();
         SerdeArgumentConf serdeArgumentConf = annotationMetadata.isEmpty() ? null : new SerdeArgumentConf(annotationMetadata);
-        SerBeanKey key = new SerBeanKey(context.getSerdeConfiguration(), context.getSerializationConfiguration(), type, serdeArgumentConf);
+        SerBeanKey key = new SerBeanKey(
+            context.getSerdeConfiguration().orElseGet(() -> beanContext.getBean(SerdeConfiguration.class)),
+            context.getSerializationConfiguration().orElseGet(() -> beanContext.getBean(SerializationConfiguration.class)),
+            type,
+            serdeArgumentConf
+        );
         // Use suppliers to prevent recursive update because the lambda will call the same method again
         Supplier<SerBean<?>> serBeanSupplier = serBeanMap.computeIfAbsent(key, ignore -> SupplierUtil.memoizedNonEmpty(() -> {
             try {

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/OptionalMultiValuesSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/OptionalMultiValuesSerializer.java
@@ -21,6 +21,7 @@ import io.micronaut.core.value.OptionalMultiValues;
 import io.micronaut.serde.Encoder;
 import io.micronaut.serde.ObjectSerializer;
 import io.micronaut.serde.Serializer;
+import io.micronaut.serde.config.SerializationConfiguration;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.util.CustomizableSerializer;
 import jakarta.inject.Singleton;
@@ -37,10 +38,16 @@ import java.util.Optional;
  */
 @Singleton
 final class OptionalMultiValuesSerializer<V> implements CustomizableSerializer<OptionalMultiValues<V>> {
+    private final boolean alwaysSerializeErrorsAsList;
+
+    public OptionalMultiValuesSerializer(SerializationConfiguration jacksonConfiguration) {
+        this.alwaysSerializeErrorsAsList = jacksonConfiguration.isAlwaysSerializeErrorsAsList();
+    }
 
     @Override
     public ObjectSerializer<OptionalMultiValues<V>> createSpecific(EncoderContext context, Argument<? extends OptionalMultiValues<V>> type) throws SerdeException {
-        boolean alwaysSerializeErrorsAsList = context.getSerializationConfiguration().isAlwaysSerializeErrorsAsList();
+        boolean alwaysSerializeErrorsAsList = context.getSerializationConfiguration().map(SerializationConfiguration::isAlwaysSerializeErrorsAsList)
+            .orElse(this.alwaysSerializeErrorsAsList);
 
         final Argument[] generics = type.getTypeParameters();
         if (ArrayUtils.isEmpty(generics)) {

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/OptionalMultiValuesSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/OptionalMultiValuesSerializer.java
@@ -21,7 +21,6 @@ import io.micronaut.core.value.OptionalMultiValues;
 import io.micronaut.serde.Encoder;
 import io.micronaut.serde.ObjectSerializer;
 import io.micronaut.serde.Serializer;
-import io.micronaut.serde.config.SerializationConfiguration;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.util.CustomizableSerializer;
 import jakarta.inject.Singleton;
@@ -38,14 +37,11 @@ import java.util.Optional;
  */
 @Singleton
 final class OptionalMultiValuesSerializer<V> implements CustomizableSerializer<OptionalMultiValues<V>> {
-    private final boolean alwaysSerializeErrorsAsList;
-
-    public OptionalMultiValuesSerializer(SerializationConfiguration jacksonConfiguration) {
-        this.alwaysSerializeErrorsAsList = jacksonConfiguration.isAlwaysSerializeErrorsAsList();
-    }
 
     @Override
     public ObjectSerializer<OptionalMultiValues<V>> createSpecific(EncoderContext context, Argument<? extends OptionalMultiValues<V>> type) throws SerdeException {
+        boolean alwaysSerializeErrorsAsList = context.getSerializationConfiguration().isAlwaysSerializeErrorsAsList();
+
         final Argument[] generics = type.getTypeParameters();
         if (ArrayUtils.isEmpty(generics)) {
             throw new SerdeException("Cannot serialize raw OptionalMultiValues");

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBean.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBean.java
@@ -110,7 +110,7 @@ final class SerBean<T> {
             BeanContext beanContext) throws SerdeException {
         // !!! Avoid accessing annotations from the argument, the annotations are not included in the cache key
         this.serdeArgumentConf = serdeArgumentConf;
-        this.configuration = encoderContext.getSerializationConfiguration();
+        this.configuration = encoderContext.getSerializationConfiguration().orElseGet(() -> beanContext.getBean(SerializationConfiguration.class));
         this.introspection = introspections.getSerializableIntrospection(type);
         this.propertyFilter = getPropertyFilterIfPresent(beanContext, type.getSimpleName());
         subtypeInfo = serdeArgumentConf == null ? null : serdeArgumentConf.getSubtypeInfo();

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBean.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBean.java
@@ -106,12 +106,11 @@ final class SerBean<T> {
     SerBean(Argument<T> type,
             SerdeIntrospections introspections,
             Serializer.EncoderContext encoderContext,
-            SerializationConfiguration configuration,
             @Nullable SerdeArgumentConf serdeArgumentConf,
             BeanContext beanContext) throws SerdeException {
         // !!! Avoid accessing annotations from the argument, the annotations are not included in the cache key
         this.serdeArgumentConf = serdeArgumentConf;
-        this.configuration = configuration;
+        this.configuration = encoderContext.getSerializationConfiguration();
         this.introspection = introspections.getSerializableIntrospection(type);
         this.propertyFilter = getPropertyFilterIfPresent(beanContext, type.getSimpleName());
         subtypeInfo = serdeArgumentConf == null ? null : serdeArgumentConf.getSubtypeInfo();

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBeanKey.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBeanKey.java
@@ -19,6 +19,8 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
+import io.micronaut.serde.config.SerdeConfiguration;
+import io.micronaut.serde.config.SerializationConfiguration;
 import io.micronaut.serde.support.util.SerdeArgumentConf;
 
 import java.util.Objects;
@@ -28,12 +30,16 @@ import java.util.Objects;
  */
 @Internal
 final class SerBeanKey {
+    private final SerdeConfiguration serdeConfiguration;
+    private final SerializationConfiguration serializationConfiguration;
     private final Argument<?> type;
     @Nullable
     private final SerdeArgumentConf serdeArgumentConf;
     private final int hashCode;
 
-    public SerBeanKey(@NonNull Argument<?> type, @Nullable SerdeArgumentConf serdeArgumentConf) {
+    public SerBeanKey(SerdeConfiguration serdeConfiguration, SerializationConfiguration serializationConfiguration, @NonNull Argument<?> type, @Nullable SerdeArgumentConf serdeArgumentConf) {
+        this.serdeConfiguration = serdeConfiguration;
+        this.serializationConfiguration = serializationConfiguration;
         this.type = type;
         this.serdeArgumentConf = serdeArgumentConf;
         this.hashCode = type.typeHashCode();
@@ -48,7 +54,7 @@ final class SerBeanKey {
             return false;
         }
         SerBeanKey that = (SerBeanKey) o;
-        return type.equalsType(that.type) && Objects.equals(serdeArgumentConf, that.serdeArgumentConf);
+        return type.equalsType(that.type) && Objects.equals(serdeArgumentConf, that.serdeArgumentConf) && serializationConfiguration == that.serializationConfiguration && serdeConfiguration == that.serdeConfiguration;
     }
 
     @Override


### PR DESCRIPTION
This new method allows creating modified ObjectMappers with different configuration. This is required so that we can create an ObjectMapper using the BeanContext in micronaut-oraclecloud, which requires non-default serde configuration.

The changes here are a bit painful. The existing use sites of the config classes all assume the configuration is global and static. They all had to be adjusted.

The API is also painful to use because the configuration classes are interfaces. ConfigCloneSpec shows an example how to use this API without having to implement SerdeConfiguration and friends manually, but it's a bit awkward.