### PR TITLE
Allow for mixins to skip validation

### DIFF
--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/mixin/AppImport.java
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/mixin/AppImport.java
@@ -1,0 +1,13 @@
+package io.micronaut.serde.jackson.mixin;
+
+import io.micronaut.serde.annotation.SerdeImport;
+
+@SerdeImport(
+    value = Request.class,
+    mixin = RequestMixin.class
+)
+@SerdeImport(
+    value = Message.class,
+    mixin = MessageMixin.class
+)
+class AppImport {}

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/mixin/FooMessage.java
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/mixin/FooMessage.java
@@ -1,0 +1,8 @@
+package io.micronaut.serde.jackson.mixin;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public record FooMessage<T extends Request>(
+    T payload
+) implements Message<T> { }

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/mixin/Message.java
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/mixin/Message.java
@@ -1,0 +1,5 @@
+package io.micronaut.serde.jackson.mixin;
+
+public interface Message<T extends Request> {
+    T payload();
+}

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/mixin/MessageMixin.java
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/mixin/MessageMixin.java
@@ -1,0 +1,9 @@
+package io.micronaut.serde.jackson.mixin;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable(validate = false)
+@JsonDeserialize(as = FooMessage.class)
+public interface MessageMixin {
+}

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/mixin/MyTestClass.java
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/mixin/MyTestClass.java
@@ -1,0 +1,5 @@
+package io.micronaut.serde.jackson.mixin;
+
+public record MyTestClass(
+    String name
+) implements Request { }

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/mixin/Request.java
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/mixin/Request.java
@@ -1,0 +1,4 @@
+package io.micronaut.serde.jackson.mixin;
+
+public interface Request {
+}

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/mixin/RequestMixin.java
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/mixin/RequestMixin.java
@@ -1,0 +1,14 @@
+package io.micronaut.serde.jackson.mixin;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    property = "type"
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(MyTestClass.class),
+})
+public interface RequestMixin {
+}

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/mixin/SerdeMixinSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/mixin/SerdeMixinSpec.groovy
@@ -1,0 +1,22 @@
+package io.micronaut.serde.jackson.mixin
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.serde.ObjectMapper
+import spock.lang.Specification
+
+class SerdeMixinSpec extends Specification {
+
+    void "should deserialize"() {
+        given:
+            def context = ApplicationContext.run()
+        expect:
+            def read = context.getBean(ObjectMapper).readValue('{"payload": {"type": "MyTestClass", "name": "Some name"}}', FooMessage)
+
+            read.getClass().name.endsWith 'FooMessage'
+            read.payload().getClass().name.endsWith 'MyTestClass'
+            read.payload().name() == 'Some name'
+
+        cleanup:
+            context.close()
+    }
+}


### PR DESCRIPTION
Adds an example of how to skip the validation, maybe we should introduce a way to mark the class as a mixin `@Serdeable.Mixin`?

Closes https://github.com/micronaut-projects/micronaut-serialization/issues/736