### PR TITLE
Convert internal serdes from beans to ordinary classes

### DIFF
--- a/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonBinaryBasicSerdeCompileSpec.groovy
+++ b/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonBinaryBasicSerdeCompileSpec.groovy
@@ -3,9 +3,6 @@ package io.micronaut.serde.bson
 import io.micronaut.core.type.Argument
 import io.micronaut.json.JsonMapper
 import io.micronaut.serde.AbstractBasicSerdeCompileSpec
-import io.micronaut.serde.AbstractBasicSerdeSpec
-import io.micronaut.test.extensions.spock.annotation.MicronautTest
-import jakarta.inject.Inject
 import org.bson.BsonDocument
 
 class BsonBinaryBasicSerdeCompileSpec extends AbstractBasicSerdeCompileSpec implements BsonBinarySpec {

--- a/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/serde/OracleJsonBinarySerde.java
+++ b/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/serde/OracleJsonBinarySerde.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.oracle.jdbc.json.serde;
 
+import io.micronaut.context.annotation.Secondary;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Order;
 import io.micronaut.core.type.Argument;
@@ -35,9 +36,9 @@ import oracle.jdbc.driver.json.tree.OracleJsonBinaryImpl;
 @Singleton
 @Order(-100)
 public class OracleJsonBinarySerde extends AbstractOracleJsonSerde<byte[]> {
-    private final DefaultSerdeRegistry.ByteArraySerde byteArraySerde;
+    private final Serde<byte[]> byteArraySerde;
 
-    public OracleJsonBinarySerde(DefaultSerdeRegistry.ByteArraySerde byteArraySerde) {
+    public OracleJsonBinarySerde(@Secondary Serde<byte[]> byteArraySerde) {
         this.byteArraySerde = byteArraySerde;
     }
 

--- a/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/serde/OracleJsonLocaleDateSerde.java
+++ b/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/serde/OracleJsonLocaleDateSerde.java
@@ -15,13 +15,13 @@
  */
 package io.micronaut.serde.oracle.jdbc.json.serde;
 
+import io.micronaut.context.annotation.Secondary;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Order;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Serde;
 import io.micronaut.serde.oracle.jdbc.json.OracleJdbcJsonGeneratorEncoder;
 import io.micronaut.serde.oracle.jdbc.json.OracleJdbcJsonParserDecoder;
-import io.micronaut.serde.support.serdes.LocalDateSerde;
 import jakarta.inject.Singleton;
 
 import java.time.LocalDate;
@@ -36,9 +36,9 @@ import java.time.LocalDate;
 @Order(-100)
 public class OracleJsonLocaleDateSerde extends AbstractOracleJsonSerde<LocalDate> {
 
-    private final LocalDateSerde localDateSerde;
+    private final Serde<LocalDate> localDateSerde;
 
-    public OracleJsonLocaleDateSerde(LocalDateSerde localDateSerde) {
+    public OracleJsonLocaleDateSerde(@Secondary Serde<LocalDate> localDateSerde) {
         this.localDateSerde = localDateSerde;
     }
 

--- a/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/serde/OracleJsonLocaleDateTimeSerde.java
+++ b/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/serde/OracleJsonLocaleDateTimeSerde.java
@@ -15,12 +15,12 @@
  */
 package io.micronaut.serde.oracle.jdbc.json.serde;
 
+import io.micronaut.context.annotation.Secondary;
 import io.micronaut.core.annotation.Order;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Serde;
 import io.micronaut.serde.oracle.jdbc.json.OracleJdbcJsonGeneratorEncoder;
 import io.micronaut.serde.oracle.jdbc.json.OracleJdbcJsonParserDecoder;
-import io.micronaut.serde.support.serdes.LocalDateTimeSerde;
 import jakarta.inject.Singleton;
 
 import java.time.LocalDateTime;
@@ -34,9 +34,9 @@ import java.time.LocalDateTime;
 @Singleton
 @Order(-100)
 public class OracleJsonLocaleDateTimeSerde extends AbstractOracleJsonSerde<LocalDateTime> {
-    private final LocalDateTimeSerde dateTimeSerde;
+    private final Serde<LocalDateTime> dateTimeSerde;
 
-    public OracleJsonLocaleDateTimeSerde(LocalDateTimeSerde dateTimeSerde) {
+    public OracleJsonLocaleDateTimeSerde(@Secondary Serde<LocalDateTime> dateTimeSerde) {
         this.dateTimeSerde = dateTimeSerde;
     }
 

--- a/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/serde/OracleJsonLocaleTimeSerde.java
+++ b/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/serde/OracleJsonLocaleTimeSerde.java
@@ -15,13 +15,13 @@
  */
 package io.micronaut.serde.oracle.jdbc.json.serde;
 
+import io.micronaut.context.annotation.Secondary;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Order;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Serde;
 import io.micronaut.serde.oracle.jdbc.json.OracleJdbcJsonGeneratorEncoder;
 import io.micronaut.serde.oracle.jdbc.json.OracleJdbcJsonParserDecoder;
-import io.micronaut.serde.support.serdes.LocalTimeSerde;
 import jakarta.inject.Singleton;
 
 import java.time.LocalDate;
@@ -37,9 +37,9 @@ import java.time.LocalTime;
 @Order(-100)
 public class OracleJsonLocaleTimeSerde extends AbstractOracleJsonSerde<LocalTime> {
 
-    private final LocalTimeSerde localTimeSerde;
+    private final Serde<LocalTime> localTimeSerde;
 
-    public OracleJsonLocaleTimeSerde(LocalTimeSerde localTimeSerde) {
+    public OracleJsonLocaleTimeSerde(@Secondary Serde<LocalTime> localTimeSerde) {
         this.localTimeSerde = localTimeSerde;
     }
 

--- a/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/serde/OracleJsonOffsetDateTimeSerde.java
+++ b/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/serde/OracleJsonOffsetDateTimeSerde.java
@@ -15,12 +15,12 @@
  */
 package io.micronaut.serde.oracle.jdbc.json.serde;
 
+import io.micronaut.context.annotation.Secondary;
 import io.micronaut.core.annotation.Order;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Serde;
 import io.micronaut.serde.oracle.jdbc.json.OracleJdbcJsonGeneratorEncoder;
 import io.micronaut.serde.oracle.jdbc.json.OracleJdbcJsonParserDecoder;
-import io.micronaut.serde.support.serdes.OffsetDateTimeSerde;
 import jakarta.inject.Singleton;
 
 import java.time.OffsetDateTime;
@@ -34,9 +34,9 @@ import java.time.OffsetDateTime;
 @Singleton
 @Order(-100)
 public class OracleJsonOffsetDateTimeSerde extends AbstractOracleJsonSerde<OffsetDateTime> {
-    private final OffsetDateTimeSerde offsetDateTimeSerde;
+    private final Serde<OffsetDateTime> offsetDateTimeSerde;
 
-    public OracleJsonOffsetDateTimeSerde(OffsetDateTimeSerde offsetDateTimeSerde) {
+    public OracleJsonOffsetDateTimeSerde(@Secondary Serde<OffsetDateTime> offsetDateTimeSerde) {
         this.offsetDateTimeSerde = offsetDateTimeSerde;
     }
 

--- a/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/serde/OracleJsonZonedDateTimeSerde.java
+++ b/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/serde/OracleJsonZonedDateTimeSerde.java
@@ -15,12 +15,12 @@
  */
 package io.micronaut.serde.oracle.jdbc.json.serde;
 
+import io.micronaut.context.annotation.Secondary;
 import io.micronaut.core.annotation.Order;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Serde;
 import io.micronaut.serde.oracle.jdbc.json.OracleJdbcJsonGeneratorEncoder;
 import io.micronaut.serde.oracle.jdbc.json.OracleJdbcJsonParserDecoder;
-import io.micronaut.serde.support.serdes.ZonedDateTimeSerde;
 import jakarta.inject.Singleton;
 
 import java.time.ZonedDateTime;
@@ -34,9 +34,9 @@ import java.time.ZonedDateTime;
 @Singleton
 @Order(-100)
 public class OracleJsonZonedDateTimeSerde extends AbstractOracleJsonSerde<ZonedDateTime> {
-    private final ZonedDateTimeSerde zonedDateTimeSerde;
+    private final Serde<ZonedDateTime> zonedDateTimeSerde;
 
-    public OracleJsonZonedDateTimeSerde(ZonedDateTimeSerde zonedDateTimeSerde) {
+    public OracleJsonZonedDateTimeSerde(@Secondary Serde<ZonedDateTime> zonedDateTimeSerde) {
         this.zonedDateTimeSerde = zonedDateTimeSerde;
     }
 

--- a/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeRegistry.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeRegistry.java
@@ -20,6 +20,7 @@ import io.micronaut.context.BeanResolutionContext;
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.Secondary;
 import io.micronaut.context.exceptions.ConfigurationException;
+import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
@@ -29,11 +30,9 @@ import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.order.OrderUtil;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.CollectionUtils;
-import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.BeanDefinition;
-import io.micronaut.serde.Decoder;
+import io.micronaut.inject.annotation.MutableAnnotationMetadata;
 import io.micronaut.serde.Deserializer;
-import io.micronaut.serde.Encoder;
 import io.micronaut.serde.Serde;
 import io.micronaut.serde.SerdeIntrospections;
 import io.micronaut.serde.SerdeRegistry;
@@ -44,24 +43,24 @@ import io.micronaut.serde.config.SerializationConfiguration;
 import io.micronaut.serde.config.naming.PropertyNamingStrategy;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.deserializers.ObjectDeserializer;
-import io.micronaut.serde.support.serdes.NumberSerde;
+import io.micronaut.serde.support.deserializers.SerdeDeserializationPreInstantiateCallback;
+import io.micronaut.serde.support.deserializers.collect.CoreCollectionsDeserializers;
+import io.micronaut.serde.support.serdes.ObjectArraySerde;
+import io.micronaut.serde.support.serdes.Serdes;
+import io.micronaut.serde.support.serializers.CoreSerializers;
 import io.micronaut.serde.support.serializers.ObjectSerializer;
 import io.micronaut.serde.support.util.MatchArgumentQualifier;
 import io.micronaut.serde.support.util.TypeKey;
-import io.micronaut.serde.util.BinaryCodecUtil;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -80,77 +79,162 @@ import java.util.concurrent.ConcurrentHashMap;
 @Singleton
 @BootstrapContextCompatible
 public class DefaultSerdeRegistry implements SerdeRegistry {
-
-    public static final IntegerSerde INTEGER_SERDE = new IntegerSerde();
-    public static final LongSerde LONG_SERDE = new LongSerde();
-    public static final ShortSerde SHORT_SERDE = new ShortSerde();
-    public static final FloatSerde FLOAT_SERDE = new FloatSerde();
-    public static final ByteSerde BYTE_SERDE = new ByteSerde();
-    public static final DoubleSerde DOUBLE_SERDE = new DoubleSerde();
-    public static final OptionalIntSerde OPTIONAL_INT_SERDE = new OptionalIntSerde();
-    public static final OptionalDoubleSerde OPTIONAL_DOUBLE_SERDE = new OptionalDoubleSerde();
-    public static final OptionalLongSerde OPTIONAL_LONG_SERDE = new OptionalLongSerde();
-    public static final BigDecimalSerde BIG_DECIMAL_SERDE = new BigDecimalSerde();
-    public static final BigIntegerSerde BIG_INTEGER_SERDE = new BigIntegerSerde();
-    public static final UUIDSerde UUID_SERDE = new UUIDSerde();
-    public static final URLSerde URL_SERDE = new URLSerde();
-    public static final URISerde URI_SERDE = new URISerde();
-    public static final CharsetSerde CHARSET_SERDE = new CharsetSerde();
-    public static final TimeZoneSerde TIME_ZONE_SERDE = new TimeZoneSerde();
-    public static final LocaleSerde LOCALE_SERDE = new LocaleSerde();
-    public static final IntArraySerde INT_ARRAY_SERDE = new IntArraySerde();
-    public static final LongArraySerde LONG_ARRAY_SERDE = new LongArraySerde();
-    public static final FloatArraySerde FLOAT_ARRAY_SERDE = new FloatArraySerde();
-    public static final ShortArraySerde SHORT_ARRAY_SERDE = new ShortArraySerde();
-    public static final DoubleArraySerde DOUBLE_ARRAY_SERDE = new DoubleArraySerde();
-    public static final BooleanArraySerde BOOLEAN_ARRAY_SERDE = new BooleanArraySerde();
     /**
-     * @deprecated This serde needs configuration now.
+     * @deprecated Internal serdes shouldn't be accessed as a static field
      */
-    @Deprecated
-    public static final ByteArraySerde BYTE_ARRAY_SERDE = new ByteArraySerde(true);
-    public static final CharArraySerde CHAR_ARRAY_SERDE = new CharArraySerde();
+    @Deprecated(since = "2.9.0")
+    public static final Serde<Integer> INTEGER_SERDE = Serdes.INTEGER_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<Long> LONG_SERDE = Serdes.LONG_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<Short> SHORT_SERDE = Serdes.SHORT_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<Float> FLOAT_SERDE = Serdes.FLOAT_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<Byte> BYTE_SERDE = Serdes.BYTE_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<Double> DOUBLE_SERDE = Serdes.DOUBLE_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<OptionalInt> OPTIONAL_INT_SERDE = Serdes.OPTIONAL_INT_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<OptionalDouble> OPTIONAL_DOUBLE_SERDE = Serdes.OPTIONAL_DOUBLE_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<OptionalLong> OPTIONAL_LONG_SERDE = Serdes.OPTIONAL_LONG_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<BigDecimal> BIG_DECIMAL_SERDE = Serdes.BIG_DECIMAL_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<BigInteger> BIG_INTEGER_SERDE = Serdes.BIG_INTEGER_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<UUID> UUID_SERDE = Serdes.UUID_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<URL> URL_SERDE = Serdes.URL_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<URI> URI_SERDE = Serdes.URI_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<Charset> CHARSET_SERDE = Serdes.CHARSET_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<TimeZone> TIME_ZONE_SERDE = Serdes.TIME_ZONE_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<Locale> LOCALE_SERDE = Serdes.LOCALE_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<int[]> INT_ARRAY_SERDE = Serdes.INT_ARRAY_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<long[]> LONG_ARRAY_SERDE = Serdes.LONG_ARRAY_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<float[]> FLOAT_ARRAY_SERDE = Serdes.FLOAT_ARRAY_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<short[]> SHORT_ARRAY_SERDE = Serdes.SHORT_ARRAY_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<double[]> DOUBLE_ARRAY_SERDE = Serdes.DOUBLE_ARRAY_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<boolean[]> BOOLEAN_ARRAY_SERDE = Serdes.BOOLEAN_ARRAY_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<byte[]> BYTE_ARRAY_SERDE = Serdes.BYTE_ARRAY_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<char[]> CHAR_ARRAY_SERDE = Serdes.CHAR_ARRAY_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<String> STRING_SERDE = Serdes.STRING_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<Boolean> BOOLEAN_SERDE = Serdes.BOOLEAN_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final Serde<Charset> CHAR_SERDE = Serdes.CHARSET_SERDE;
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
+    public static final List<SerdeRegistrar<?>> DEFAULT_SERDES = Serdes.LEGACY_DEFAULT_SERDES;
 
-    public static final StringSerde STRING_SERDE = new StringSerde();
+    private final List<BeanDefinition<Serializer>> serializers = new ArrayList<>(100);
+    private final List<BeanDefinition<Deserializer>> deserializers = new ArrayList<>(100);
+    private final List<BeanDefinition<Serde>> internalSerdes = new ArrayList<>(100);
 
-    public static final BooleanSerde BOOLEAN_SERDE = new BooleanSerde();
-    public static final CharSerde CHAR_SERDE = new CharSerde();
-    public static final List<SerdeRegistrar<?>> DEFAULT_SERDES = List.of(
-        BOOLEAN_SERDE,
-        BYTE_SERDE,
-        CHAR_SERDE,
-        DOUBLE_SERDE,
-        FLOAT_SERDE,
-        INTEGER_SERDE,
-        LONG_SERDE,
-        SHORT_SERDE,
-        STRING_SERDE,
-        OPTIONAL_INT_SERDE,
-        OPTIONAL_DOUBLE_SERDE,
-        OPTIONAL_LONG_SERDE,
-        BIG_DECIMAL_SERDE,
-        BIG_INTEGER_SERDE,
-        UUID_SERDE,
-        URL_SERDE,
-        URI_SERDE,
-        CHARSET_SERDE,
-        TIME_ZONE_SERDE,
-        LOCALE_SERDE,
-        INT_ARRAY_SERDE,
-        LONG_ARRAY_SERDE,
-        FLOAT_ARRAY_SERDE,
-        SHORT_ARRAY_SERDE,
-        DOUBLE_ARRAY_SERDE,
-        BOOLEAN_ARRAY_SERDE,
-        CHAR_ARRAY_SERDE
-    );
-    private final ObjectSerializer objectSerializer;
-    private final List<BeanDefinition<Serializer>> serializers;
-    private final List<BeanDefinition<Deserializer>> deserializers;
     private final Map<TypeKey, Serializer<?>> serializerMap = new ConcurrentHashMap<>(50);
     private final Map<TypeKey, Deserializer<?>> deserializerMap = new ConcurrentHashMap<>(50);
+
     private final BeanContext beanContext;
     private final SerdeIntrospections introspections;
+    private final ObjectSerializer objectSerializer;
     private final ObjectDeserializer objectDeserializer;
     private final Serde<Object[]> objectArraySerde;
     private final ConversionService conversionService;
@@ -160,73 +244,92 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
 
     /**
      * Default constructor.
-     * @param beanContext The bean context
-     * @param objectSerializer  The object serializer
-     * @param objectDeserializer The object deserializer
-     * @param objectArraySerde The object array Serde
-     * @param introspections The introspections
-     * @param conversionService The conversion service
-     * @param serdeConfiguration The {@link SerdeConfiguration}
-     * @param serializationConfiguration The {@link SerializationConfiguration}
+     *
+     * @param beanContext                  The bean context
+     * @param objectSerializer             The object serializer
+     * @param objectDeserializer           The object deserializer
+     * @param objectArraySerde             The object array Serde
+     * @param introspections               The introspections
+     * @param conversionService            The conversion service
+     * @param serdeConfiguration           The {@link SerdeConfiguration}
+     * @param serializationConfiguration   The {@link SerializationConfiguration}
+     * @param deserializationConfiguration The {@link DeserializationConfiguration}
+     * @deprecated Use {@link #DefaultSerdeRegistry(BeanContext, SerdeIntrospections, ConversionService, SerdeConfiguration, SerializationConfiguration, DeserializationConfiguration)}
+     */
+    @Deprecated(forRemoval = true, since = "2.9.0")
+    public DefaultSerdeRegistry(
+        BeanContext beanContext,
+        ObjectSerializer objectSerializer,
+        ObjectDeserializer objectDeserializer,
+        Serde<Object[]> objectArraySerde,
+        SerdeIntrospections introspections,
+        ConversionService conversionService,
+        SerdeConfiguration serdeConfiguration,
+        SerializationConfiguration serializationConfiguration,
+        DeserializationConfiguration deserializationConfiguration) {
+        this.serdeConfiguration = serdeConfiguration;
+        this.serializationConfiguration = serializationConfiguration;
+        this.deserializationConfiguration = deserializationConfiguration;
+        this.introspections = introspections;
+        this.objectArraySerde = objectArraySerde;
+        this.beanContext = beanContext;
+        this.conversionService = conversionService;
+
+        registerSerializersDeserializersFromBeanContext(beanContext);
+        registerBuiltInSerdes();
+
+        this.objectSerializer = objectSerializer;
+        this.objectDeserializer = objectDeserializer;
+    }
+
+    /**
+     * Default constructor.
+     *
+     * @param beanContext                  The bean context
+     * @param introspections               The introspections
+     * @param conversionService            The conversion service
+     * @param serdeConfiguration           The {@link SerdeConfiguration}
+     * @param serializationConfiguration   The {@link SerializationConfiguration}
      * @param deserializationConfiguration The {@link DeserializationConfiguration}
      */
     @Inject
     public DefaultSerdeRegistry(
-            BeanContext beanContext,
-            ObjectSerializer objectSerializer,
-            ObjectDeserializer objectDeserializer,
-            Serde<Object[]> objectArraySerde,
-            SerdeIntrospections introspections,
-            ConversionService conversionService,
-            SerdeConfiguration serdeConfiguration,
-            SerializationConfiguration serializationConfiguration,
-            DeserializationConfiguration deserializationConfiguration) {
+        @Nullable BeanContext beanContext,
+        SerdeIntrospections introspections,
+        ConversionService conversionService,
+        SerdeConfiguration serdeConfiguration,
+        SerializationConfiguration serializationConfiguration,
+        DeserializationConfiguration deserializationConfiguration) {
         this.serdeConfiguration = serdeConfiguration;
         this.serializationConfiguration = serializationConfiguration;
         this.deserializationConfiguration = deserializationConfiguration;
-        final Collection<BeanDefinition<Serializer>> serializersBeanDefinitions =
-                beanContext.getBeanDefinitions(Serializer.class);
-        final Collection<BeanDefinition<Deserializer>> deserializersBeanDefinitions =
-                beanContext.getBeanDefinitions(Deserializer.class);
         this.introspections = introspections;
-        this.serializers = new ArrayList<>(serializersBeanDefinitions.size() + 30); // some padding
-        this.deserializers = new ArrayList<>(deserializersBeanDefinitions.size() + 30); // some padding
-        this.objectArraySerde = objectArraySerde;
         this.beanContext = beanContext;
-        for (BeanDefinition<Serializer> serializer : serializersBeanDefinitions) {
-            final List<Argument<?>> typeArguments = serializer.getTypeArguments(Serializer.class);
-            if (CollectionUtils.isEmpty(typeArguments)) {
-                throw new ConfigurationException("Serializer without generic types defined: " + serializer.getBeanType());
-            }
-            final Argument<?> argument = typeArguments.iterator().next();
-            if (!argument.equalsType(Argument.OBJECT_ARGUMENT)) {
-                serializers.add(serializer);
-            }
-        }
-        for (BeanDefinition<Deserializer> deserializer : deserializersBeanDefinitions) {
-            final List<Argument<?>> typeArguments = deserializer.getTypeArguments(Deserializer.class);
-            if (CollectionUtils.isEmpty(typeArguments)) {
-                throw new ConfigurationException("Deserializer without generic types defined: " + deserializer.getBeanType());
-            }
-            final Argument<?> argument = typeArguments.iterator().next();
-            if (!argument.equalsType(Argument.OBJECT_ARGUMENT)) {
-                deserializers.add(deserializer);
-            }
-        }
-
-        registerBuiltInSerdes();
-        this.objectSerializer = objectSerializer;
-        this.objectDeserializer = objectDeserializer;
         this.conversionService = conversionService;
+
+        registerSerializersDeserializersFromBeanContext(beanContext);
+        registerBuiltInSerdes();
+
+        this.objectSerializer = new ObjectSerializer(
+            introspections,
+            serdeConfiguration,
+            serializationConfiguration,
+            beanContext);
+        this.objectDeserializer = new ObjectDeserializer(introspections,
+            deserializationConfiguration,
+            serdeConfiguration,
+            beanContext == null ? null : beanContext.findBean(SerdeDeserializationPreInstantiateCallback.class).orElse(null)
+        );
+        this.objectArraySerde = new ObjectArraySerde();
     }
 
     /**
-     * @param beanContext The bean context
-     * @param objectSerializer  The object serializer
+     * @param beanContext        The bean context
+     * @param objectSerializer   The object serializer
      * @param objectDeserializer The object deserializer
-     * @param objectArraySerde The object array Serde
-     * @param introspections The introspections
-     * @param conversionService The conversion service
+     * @param objectArraySerde   The object array Serde
+     * @param introspections     The introspections
+     * @param conversionService  The conversion service
      * @deprecated Use {@link #DefaultSerdeRegistry(BeanContext, ObjectSerializer, ObjectDeserializer, Serde, SerdeIntrospections, ConversionService, SerdeConfiguration, SerializationConfiguration, DeserializationConfiguration)} instead
      */
     @Deprecated
@@ -240,13 +343,42 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
         this(beanContext, objectSerializer, objectDeserializer, objectArraySerde, introspections, conversionService, beanContext.getBean(SerdeConfiguration.class), beanContext.getBean(SerializationConfiguration.class), beanContext.getBean(DeserializationConfiguration.class));
     }
 
+    private void registerSerializersDeserializersFromBeanContext(@Nullable BeanContext beanContext) {
+        if (beanContext == null) {
+            return;
+        }
+        for (BeanDefinition<Serializer> serializer : beanContext.getBeanDefinitions(Serializer.class)) {
+            if (serializer.getDeclaringType().orElse(null) == LegacyBeansFactory.class) {
+                continue;
+            }
+            final List<Argument<?>> typeArguments = serializer.getTypeArguments(Serializer.class);
+            if (CollectionUtils.isEmpty(typeArguments)) {
+                throw new ConfigurationException("Serializer without generic types defined: " + serializer.getBeanType());
+            }
+            final Argument<?> argument = typeArguments.iterator().next();
+            if (!argument.equalsType(Argument.OBJECT_ARGUMENT)) {
+                serializers.add(serializer);
+            }
+        }
+        for (BeanDefinition<Deserializer> deserializer : beanContext.getBeanDefinitions(Deserializer.class)) {
+            if (deserializer.getDeclaringType().orElse(null) == LegacyBeansFactory.class) {
+                continue;
+            }
+            final List<Argument<?>> typeArguments = deserializer.getTypeArguments(Deserializer.class);
+            if (CollectionUtils.isEmpty(typeArguments)) {
+                throw new ConfigurationException("Deserializer without generic types defined: " + deserializer.getBeanType());
+            }
+            final Argument<?> argument = typeArguments.iterator().next();
+            if (!argument.equalsType(Argument.OBJECT_ARGUMENT)) {
+                deserializers.add(deserializer);
+            }
+        }
+    }
+
     @Override
     public SerdeRegistry cloneWithConfiguration(@Nullable SerdeConfiguration configuration, @Nullable SerializationConfiguration serializationConfiguration, @Nullable DeserializationConfiguration deserializationConfiguration) {
         return new DefaultSerdeRegistry(
             beanContext,
-            objectSerializer,
-            objectDeserializer,
-            objectArraySerde,
             introspections,
             conversionService,
             configuration == null ? this.serdeConfiguration : configuration,
@@ -255,30 +387,67 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
         );
     }
 
-    private void registerBuiltInSerdes() {
-        DEFAULT_SERDES.forEach(this::register);
+    /**
+     * Find internal serde by type.
+     *
+     * @param type The serde type
+     * @param <T>  The serde type
+     * @return a serde or null
+     */
+    @Nullable
+    @Internal
+    public <T> Serde<T> findInternalSerde(Argument<T> type) {
+        for (BeanDefinition<Serde> serdeBeanDefinition : internalSerdes) {
+            if (serdeBeanDefinition instanceof InternaSerdeBeanDefinition<?> internaSerdeBeanDefinition
+                && internaSerdeBeanDefinition.typeArgument.equalsType(type)) {
+                return (Serde<T>) internaSerdeBeanDefinition.value;
+            }
+        }
+        return null;
     }
 
-    private void register(SerdeRegistrar<?> serdeRegistrar) {
-        for (Argument<?> type : serdeRegistrar.getTypes()) {
-            deserializers.add(new InternaSerdeBeanDefinition(type, Deserializer.class, serdeRegistrar));
-            serializers.add(new InternaSerdeBeanDefinition(type, Serializer.class, serdeRegistrar));
-        }
+    private void registerBuiltInSerdes() {
+        Serdes.register(serdeConfiguration, introspections, serdeRegistrar -> {
+            for (Argument<?> type : serdeRegistrar.getTypes()) {
+                deserializers.add(new InternaSerdeBeanDefinition<>(type, Deserializer.class, serdeRegistrar, serdeRegistrar.getOrder()));
+                serializers.add(new InternaSerdeBeanDefinition<>(type, Serializer.class, serdeRegistrar, serdeRegistrar.getOrder()));
+                internalSerdes.add(new InternaSerdeBeanDefinition<>(type, Serde.class, serdeRegistrar, serdeRegistrar.getOrder()));
+            }
+        });
+        CoreCollectionsDeserializers.register(conversionService, deserializerRegistrar -> {
+            for (Argument<?> type : deserializerRegistrar.getTypes()) {
+                deserializers.add(new InternaSerdeBeanDefinition<>(type, Deserializer.class, deserializerRegistrar, deserializerRegistrar.getOrder()));
+            }
+        });
+        CoreSerializers.register(serializationConfiguration, serializerRegistrar -> {
+            for (Argument<?> type : serializerRegistrar.getTypes()) {
+                serializers.add(new InternaSerdeBeanDefinition<>(type, Serializer.class, serializerRegistrar, serializerRegistrar.getOrder()));
+            }
+        });
     }
 
     @Override
     public <T, D extends Serializer<? extends T>> D findCustomSerializer(Class<? extends D> serializerClass) throws SerdeException {
+        checkBeanContext();
         return beanContext.findBean(serializerClass).orElseThrow(() -> new SerdeException("Cannot find serializer: " + serializerClass));
     }
 
     @Override
     public <T, D extends Deserializer<? extends T>> D findCustomDeserializer(Class<? extends D> deserializerClass) throws SerdeException {
+        checkBeanContext();
         return beanContext.findBean(deserializerClass).orElseThrow(() -> new SerdeException("Cannot find deserializer: " + deserializerClass));
     }
 
     @Override
     public <D extends PropertyNamingStrategy> D findNamingStrategy(Class<? extends D> namingStrategyClass) throws SerdeException {
+        checkBeanContext();
         return beanContext.findBean(namingStrategyClass).orElseThrow(() -> new SerdeException("Cannot find naming strategy: " + namingStrategyClass));
+    }
+
+    private void checkBeanContext() throws SerdeException {
+        if (beanContext == null) {
+            throw new SerdeException("No bean context present!");
+        }
     }
 
     @Override
@@ -311,15 +480,14 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
         if (key.getType().isArray()) {
             deserializerMap.put(key, objectArraySerde);
             return (Deserializer<? extends T>) objectArraySerde;
-        } else {
-            deserializerMap.put(key, objectDeserializer);
-            return (Deserializer<? extends T>) objectDeserializer;
         }
+        deserializerMap.put(key, objectDeserializer);
+        return (Deserializer<? extends T>) objectDeserializer;
     }
 
     private <T> T getBean(BeanDefinition<T> definition) {
         if (definition instanceof InternaSerdeBeanDefinition<?> internaSerdeBeanDefinition) {
-            return (T) internaSerdeBeanDefinition.getSerde();
+            return (T) internaSerdeBeanDefinition.value;
         }
         return beanContext.getBean(definition);
     }
@@ -337,6 +505,12 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
         if (serializer != null) {
             return (Serializer<? super T>) serializer;
         }
+        if (type.getType().equals(Object.class)) {
+            return objectSerializer;
+        }
+        if (type.getType().equals(Object[].class)) {
+            return (Serializer<? super T>) objectArraySerde;
+        }
 
         Collection<BeanDefinition<Serializer>> beanDefinitions = MatchArgumentQualifier.ofExtendsVariable(Serializer.class, type)
             .filter(Serializer.class, serializers);
@@ -351,6 +525,11 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
             serializerMap.put(key, ser);
             return (Serializer<? super T>) ser;
         }
+        if (key.getType().isArray()) {
+            serializerMap.put(key, objectArraySerde);
+            return (Serializer<? super T>) objectArraySerde;
+        }
+        serializerMap.put(key, objectSerializer);
         return objectSerializer;
     }
 
@@ -358,10 +537,6 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
     private <T> BeanDefinition<T> lastChanceResolve(Argument<?> type,
                                                     Collection<BeanDefinition<T>> candidates,
                                                     String beansResolved) throws SerdeException {
-        if (candidates.size() > 1) {
-            // Filter out internal definitions to find possible overrides
-            candidates = candidates.stream().filter(bd -> !(bd instanceof InternaSerdeBeanDefinition<?>)).toList();
-        }
         if (candidates.size() > 1) {
             List<BeanDefinition<T>> primary = candidates.stream().filter(BeanDefinition::isPrimary).toList();
             if (!primary.isEmpty()) {
@@ -375,27 +550,24 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
         if (candidates.size() == 1) {
             return candidates.iterator().next();
         }
-        if (candidates.stream().anyMatch(candidate -> candidate.hasAnnotation(Order.class))) {
-            // pick the bean with the highest priority
-            final Iterator<BeanDefinition<T>> i = candidates.stream()
-                    .sorted((bean1, bean2) -> {
-                        int order1 = OrderUtil.getOrder(bean1.getAnnotationMetadata());
-                        int order2 = OrderUtil.getOrder(bean2.getAnnotationMetadata());
-                        return Integer.compare(order1, order2);
-                    })
-                    .iterator();
+        // pick the bean with the highest priority
+        final Iterator<BeanDefinition<T>> i = candidates.stream()
+            .sorted((bean1, bean2) -> {
+                int order1 = OrderUtil.getOrder(bean1.getAnnotationMetadata());
+                int order2 = OrderUtil.getOrder(bean2.getAnnotationMetadata());
+                return Integer.compare(order1, order2);
+            })
+            .iterator();
+        if (i.hasNext()) {
+            final BeanDefinition<T> bean = i.next();
             if (i.hasNext()) {
-                final BeanDefinition<T> bean = i.next();
-                if (i.hasNext()) {
-                    // check there are not 2 beans with the same order
-                    final BeanDefinition<T> next = i.next();
-                    if (OrderUtil.getOrder(bean.getAnnotationMetadata()) == OrderUtil.getOrder(next.getAnnotationMetadata())) {
-                        throw new SerdeException("Multiple possible " + beansResolved + " found for type [" + type + "]: " + candidates);
-                    }
+                // check there are not 2 beans with the same order
+                final BeanDefinition<T> next = i.next();
+                if (OrderUtil.getOrder(bean.getAnnotationMetadata()) == OrderUtil.getOrder(next.getAnnotationMetadata())) {
+                    throw new SerdeException("Multiple possible " + beansResolved + " found for type [" + type + "]: " + candidates);
                 }
-                return bean;
             }
-            throw new SerdeException("Multiple possible " + beansResolved + " found for type [" + type + "]: " + candidates);
+            return bean;
         }
         throw new SerdeException("Multiple possible " + beansResolved + " found for type [" + type + "]: " + candidates);
     }
@@ -420,7 +592,7 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
             return new DefaultEncoderContext(this) {
                 @Override
                 public boolean hasView(Class<?>... views) {
-                    if (view == null || view == Object.class) {
+                    if (view == Object.class) {
                         return true;
                     }
                     for (Class<?> candidate : views) {
@@ -441,7 +613,7 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
             return new DefaultDecoderContext(this) {
                 @Override
                 public boolean hasView(Class<?>... views) {
-                    if (view == null || view == Object.class) {
+                    if (view == Object.class) {
                         return true;
                     }
                     for (Class<?> candidate : views) {
@@ -476,1153 +648,51 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
         return deserializationConfiguration;
     }
 
-    private static final class ByteSerde extends SerdeRegistrar<Byte> implements NumberSerde<Byte> {
-        @Override
-        public Byte deserialize(Decoder decoder,
-                                       DecoderContext decoderContext,
-                                       Argument<? super Byte> type) throws IOException {
-            return decoder.decodeByte();
-        }
-
-        @Override
-        public Byte deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super Byte> type) throws IOException {
-            return decoder.decodeByteNullable();
-        }
-
-        @Override
-        public void serialize(Encoder encoder,
-                              EncoderContext context,
-                              Argument<? extends Byte> type, Byte value) throws IOException {
-            encoder.encodeByte(value);
-        }
-
-        @Override
-        Argument<Byte> getType() {
-            return Argument.of(Byte.class);
-        }
-
-        @Override
-        protected Iterable<Argument<?>> getTypes() {
-            return Arrays.asList(
-                    getType(), Argument.BYTE
-            );
-        }
-
-        @Nullable
-        @Override
-        public Byte getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Byte> type) {
-            return type.isPrimitive() ? (byte) 0 : null;
-        }
-    }
-
-    private static final class DoubleSerde extends SerdeRegistrar<Double> implements NumberSerde<Double> {
-        @Override
-        public Double deserialize(Decoder decoder,
-                                        DecoderContext decoderContext,
-                                        Argument<? super Double> type) throws IOException {
-            return decoder.decodeDouble();
-        }
-
-        @Override
-        public Double deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super Double> type) throws IOException {
-            return decoder.decodeDoubleNullable();
-        }
-
-        @Override
-        public void serialize(Encoder encoder,
-                              EncoderContext context,
-                              Argument<? extends Double> type, Double value) throws IOException {
-            encoder.encodeDouble(value);
-        }
-
-        @Override
-        Argument<Double> getType() {
-            return Argument.of(Double.class);
-        }
-
-        @Override
-        protected Iterable<Argument<?>> getTypes() {
-            return Arrays.asList(
-                    getType(), Argument.DOUBLE
-            );
-        }
-
-        @Nullable
-        @Override
-        public Double getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Double> type) {
-            return type.isPrimitive() ? 0D : null;
-        }
-    }
-
-    private static final class ShortSerde extends SerdeRegistrar<Short> implements NumberSerde<Short> {
-        @Override
-        public Short deserialize(Decoder decoder,
-                                          DecoderContext decoderContext,
-                                          Argument<? super Short> type) throws IOException {
-            return decoder.decodeShort();
-        }
-
-        @Override
-        public Short deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super Short> type) throws IOException {
-            return decoder.decodeShortNullable();
-        }
-
-        @Override
-        public void serialize(Encoder encoder,
-                              EncoderContext context,
-                              Argument<? extends Short> type, Short value) throws IOException {
-            encoder.encodeShort(value);
-        }
-
-        @Override
-        Argument<Short> getType() {
-            return Argument.of(Short.class);
-        }
-
-        @Override
-        protected Iterable<Argument<?>> getTypes() {
-            return Arrays.asList(
-                    getType(), Argument.SHORT
-            );
-        }
-
-        @Nullable
-        @Override
-        public Short getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Short> type) {
-            return type.isPrimitive() ? (short) 0 : null;
-        }
-    }
-
-    private static final class FloatSerde extends SerdeRegistrar<Float> implements NumberSerde<Float> {
-        @Override
-        public Float deserialize(Decoder decoder,
-                                        DecoderContext decoderContext,
-                                        Argument<? super Float> type) throws IOException {
-            return decoder.decodeFloat();
-        }
-
-        @Override
-        public Float deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super Float> type) throws IOException {
-            return decoder.decodeFloatNullable();
-        }
-
-        @Override
-        public void serialize(Encoder encoder,
-                              EncoderContext context,
-                              Argument<? extends Float> type, Float value) throws IOException {
-            encoder.encodeFloat(value);
-        }
-
-        @Override
-        Argument<Float> getType() {
-            return Argument.of(Float.class);
-        }
-
-        @Override
-        protected Iterable<Argument<?>> getTypes() {
-            return Arrays.asList(
-                    getType(), Argument.FLOAT
-            );
-        }
-
-        @Nullable
-        @Override
-        public Float getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Float> type) {
-            return type.isPrimitive() ? 0F : null;
-        }
-    }
-
-    private static final class IntegerSerde extends SerdeRegistrar<Integer> implements NumberSerde<Integer> {
-        @Override
-        public Integer deserialize(Decoder decoder,
-                                          DecoderContext decoderContext,
-                                          Argument<? super Integer> type) throws IOException {
-            return decoder.decodeInt();
-        }
-
-        @Override
-        public Integer deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super Integer> type) throws IOException {
-            return decoder.decodeIntNullable();
-        }
-
-        @Override
-        public void serialize(Encoder encoder,
-                              EncoderContext context,
-                              Argument<? extends Integer> type, Integer value) throws IOException {
-            encoder.encodeInt(value);
-        }
-
-        @Override
-        Argument<Integer> getType() {
-            return Argument.of(Integer.class);
-        }
-
-        @Override
-        protected Iterable<Argument<?>> getTypes() {
-            return Arrays.asList(
-                    getType(), Argument.INT
-            );
-        }
-
-        @Nullable
-        @Override
-        public Integer getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Integer> type) {
-            return type.isPrimitive() ? 0 : null;
-        }
-    }
-
-    private static final class CharSerde extends SerdeRegistrar<Character> {
-        @Override
-        public Character deserialize(Decoder decoder,
-                                          DecoderContext decoderContext,
-                                          Argument<? super Character> type) throws IOException {
-            return decoder.decodeChar();
-        }
-
-        @Override
-        public Character deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super Character> type) throws IOException {
-            return decoder.decodeCharNullable();
-        }
-
-        @Override
-        public void serialize(Encoder encoder,
-                              EncoderContext context,
-                              Argument<? extends Character> type, Character value) throws IOException {
-            encoder.encodeChar(value);
-        }
-
-        @Override
-        Argument<Character> getType() {
-            return Argument.of(Character.class);
-        }
-
-        @Override
-        protected Iterable<Argument<?>> getTypes() {
-            return Arrays.asList(
-                getType(), Argument.CHAR
-            );
-        }
-
-        @Nullable
-        @Override
-        public Character getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Character> type) {
-            return type.isPrimitive() ? (char) 0 : null;
-        }
-    }
-
-    private static final class BooleanSerde extends SerdeRegistrar<Boolean> {
-        @Override
-        public Boolean deserialize(Decoder decoder,
-                                          DecoderContext decoderContext,
-                                          Argument<? super Boolean> type) throws IOException {
-            return decoder.decodeBoolean();
-        }
-
-        @Override
-        public Boolean deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super Boolean> type) throws IOException {
-            return decoder.decodeBooleanNullable();
-        }
-
-        @Override
-        public void serialize(Encoder encoder,
-                              EncoderContext context,
-                              Argument<? extends Boolean> type, Boolean value) throws IOException {
-            encoder.encodeBoolean(value);
-        }
-
-        @Override
-        Argument<Boolean> getType() {
-            return Argument.of(Boolean.class);
-        }
-
-        @Override
-        protected Iterable<Argument<?>> getTypes() {
-            return Arrays.asList(
-                getType(), Argument.BOOLEAN
-            );
-        }
-
-        @Nullable
-        @Override
-        public Boolean getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Boolean> type) {
-            return type.isPrimitive() ? false : null;
-        }
-    }
-
-    private static final class LongSerde extends SerdeRegistrar<Long> implements NumberSerde<Long> {
-        @Override
-        public Long deserialize(Decoder decoder,
-                                          DecoderContext decoderContext,
-                                          Argument<? super Long> type) throws IOException {
-            return decoder.decodeLong();
-        }
-
-        @Override
-        public Long deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super Long> type) throws IOException {
-            return decoder.decodeLongNullable();
-        }
-
-        @Override
-        public void serialize(Encoder encoder,
-                              EncoderContext context,
-                              Argument<? extends Long> type, Long value) throws IOException {
-            encoder.encodeLong(value);
-        }
-
-        @Override
-        Argument<Long> getType() {
-            return Argument.of(Long.class);
-        }
-
-        @Override
-        protected Iterable<Argument<?>> getTypes() {
-            return Arrays.asList(
-                    getType(), Argument.LONG
-            );
-        }
-
-        @Nullable
-        @Override
-        public Long getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Long> type) {
-            return type.isPrimitive() ? 0L : null;
-        }
-    }
-
-    private abstract static class SerdeRegistrar<T> implements Serde<T> {
-        @NonNull
-        abstract Argument<T> getType();
-
-        @NonNull
-        Iterable<Argument<?>> getTypes() {
-            return Collections.singleton(getType());
-        }
-
-    }
-
-    private static final class BooleanArraySerde extends SerdeRegistrar<boolean[]> {
-        @Override
-        public boolean[] deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super boolean[]> type)
-                throws IOException {
-            final Decoder arrayDecoder = decoder.decodeArray();
-            boolean[] buffer = new boolean[50];
-            int index = 0;
-            while (arrayDecoder.hasNextArrayValue()) {
-                if (buffer.length == index) {
-                    buffer = Arrays.copyOf(buffer, buffer.length * 2);
-                }
-                if (!arrayDecoder.decodeNull()) {
-                    buffer[index] = arrayDecoder.decodeBoolean();
-                }
-                index++;
-            }
-            arrayDecoder.finishStructure();
-            return Arrays.copyOf(buffer, index);
-        }
-
-        @Override
-        public boolean[] deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super boolean[]> type) throws IOException {
-            if (decoder.decodeNull()) {
-                return null;
-            }
-            return deserialize(decoder, context, type);
-        }
-
-        @Override
-        public void serialize(Encoder encoder,
-                              EncoderContext context,
-                              Argument<? extends boolean[]> type, boolean[] value) throws IOException {
-            final Encoder arrayEncoder = encoder.encodeArray(type);
-            for (boolean i : value) {
-                arrayEncoder.encodeBoolean(i);
-            }
-            arrayEncoder.finishStructure();
-        }
-
-        @Override
-        public boolean isEmpty(EncoderContext context, boolean[] value) {
-            return value == null || value.length == 0;
-        }
-
-        @Override
-        Argument<boolean[]> getType() {
-            return Argument.of(boolean[].class);
-        }
-    }
-
-    private static final class DoubleArraySerde extends SerdeRegistrar<double[]> {
-        @Override
-        public double[] deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super double[]> type)
-                throws IOException {
-            final Decoder arrayDecoder = decoder.decodeArray();
-            double[] buffer = new double[50];
-            int index = 0;
-            while (arrayDecoder.hasNextArrayValue()) {
-                if (buffer.length == index) {
-                    buffer = Arrays.copyOf(buffer, buffer.length * 2);
-                }
-                if (!arrayDecoder.decodeNull()) {
-                    buffer[index] = arrayDecoder.decodeDouble();
-                }
-                index++;
-            }
-            arrayDecoder.finishStructure();
-            return Arrays.copyOf(buffer, index);
-        }
-
-        @Override
-        public double[] deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super double[]> type) throws IOException {
-            if (decoder.decodeNull()) {
-                return null;
-            }
-            return deserialize(decoder, context, type);
-        }
-
-        @Override
-        public void serialize(Encoder encoder,
-                              EncoderContext context,
-                              Argument<? extends double[]> type, double[] value) throws IOException {
-            final Encoder arrayEncoder = encoder.encodeArray(type);
-            for (double i : value) {
-                arrayEncoder.encodeDouble(i);
-            }
-            arrayEncoder.finishStructure();
-        }
-
-        @Override
-        public boolean isEmpty(EncoderContext context, double[] value) {
-            return value == null || value.length == 0;
-        }
-
-        @Override
-        Argument<double[]> getType() {
-            return Argument.of(double[].class);
-        }
-    }
-
-    private static final class ShortArraySerde extends SerdeRegistrar<short[]> {
-        @Override
-        public short[] deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super short[]> type)
-                throws IOException {
-            final Decoder arrayDecoder = decoder.decodeArray();
-            short[] buffer = new short[50];
-            int index = 0;
-            while (arrayDecoder.hasNextArrayValue()) {
-                if (buffer.length == index) {
-                    buffer = Arrays.copyOf(buffer, buffer.length * 2);
-                }
-                if (!arrayDecoder.decodeNull()) {
-                    buffer[index] = arrayDecoder.decodeShort();
-                }
-                index++;
-            }
-            arrayDecoder.finishStructure();
-            return Arrays.copyOf(buffer, index);
-        }
-
-        @Override
-        public short[] deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super short[]> type) throws IOException {
-            if (decoder.decodeNull()) {
-                return null;
-            }
-            return deserialize(decoder, context, type);
-        }
-
-        @Override
-        public void serialize(Encoder encoder,
-                              EncoderContext context,
-                              Argument<? extends short[]> type, short[] value) throws IOException {
-            final Encoder arrayEncoder = encoder.encodeArray(type);
-            for (short i : value) {
-                arrayEncoder.encodeShort(i);
-            }
-            arrayEncoder.finishStructure();
-        }
-
-        @Override
-        public boolean isEmpty(EncoderContext context, short[] value) {
-            return value == null || value.length == 0;
-        }
-
-        @Override
-        Argument<short[]> getType() {
-            return Argument.of(short[].class);
-        }
-    }
-
-    private static final class FloatArraySerde extends SerdeRegistrar<float[]> {
-        @Override
-        public float[] deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super float[]> type)
-                throws IOException {
-            final Decoder arrayDecoder = decoder.decodeArray();
-            float[] buffer = new float[50];
-            int index = 0;
-            while (arrayDecoder.hasNextArrayValue()) {
-                if (buffer.length == index) {
-                    buffer = Arrays.copyOf(buffer, buffer.length * 2);
-                }
-                if (!arrayDecoder.decodeNull()) {
-                    buffer[index] = arrayDecoder.decodeFloat();
-                }
-                index++;
-            }
-            arrayDecoder.finishStructure();
-            return Arrays.copyOf(buffer, index);
-        }
-
-        @Override
-        public float[] deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super float[]> type) throws IOException {
-            if (decoder.decodeNull()) {
-                return null;
-            }
-            return deserialize(decoder, context, type);
-        }
-
-        @Override
-        public void serialize(Encoder encoder,
-                              EncoderContext context,
-                              Argument<? extends float[]> type, float[] value) throws IOException {
-            final Encoder arrayEncoder = encoder.encodeArray(type);
-            for (float i : value) {
-                arrayEncoder.encodeFloat(i);
-            }
-            arrayEncoder.finishStructure();
-        }
-
-        @Override
-        public boolean isEmpty(EncoderContext context, float[] value) {
-            return value == null || value.length == 0;
-        }
-
-        @Override
-        Argument<float[]> getType() {
-            return Argument.of(float[].class);
-        }
-    }
-
-    private static final class LongArraySerde extends SerdeRegistrar<long[]> {
-
-        @Override
-        public long[] deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super long[]> type)
-                throws IOException {
-            final Decoder arrayDecoder = decoder.decodeArray();
-            long[] buffer = new long[50];
-            int index = 0;
-            while (arrayDecoder.hasNextArrayValue()) {
-                if (buffer.length == index) {
-                    buffer = Arrays.copyOf(buffer, buffer.length * 2);
-                }
-                if (!arrayDecoder.decodeNull()) {
-                    buffer[index] = arrayDecoder.decodeLong();
-                }
-                index++;
-            }
-            arrayDecoder.finishStructure();
-            return Arrays.copyOf(buffer, index);
-        }
-
-        @Override
-        public long[] deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super long[]> type) throws IOException {
-            if (decoder.decodeNull()) {
-                return null;
-            }
-            return deserialize(decoder, context, type);
-        }
-
-        @Override
-        public void serialize(Encoder encoder,
-                              EncoderContext context,
-                              Argument<? extends long[]> type, long[] value) throws IOException {
-            final Encoder arrayEncoder = encoder.encodeArray(type);
-            for (long i : value) {
-                arrayEncoder.encodeLong(i);
-            }
-            arrayEncoder.finishStructure();
-        }
-
-        @Override
-        public boolean isEmpty(EncoderContext context, long[] value) {
-            return value == null || value.length == 0;
-        }
-
-        @Override
-        Argument<long[]> getType() {
-            return Argument.of(long[].class);
-        }
-    }
-
-    private static final class CharArraySerde extends SerdeRegistrar<char[]> {
-        @Override
-        public char[] deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super char[]> type)
-                throws IOException {
-            final Decoder arrayDecoder = decoder.decodeArray();
-            char[] buffer = new char[100];
-            int index = 0;
-            while (arrayDecoder.hasNextArrayValue()) {
-                if (buffer.length == index) {
-                    buffer = Arrays.copyOf(buffer, buffer.length * 2);
-                }
-                if (!arrayDecoder.decodeNull()) {
-                    buffer[index] = arrayDecoder.decodeChar();
-                }
-                index++;
-            }
-            arrayDecoder.finishStructure();
-            return Arrays.copyOf(buffer, index);
-        }
-
-        @Override
-        public char[] deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super char[]> type) throws IOException {
-            if (decoder.decodeNull()) {
-                return null;
-            }
-            return deserialize(decoder, context, type);
-        }
-
-        @Override
-        public void serialize(Encoder encoder,
-                              EncoderContext context,
-                              Argument<? extends char[]> type, char[] value) throws IOException {
-            final Encoder arrayEncoder = encoder.encodeArray(type);
-            for (char i : value) {
-                arrayEncoder.encodeChar(i);
-            }
-            arrayEncoder.finishStructure();
-        }
-
-        @Override
-        public boolean isEmpty(EncoderContext context, char[] value) {
-            return value == null || value.length == 0;
-        }
-
-        @Override
-        Argument<char[]> getType() {
-            return Argument.of(char[].class);
-        }
-    }
-
-    /**
-     * Serde for byte arrays. Nested class for binary compatibility.
-     */
-    @Singleton
-    @Internal
-    public static final class ByteArraySerde implements Serde<byte[]> {
-        private final boolean writeLegacyByteArrays;
-
-        public ByteArraySerde(SerdeConfiguration serdeConfiguration) {
-            this(serdeConfiguration.isWriteBinaryAsArray());
-        }
-
-        @Internal
-        public ByteArraySerde(boolean writeLegacyByteArrays) {
-            this.writeLegacyByteArrays = writeLegacyByteArrays;
-        }
-
-        @Override
-        public @NonNull Serializer<byte[]> createSpecific(@NonNull EncoderContext context, @NonNull Argument<? extends byte[]> type) throws SerdeException {
-            return context.getSerdeConfiguration().map(ByteArraySerde::new).orElse(this);
-        }
-
-        @Override
-        public @NonNull Deserializer<byte[]> createSpecific(@NonNull DecoderContext context, @NonNull Argument<? super byte[]> type) throws SerdeException {
-            return context.getSerdeConfiguration().map(ByteArraySerde::new).orElse(this);
-        }
-
-        @Override
-        public byte[] deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super byte[]> type)
-            throws IOException {
-            return decoder.decodeBinary();
-        }
-
-        @Override
-        public byte[] deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super byte[]> type) throws IOException {
-            return decoder.decodeBinaryNullable();
-        }
-
-        @Override
-        public void serialize(Encoder encoder,
-                              EncoderContext context,
-                              Argument<? extends byte[]> type, byte[] value) throws IOException {
-            if (writeLegacyByteArrays) {
-                BinaryCodecUtil.encodeToArray(encoder, value);
-            } else {
-                encoder.encodeBinary(value);
-            }
-        }
-
-        @Override
-        public boolean isEmpty(EncoderContext context, byte[] value) {
-            return value == null || value.length == 0;
-        }
-    }
-
-    private static final class IntArraySerde extends SerdeRegistrar<int[]> {
-        @Override
-        public int[] deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super int[]> type)
-                throws IOException {
-            final Decoder arrayDecoder = decoder.decodeArray();
-            int[] buffer = new int[50];
-            int index = 0;
-            while (arrayDecoder.hasNextArrayValue()) {
-                if (buffer.length == index) {
-                    buffer = Arrays.copyOf(buffer, buffer.length * 2);
-                }
-                if (!arrayDecoder.decodeNull()) {
-                    buffer[index] = arrayDecoder.decodeInt();
-                }
-                index++;
-            }
-            arrayDecoder.finishStructure();
-            return Arrays.copyOf(buffer, index);
-        }
-
-        @Override
-        public int[] deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super int[]> type) throws IOException {
-            if (decoder.decodeNull()) {
-                return null;
-            }
-            return deserialize(decoder, context, type);
-        }
-
-        @Override
-        public void serialize(Encoder encoder,
-                              EncoderContext context,
-                              Argument<? extends int[]> type, int[] value) throws IOException {
-            final Encoder arrayEncoder = encoder.encodeArray(type);
-            for (int i : value) {
-                arrayEncoder.encodeInt(i);
-            }
-            arrayEncoder.finishStructure();
-        }
-
-        @Override
-        public boolean isEmpty(EncoderContext context, int[] value) {
-            return value == null || value.length == 0;
-        }
-
-        @Override
-        Argument<int[]> getType() {
-            return Argument.of(int[].class);
-        }
-    }
-
-    private static final class BigDecimalSerde extends SerdeRegistrar<BigDecimal> implements NumberSerde<BigDecimal> {
-
-        @Override
-        Argument<BigDecimal> getType() {
-            return Argument.of(BigDecimal.class);
-        }
-
-        @Override
-        public void serialize(Encoder encoder, EncoderContext context, Argument<? extends BigDecimal> type, BigDecimal value)
-                throws IOException {
-            encoder.encodeBigDecimal(value);
-        }
-
-        @Override
-        public BigDecimal deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super BigDecimal> type)
-                throws IOException {
-            return decoder.decodeBigDecimal();
-        }
-
-        @Override
-        public BigDecimal deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super BigDecimal> type) throws IOException {
-            if (decoder.decodeNull()) {
-                return null;
-            }
-            return deserialize(decoder, context, type);
-        }
-    }
-
-    private static final class StringSerde extends SerdeRegistrar<String> implements Serde<String> {
-
-        @Override
-        Argument<String> getType() {
-            return Argument.of(String.class);
-        }
-
-        @Override
-        public void serialize(Encoder encoder, EncoderContext context, Argument<? extends String> type, String value)
-            throws IOException {
-            encoder.encodeString(value);
-        }
-
-        @Override
-        public String deserialize(Decoder decoder, DecoderContext context, Argument<? super String> type) throws IOException {
-            return decoder.decodeString();
-        }
-
-        @Override
-        public String deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super String> type) throws IOException {
-            return decoder.decodeStringNullable();
-        }
-    }
-
-
-    private static final class URLSerde extends SerdeRegistrar<URL> {
-
-        @Override
-        Argument<URL> getType() {
-            return Argument.of(URL.class);
-        }
-
-        @Override
-        public void serialize(Encoder encoder, EncoderContext context, Argument<? extends URL> type, URL value)
-                throws IOException {
-            encoder.encodeString(value.toString());
-        }
-
-        @Override
-        public URL deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super URL> type)
-                throws IOException {
-            return new URL(decoder.decodeString());
-        }
-
-        @Override
-        public URL deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super URL> type) throws IOException {
-            if (decoder.decodeNull()) {
-                return null;
-            }
-            return deserialize(decoder, context, type);
-        }
-    }
-
-    private static final class URISerde extends SerdeRegistrar<URI> {
-
-        @Override
-        Argument<URI> getType() {
-            return Argument.of(URI.class);
-        }
-
-        @Override
-        public void serialize(Encoder encoder, EncoderContext context, Argument<? extends URI> type, URI value)
-                throws IOException {
-            encoder.encodeString(value.toString());
-        }
-
-        @Override
-        public URI deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super URI> type)
-                throws IOException {
-            return URI.create(decoder.decodeString());
-        }
-
-        @Override
-        public URI deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super URI> type) throws IOException {
-            if (decoder.decodeNull()) {
-                return null;
-            }
-            return deserialize(decoder, context, type);
-        }
-    }
-
-    private static final class CharsetSerde extends SerdeRegistrar<Charset> {
-
-        @Override
-        Argument<Charset> getType() {
-            return Argument.of(Charset.class);
-        }
-
-        @Override
-        public void serialize(Encoder encoder, EncoderContext context, Argument<? extends Charset> type, Charset value)
-                throws IOException {
-            encoder.encodeString(value.name());
-        }
-
-        @Override
-        public Charset deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super Charset> type)
-                throws IOException {
-            return Charset.forName(decoder.decodeString());
-        }
-
-        @Override
-        public Charset deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super Charset> type) throws IOException {
-            if (decoder.decodeNull()) {
-                return null;
-            }
-            return deserialize(decoder, context, type);
-        }
-    }
-
-    private static final class TimeZoneSerde extends SerdeRegistrar<TimeZone> {
-
-        @Override
-        Argument<TimeZone> getType() {
-            return Argument.of(TimeZone.class);
-        }
-
-        @Override
-        public void serialize(Encoder encoder, EncoderContext context, Argument<? extends TimeZone> type, TimeZone value)
-                throws IOException {
-            encoder.encodeString(value.getID());
-        }
-
-        @Override
-        public TimeZone deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super TimeZone> type)
-                throws IOException {
-            return TimeZone.getTimeZone(decoder.decodeString());
-        }
-
-        @Override
-        public TimeZone deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super TimeZone> type) throws IOException {
-            if (decoder.decodeNull()) {
-                return null;
-            }
-            return deserialize(decoder, context, type);
-        }
-    }
-
-    private static final class LocaleSerde extends SerdeRegistrar<Locale> {
-
-        @Override
-        Argument<Locale> getType() {
-            return Argument.of(Locale.class);
-        }
-
-        @Override
-        public void serialize(Encoder encoder, EncoderContext context, Argument<? extends Locale> type, Locale value)
-                throws IOException {
-            encoder.encodeString(value.toLanguageTag());
-        }
-
-        @Override
-        public Locale deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super Locale> type)
-                throws IOException {
-            return StringUtils.parseLocale(decoder.decodeString());
-        }
-
-        @Override
-        public Locale deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super Locale> type) throws IOException {
-            if (decoder.decodeNull()) {
-                return null;
-            }
-            return deserialize(decoder, context, type);
-        }
-    }
-
-    private static final class UUIDSerde extends SerdeRegistrar<UUID> {
-
-        @Override
-        Argument<UUID> getType() {
-            return Argument.of(UUID.class);
-        }
-
-        @Override
-        public void serialize(Encoder encoder, EncoderContext context, Argument<? extends UUID> type, UUID value)
-                throws IOException {
-            encoder.encodeString(value.toString());
-        }
-
-        @Override
-        public UUID deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super UUID> type)
-                throws IOException {
-            return UUID.fromString(decoder.decodeString());
-        }
-
-        @Override
-        public UUID deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super UUID> type) throws IOException {
-            if (decoder.decodeNull()) {
-                return null;
-            }
-            return deserialize(decoder, context, type);
-        }
-    }
-
-    private static final class BigIntegerSerde extends SerdeRegistrar<BigInteger> implements NumberSerde<BigInteger> {
-
-        @Override
-        Argument<BigInteger> getType() {
-            return Argument.of(BigInteger.class);
-        }
-
-        @Override
-        public void serialize(Encoder encoder, EncoderContext context, Argument<? extends BigInteger> type, BigInteger value)
-                throws IOException {
-            encoder.encodeBigInteger(value);
-        }
-
-        @Override
-        public BigInteger deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super BigInteger> type)
-                throws IOException {
-            return decoder.decodeBigInteger();
-        }
-
-        @Override
-        public BigInteger deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super BigInteger> type) throws IOException {
-            return decoder.decodeBigIntegerNullable();
-        }
-    }
-
-    private static final class OptionalIntSerde extends SerdeRegistrar<OptionalInt> implements Serde<OptionalInt> {
-        @Override
-        public void serialize(Encoder encoder,
-                              EncoderContext context,
-                              Argument<? extends OptionalInt> type, OptionalInt value) throws IOException {
-            if (value.isPresent()) {
-                encoder.encodeInt(value.getAsInt());
-            } else {
-                encoder.encodeNull();
-            }
-        }
-
-        @Override
-        public OptionalInt deserialize(Decoder decoder, DecoderContext context, Argument<? super OptionalInt> type)
-                throws IOException {
-            if (decoder.decodeNull()) {
-                return OptionalInt.empty();
-            } else {
-                return OptionalInt.of(
-                        decoder.decodeInt()
-                );
-            }
-        }
-
-        @Override
-        public OptionalInt deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super OptionalInt> type) throws IOException {
-            return deserialize(decoder, context, type);
-        }
-
-        @Override
-        public OptionalInt getDefaultValue(DecoderContext context, Argument<? super OptionalInt> type) {
-            return OptionalInt.empty();
-        }
-
-        @Override
-        public boolean isEmpty(EncoderContext context, OptionalInt value) {
-            return value == null || value.isEmpty();
-        }
-
-        @Override
-        public boolean isAbsent(EncoderContext context, OptionalInt value) {
-            return value == null || value.isEmpty();
-        }
-
-        @Override
-        Argument<OptionalInt> getType() {
-            return Argument.of(OptionalInt.class);
-        }
-    }
-
-    private static final class OptionalDoubleSerde extends SerdeRegistrar<OptionalDouble> implements Serde<OptionalDouble> {
-        @Override
-        public void serialize(Encoder encoder,
-                              EncoderContext context,
-                              Argument<? extends OptionalDouble> type, OptionalDouble value) throws IOException {
-            if (value.isPresent()) {
-                encoder.encodeDouble(value.getAsDouble());
-            } else {
-                encoder.encodeNull();
-            }
-        }
-
-        @Override
-        public OptionalDouble deserialize(Decoder decoder,
-                                          DecoderContext context,
-                                          Argument<? super OptionalDouble> type) throws IOException {
-            if (decoder.decodeNull()) {
-                return OptionalDouble.empty();
-            } else {
-                return OptionalDouble.of(decoder.decodeDouble());
-            }
-        }
-
-        @Override
-        public OptionalDouble deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super OptionalDouble> type) throws IOException {
-            return deserialize(decoder, context, type);
-        }
-
-        @Override
-        public boolean isEmpty(EncoderContext context, OptionalDouble value) {
-            return value == null || value.isEmpty();
-        }
-
-        @Override
-        public boolean isAbsent(EncoderContext context, OptionalDouble value) {
-            return value == null || value.isEmpty();
-        }
-
-        @Override
-        public OptionalDouble getDefaultValue(DecoderContext context, Argument<? super OptionalDouble> type) {
-            return OptionalDouble.empty();
-        }
-
-        @Override
-        Argument<OptionalDouble> getType() {
-            return Argument.of(OptionalDouble.class);
-        }
-    }
-
-    private static final class OptionalLongSerde extends SerdeRegistrar<OptionalLong> implements Serde<OptionalLong> {
-        @Override
-        public void serialize(Encoder encoder,
-                              EncoderContext context,
-                              Argument<? extends OptionalLong> type, OptionalLong value) throws IOException {
-            if (value.isPresent()) {
-                encoder.encodeLong(value.getAsLong());
-            } else {
-                encoder.encodeNull();
-            }
-        }
-
-        @Override
-        public OptionalLong deserialize(Decoder decoder, DecoderContext context, Argument<? super OptionalLong> type)
-                throws IOException {
-            if (decoder.decodeNull()) {
-                return OptionalLong.empty();
-            } else {
-                return OptionalLong.of(decoder.decodeLong());
-            }
-        }
-
-        @Override
-        public OptionalLong deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super OptionalLong> type) throws IOException {
-            return deserialize(decoder, context, type);
-        }
-
-        @Override
-        public OptionalLong getDefaultValue(DecoderContext context, Argument<? super OptionalLong> type) {
-            return OptionalLong.empty();
-        }
-
-        @Override
-        public boolean isEmpty(EncoderContext context, OptionalLong value) {
-            return value == null || value.isEmpty();
-        }
-
-        @Override
-        public boolean isAbsent(EncoderContext context, OptionalLong value) {
-            return value == null || value.isEmpty();
-        }
-
-        @Override
-        Argument<OptionalLong> getType() {
-            return Argument.of(OptionalLong.class);
-        }
-    }
-
-    private static final class InternaSerdeBeanDefinition<T extends Serde<?>> implements BeanDefinition<T> {
+    private static final class InternaSerdeBeanDefinition<T> implements BeanDefinition<T> {
         private final Argument<?> argument;
-        private final Serde<?> serde;
+        private final Argument<?> typeArgument;
+        private final T value;
+        private final List<Argument<?>> typeParameters;
+        private final AnnotationMetadata annotationMetadata;
 
-        private InternaSerdeBeanDefinition(Argument<?> argument,
-                                           Class<?> container,
-                                           Serde<?> serde) {
-            this.argument = Argument.of(container, argument);
-            this.serde = serde;
+        private InternaSerdeBeanDefinition(Argument<?> typeArgument,
+                                           Class<T> container,
+                                           T value,
+                                           int order) {
+            this.argument = Argument.of(container, typeArgument);
+            this.value = value;
+            this.typeArgument = typeArgument;
+            this.typeParameters = List.of(argument.getTypeParameters());
+            if (order == 0) {
+                order = 10; // Assign internal serdes to a lower priority
+            }
+            MutableAnnotationMetadata mutableAnnotationMetadata = new MutableAnnotationMetadata();
+            mutableAnnotationMetadata.addAnnotation(Order.class.getName(), Map.of("value", order));
+            annotationMetadata = mutableAnnotationMetadata;
         }
 
         @Override
-        public @NonNull Argument<T> asArgument() {
+        public AnnotationMetadata getAnnotationMetadata() {
+            return annotationMetadata;
+        }
+
+        @NonNull
+        @Override
+        public Argument<T> asArgument() {
             return (Argument<T>) argument;
         }
 
+        @NonNull
         @Override
-        public @NonNull List<Argument<?>> getTypeArguments() {
-            return List.of(argument.getTypeParameters());
+        public List<Argument<?>> getTypeArguments() {
+            return typeParameters;
         }
 
+        @NonNull
         @Override
-        public @NonNull List<Argument<?>> getTypeArguments(Class<?> type) {
+        public List<Argument<?>> getTypeArguments(Class<?> type) {
             if (type == Serializer.class || type == Deserializer.class) {
-                return List.of(argument.getTypeParameters());
+                return typeParameters;
             }
             return List.of();
         }
@@ -1637,9 +707,11 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
             return true;
         }
 
-        Serde<?> getSerde() {
-            return serde;
+        @Override
+        public String toString() {
+            return argument.getTypeName();
         }
 
     }
+
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/DeserializerRegistrar.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/DeserializerRegistrar.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.order.Ordered;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Deserializer;
+
+import java.util.Collections;
+
+/**
+ * The registrar of {@link Deserializer}.
+ * @param <T> The serde type
+ */
+@Internal
+public interface DeserializerRegistrar<T> extends Deserializer<T>, Ordered {
+
+    /**
+     * @return The serde argument type
+     */
+    @NonNull
+    Argument<T> getType();
+
+    /**
+     * @return The multiple serde argument types
+     */
+    @NonNull
+    default Iterable<Argument<?>> getTypes() {
+        return Collections.singleton(getType());
+    }
+
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/LegacyBeansFactory.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/LegacyBeansFactory.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017-2021 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support;
+
+import io.micronaut.context.BeanContext;
+import io.micronaut.context.BeanProvider;
+import io.micronaut.context.annotation.Any;
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Prototype;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.Argument;
+import io.micronaut.inject.ArgumentInjectionPoint;
+import io.micronaut.inject.InjectionPoint;
+import io.micronaut.serde.Serde;
+import io.micronaut.serde.SerdeIntrospections;
+import io.micronaut.serde.config.DeserializationConfiguration;
+import io.micronaut.serde.config.SerdeConfiguration;
+import io.micronaut.serde.config.SerializationConfiguration;
+import io.micronaut.serde.support.deserializers.ObjectDeserializer;
+import io.micronaut.serde.support.deserializers.SerdeDeserializationPreInstantiateCallback;
+import io.micronaut.serde.support.serdes.ObjectArraySerde;
+import io.micronaut.serde.support.serializers.ObjectSerializer;
+import jakarta.annotation.Nullable;
+import jakarta.inject.Singleton;
+
+/**
+ * Factory for the legacy beans removed from the bean context.
+ */
+@Internal
+@Factory
+@BootstrapContextCompatible
+final class LegacyBeansFactory {
+
+    @Any
+    @Prototype
+    @BootstrapContextCompatible
+    <T> Serde<T> provideSerde(InjectionPoint<Serde<T>> serdeInjectionPoint,
+                                        BeanProvider<DefaultSerdeRegistry> serdeRegistry) {
+        if (serdeInjectionPoint instanceof ArgumentInjectionPoint<?, ?> argumentInjectionPoint) {
+            Argument typeParameter = argumentInjectionPoint.getArgument().getTypeParameters()[0];
+            if (typeParameter.getType() == Object[].class) {
+                return (Serde<T>) new ObjectArraySerde();
+            }
+            DefaultSerdeRegistry defaultSerdeRegistry = serdeRegistry.get();
+            return defaultSerdeRegistry.findInternalSerde(typeParameter);
+        }
+        return null;
+    }
+
+    @Singleton
+    @BootstrapContextCompatible
+    ObjectSerializer provideObjectSerializer(BeanContext beanContext,
+                                                       SerdeIntrospections introspections,
+                                                       SerdeConfiguration serdeConfiguration,
+                                                       SerializationConfiguration serializationConfiguration) {
+
+        return new ObjectSerializer(
+            introspections,
+            serdeConfiguration,
+            serializationConfiguration,
+            beanContext);
+    }
+
+    @Singleton
+    @BootstrapContextCompatible
+    ObjectDeserializer provideObjectDeserializer(SerdeIntrospections introspections,
+                                                           SerdeConfiguration serdeConfiguration,
+                                                           DeserializationConfiguration deserializationConfiguration,
+                                                           @Nullable SerdeDeserializationPreInstantiateCallback instantiateCallback) {
+        return new ObjectDeserializer(introspections,
+            deserializationConfiguration,
+            serdeConfiguration,
+            instantiateCallback
+        );
+    }
+
+    @Singleton
+    @BootstrapContextCompatible
+    protected ObjectArraySerde provideObjectArraySerde() {
+        return new ObjectArraySerde();
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/SerdeRegistrar.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/SerdeRegistrar.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Serde;
+
+import java.util.Collections;
+
+/**
+ * The registrar of {@link Serde}.
+ * @param <T> The serde type
+ */
+@Internal
+public interface SerdeRegistrar<T> extends Serde<T>, SerializerRegistrar<T>, DeserializerRegistrar<T> {
+
+    /**
+     * @return The serde argument type
+     */
+    @NonNull
+    Argument<T> getType();
+
+    /**
+     * @return The multiple serde argument types
+     */
+    @NonNull
+    default Iterable<Argument<?>> getTypes() {
+        return Collections.singleton(getType());
+    }
+
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/SerializerRegistrar.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/SerializerRegistrar.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.order.Ordered;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Serializer;
+
+import java.util.Collections;
+
+/**
+ * The registrar of {@link Serializer}.
+ * @param <T> The serde type
+ */
+@Internal
+public interface SerializerRegistrar<T> extends Serializer<T>, Ordered {
+
+    /**
+     * @return The serde argument type
+     */
+    @NonNull
+    Argument<T> getType();
+
+    /**
+     * @return The multiple serde argument types
+     */
+    @NonNull
+    default Iterable<Argument<?>> getTypes() {
+        return Collections.singleton(getType());
+    }
+
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/HealthResultDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/HealthResultDeserializer.java
@@ -16,6 +16,7 @@
 package io.micronaut.serde.support.deserializers;
 
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
@@ -31,6 +32,7 @@ import jakarta.inject.Singleton;
 import java.io.IOException;
 import java.util.Map;
 
+@Internal
 @Singleton
 @Requires(classes = HealthResult.class)
 final class HealthResultDeserializer implements CustomizableDeserializer<HealthResult> {

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/JsonValueDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/JsonValueDeserializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.deserializers;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.reflect.exception.InstantiationException;
 import io.micronaut.core.type.Argument;
@@ -30,6 +31,7 @@ import java.io.IOException;
  * @author Denis Stepanov
  * @since 2.5.0
  */
+@Internal
 final class JsonValueDeserializer implements Deserializer<Object> {
     private final DeserBean<? super Object> deserBean;
 

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/ObjectDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/ObjectDeserializer.java
@@ -15,8 +15,7 @@
  */
 package io.micronaut.serde.support.deserializers;
 
-import io.micronaut.context.annotation.BootstrapContextCompatible;
-import io.micronaut.context.annotation.Primary;
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.beans.BeanIntrospection;
 import io.micronaut.core.beans.exceptions.IntrospectionException;
@@ -32,7 +31,6 @@ import io.micronaut.serde.config.annotation.SerdeConfig;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.util.SerdeArgumentConf;
 import io.micronaut.serde.util.CustomizableDeserializer;
-import jakarta.inject.Singleton;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,9 +42,7 @@ import java.util.function.Supplier;
  * @author graemerocher
  * @since 1.0.0
  */
-@Singleton
-@Primary
-@BootstrapContextCompatible
+@Internal
 public class ObjectDeserializer implements CustomizableDeserializer<Object>, DeserBeanRegistry {
     private final SerdeIntrospections introspections;
     private final Map<DeserBeanKey, Supplier<DeserBean<?>>> deserBeanMap = new ConcurrentHashMap<>(50);

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/PropertiesBag.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/PropertiesBag.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.deserializers;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.beans.BeanIntrospection;
@@ -40,6 +41,7 @@ import java.util.stream.Stream;
  * @author Denis Stepanov
  * @since 1.0.0
  */
+@Internal
 final class PropertiesBag<T> {
 
     private final BeanIntrospection<T> beanIntrospection;

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SimpleObjectDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SimpleObjectDeserializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.deserializers;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.beans.BeanIntrospection;
@@ -34,6 +35,7 @@ import java.io.IOException;
  * @author Denis Stepanov
  * @since 1.0.0
  */
+@Internal
 final class SimpleObjectDeserializer implements Deserializer<Object>, UpdatingDeserializer<Object> {
     private final boolean ignoreUnknown;
     private final boolean strictNullable;

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SimpleRecordLikeObjectDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SimpleRecordLikeObjectDeserializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.deserializers;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.beans.BeanIntrospection;
@@ -32,6 +33,7 @@ import java.io.IOException;
  *
  * @author Denis Stepanov
  */
+@Internal
 final class SimpleRecordLikeObjectDeserializer implements Deserializer<Object>, UpdatingDeserializer<Object> {
     private final BeanIntrospection<Object> introspection;
     private final PropertiesBag<Object> constructorParameters;

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SubtypedExternalPropertyObjectDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SubtypedExternalPropertyObjectDeserializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.deserializers;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Deserializer;
@@ -30,6 +31,7 @@ import java.util.Map;
  * @author Denis Stepanov
  * @since 2.5.0
  */
+@Internal
 final class SubtypedExternalPropertyObjectDeserializer implements Deserializer<Object> {
 
     private final DeserializeSubtypeInfo<?> subtypeInfo;

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SubtypedPropertyObjectDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SubtypedPropertyObjectDeserializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.deserializers;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
@@ -30,6 +31,7 @@ import java.util.Map;
  * @author Denis Stepanov
  * @since 2.4.0
  */
+@Internal
 final class SubtypedPropertyObjectDeserializer implements Deserializer<Object> {
 
     private final DeserBean<? super Object> deserBean;

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/ArrayDequeDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/ArrayDequeDeserializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.deserializers.collect;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
@@ -29,6 +30,7 @@ import java.util.ArrayDeque;
  * @param <E> The item type
  * @author Denis Stepanov
  */
+@Internal
 final class ArrayDequeDeserializer<E> extends CollectionDeserializer<E, ArrayDeque<E>> {
 
     ArrayDequeDeserializer(Deserializer<? extends E> valueDeser, Argument<E> collectionItemArgument) {

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/ArrayListDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/ArrayListDeserializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.deserializers.collect;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
@@ -29,6 +30,7 @@ import java.util.ArrayList;
  * @param <E> The item type
  * @author Denis Stepanov
  */
+@Internal
 final class ArrayListDeserializer<E> extends CollectionDeserializer<E, ArrayList<E>> {
 
     ArrayListDeserializer(Deserializer<? extends E> valueDeser, Argument<E> collectionItemArgument) {

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/CollectionDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/CollectionDeserializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.deserializers.collect;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Deserializer;
@@ -29,7 +30,9 @@ import java.util.Collection;
  * @param <E> The item type
  * @author Denis Stepanov
  */
-abstract class CollectionDeserializer<E, C extends Collection<E>> implements Deserializer<C> {
+@Internal
+abstract sealed class CollectionDeserializer<E, C extends Collection<E>> implements Deserializer<C>
+    permits ArrayDequeDeserializer, ArrayListDeserializer, HashSetDeserializer, LinkedHashSetDeserializer, LinkedListDeserializer, TreeSetDeserializer {
 
     private final Deserializer<? extends E> valueDeser;
     private final Argument<E> collectionItemArgument;

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/ConvertibleValuesDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/ConvertibleValuesDeserializer.java
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.micronaut.serde.support.deserializers;
+package io.micronaut.serde.support.deserializers.collect;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.convert.ConversionService;
@@ -26,14 +27,14 @@ import io.micronaut.json.tree.JsonNode;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Deserializer;
 import io.micronaut.serde.exceptions.SerdeException;
-import jakarta.inject.Singleton;
+import io.micronaut.serde.support.DeserializerRegistrar;
 
 import java.io.IOException;
 import java.util.Optional;
 
-@Singleton
+@Internal
 @SuppressWarnings("rawtypes")
-final class ConvertibleValuesDeserializer implements Deserializer<ConvertibleValues> {
+final class ConvertibleValuesDeserializer implements DeserializerRegistrar<ConvertibleValues> {
     @NonNull
     private final ConversionService conversionService;
 
@@ -62,6 +63,11 @@ final class ConvertibleValuesDeserializer implements Deserializer<ConvertibleVal
         return new JsonNodeConvertibleValues(node, conversionService);
     }
 
+    @Override
+    public Argument<ConvertibleValues> getType() {
+        return Argument.of(ConvertibleValues.class, Argument.ofTypeVariable(Object.class, "V"));
+    }
+
     private class Specialized implements Deserializer<ConvertibleValues> {
         @Nullable
         private final Argument<Object> componentType;
@@ -84,7 +90,7 @@ final class ConvertibleValuesDeserializer implements Deserializer<ConvertibleVal
                 if (key == null) {
                     break;
                 }
-                map.put(key, componentDeserializer.deserialize(decoder, context, componentType));
+                map.put(key, componentDeserializer.deserialize(obj, context, componentType));
             }
             obj.finishStructure();
             return map;

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/CoreCollectionsDeserializers.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/CoreCollectionsDeserializers.java
@@ -15,331 +15,127 @@
  */
 package io.micronaut.serde.support.deserializers.collect;
 
-import io.micronaut.context.annotation.BootstrapContextCompatible;
-import io.micronaut.context.annotation.Factory;
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Order;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.type.Argument;
-import io.micronaut.core.util.ArrayUtils;
-import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Deserializer;
-import io.micronaut.serde.exceptions.SerdeException;
-import io.micronaut.serde.util.CustomizableDeserializer;
-import jakarta.inject.Singleton;
+import io.micronaut.serde.support.DeserializerRegistrar;
 
-import java.io.IOException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.function.Consumer;
 
 /**
- * Core deserializers.
+ * Core collections deserializers.
  */
-@Factory
-@BootstrapContextCompatible
-public class CoreCollectionsDeserializers {
+@Internal
+public final class CoreCollectionsDeserializers {
 
-    /**
-     * Deserializes array lists.
-     *
-     * @param <E> The element type
-     * @return the array list deserializer, never {@code null}
-     */
-    @Singleton
-    @Order(-100) // prioritize over hashset
-    @NonNull
-    protected <E> Deserializer<ArrayList<E>> arrayListDeserializer() {
-        return new SpecificOnlyCollectionDeserializer<>() {
+    private static final int PREFERRED_COLLECTION_OR_LIST_ORDER = -100;
+    private static final int PREFERRED_DEQUE_ORDER = -99;
+    private static final int PREFERRED_SET_ORDER = -98;
+    private static final int PREFERRED_MAP_ORDER = -97;
+
+    public static void register(ConversionService conversionService, Consumer<DeserializerRegistrar<?>> consumer) {
+        consumer.accept(new StringListDeserializer());
+        consumer.accept(new SpecificOnlyCollectionDeserializer<Object, ArrayList<Object>>(ArrayList.class) {
 
             @Override
-            protected Deserializer<ArrayList<E>> createSpecific(Argument<? super ArrayList<E>> collectionArgument,
-                                                                Argument<E> collectionItemArgument,
-                                                                Deserializer<? extends E> valueDeser) {
-                if (collectionArgument.getType().isAssignableFrom(ArrayList.class) && collectionItemArgument.getType().equals(String.class)) {
-                    return (Deserializer) StringListDeserializer.INSTANCE;
-                }
+            protected Deserializer<ArrayList<Object>> createSpecific(Argument<? super ArrayList<Object>> collectionArgument, Argument<Object> collectionItemArgument, Deserializer<?> valueDeser) {
                 return new ArrayListDeserializer<>(valueDeser, collectionItemArgument);
             }
-        };
-    }
-
-    /**
-     * Deserializes array deque.
-     *
-     * @param <E> The element type
-     * @return the array list deserializer, never {@code null}
-     */
-    @Singleton
-    @Order(-99) // prioritize over hashset
-    @NonNull
-    protected <E> Deserializer<ArrayDeque<E>> arrayDequeDeserializer() {
-        return new SpecificOnlyCollectionDeserializer<>() {
 
             @Override
-            protected Deserializer<ArrayDeque<E>> createSpecific(Argument<? super ArrayDeque<E>> collectionArgument,
-                                                                 Argument<E> collectionItemArgument,
-                                                                 Deserializer<? extends E> valueDeser) {
+            public int getOrder() {
+                return PREFERRED_COLLECTION_OR_LIST_ORDER;
+            }
+        });
+        consumer.accept(new SpecificOnlyCollectionDeserializer<Object, ArrayDeque<Object>>(ArrayDeque.class) {
+
+            @Override
+            protected Deserializer<ArrayDeque<Object>> createSpecific(Argument<? super ArrayDeque<Object>> collectionArgument, Argument<Object> collectionItemArgument, Deserializer<?> valueDeser) {
                 return new ArrayDequeDeserializer<>(valueDeser, collectionItemArgument);
             }
-        };
-    }
-
-    /**
-     * Deserializes linked lists.
-     *
-     * @param <E> The element type
-     * @return the array list deserializer, never {@code null}
-     */
-    @Singleton
-    @Order(-99) // prioritize over hashset
-    @NonNull
-    protected <E> Deserializer<LinkedList<E>> linkedListDeserializer() {
-        return new SpecificOnlyCollectionDeserializer<>() {
 
             @Override
-            protected Deserializer<LinkedList<E>> createSpecific(Argument<? super LinkedList<E>> collectionArgument,
-                                                                 Argument<E> collectionItemArgument,
-                                                                 Deserializer<? extends E> valueDeser) {
+            public int getOrder() {
+                return PREFERRED_DEQUE_ORDER;
+            }
+        });
+        consumer.accept(new SpecificOnlyCollectionDeserializer<Object, LinkedList<Object>>(LinkedList.class) {
+
+            @Override
+            protected Deserializer<LinkedList<Object>> createSpecific(Argument<? super LinkedList<Object>> collectionArgument, Argument<Object> collectionItemArgument, Deserializer<?> valueDeser) {
                 return new LinkedListDeserializer<>(valueDeser, collectionItemArgument);
             }
-        };
-    }
 
-    /**
-     * Deserializes hash sets.
-     *
-     * @param <E> The element type
-     * @return The hash set deserializer, never null
-     */
-    @NonNull
-    @Singleton
-    @Order(-50) // prioritize over enumset
-    protected <E> Deserializer<HashSet<E>> hashSetDeserializer() {
-        return new SpecificOnlyCollectionDeserializer<>() {
+        });
+        consumer.accept(new SpecificOnlyCollectionDeserializer<Object, HashSet<Object>>(HashSet.class) {
 
             @Override
-            protected Deserializer<HashSet<E>> createSpecific(Argument<? super HashSet<E>> collectionArgument,
-                                                              Argument<E> collectionItemArgument,
-                                                              Deserializer<? extends E> valueDeser) {
+            protected Deserializer<HashSet<Object>> createSpecific(Argument<? super HashSet<Object>> collectionArgument, Argument<Object> collectionItemArgument, Deserializer<?> valueDeser) {
                 return new HashSetDeserializer<>(valueDeser, collectionItemArgument);
             }
-        };
-    }
 
-    /**
-     * Deserializes default set.
-     *
-     * @param <E> The element type
-     * @return The hash set deserializer, never null
-     */
-    @NonNull
-    @Singleton
-    protected <E> Deserializer<? extends Set<E>> defaultSetDeserializer() {
-        return hashSetDeserializer();
-    }
-
-    /**
-     * Deserializes linked hash sets.
-     *
-     * @param <E> The element type
-     * @return The linked hash set deserializer, never null
-     */
-    @NonNull
-    @Singleton
-    @Order(-51) // prioritize over hashset
-    protected <E> Deserializer<LinkedHashSet<E>> linkedHashSetDeserializer() {
-        return new SpecificOnlyCollectionDeserializer<>() {
+        });
+        consumer.accept(new SpecificOnlyCollectionDeserializer<Object, LinkedHashSet<Object>>(LinkedHashSet.class) {
 
             @Override
-            protected Deserializer<LinkedHashSet<E>> createSpecific(Argument<? super LinkedHashSet<E>> collectionArgument,
-                                                                    Argument<E> collectionItemArgument,
-                                                                    Deserializer<? extends E> valueDeser) {
+            protected Deserializer<LinkedHashSet<Object>> createSpecific(Argument<? super LinkedHashSet<Object>> collectionArgument, Argument<Object> collectionItemArgument, Deserializer<?> valueDeser) {
                 return new LinkedHashSetDeserializer<>(valueDeser, collectionItemArgument);
             }
-        };
-    }
-
-    /**
-     * Deserializes linked hash sets.
-     *
-     * @param <E> The element type
-     * @return The linked hash set deserializer, never null
-     */
-    @NonNull
-    @Singleton
-    @Order(-52) // prioritize over hashset
-    protected <E> Deserializer<TreeSet<E>> treeSetDeserializer() {
-        return new SpecificOnlyCollectionDeserializer<>() {
 
             @Override
-            protected Deserializer<TreeSet<E>> createSpecific(Argument<? super TreeSet<E>> collectionArgument,
-                                                              Argument<E> collectionItemArgument,
-                                                              Deserializer<? extends E> valueDeser) {
+            public int getOrder() {
+                return PREFERRED_SET_ORDER;
+            }
+        });
+        consumer.accept(new SpecificOnlyCollectionDeserializer<Object, TreeSet<Object>>(TreeSet.class) {
+
+            @Override
+            protected Deserializer<TreeSet<Object>> createSpecific(Argument<? super TreeSet<Object>> collectionArgument, Argument<Object> collectionItemArgument, Deserializer<?> valueDeser) {
                 return new TreeSetDeserializer<>(valueDeser, collectionItemArgument);
             }
-        };
-    }
 
-    /**
-     * Deserializes hash maps.
-     *
-     * @param <K> The key type
-     * @param <V> The value type
-     * @return The hash map deserializer, never {@code null}
-     */
-    @Singleton
-    @NonNull
-    @Order(1001)
-    protected <K, V> Deserializer<LinkedHashMap<K, V>> linkedHashMapDeserializer() {
-        return new SpecificOnlyMapDeserializer<>() {
+        });
+        consumer.accept(new SpecificOnlyMapDeserializer<Object, Object, HashMap<Object, Object>>(HashMap.class) {
 
             @Override
-            protected Deserializer<LinkedHashMap<K, V>> createSpecific(Argument<K> keyType, Argument<V> valueType, Deserializer<? extends V> valueDeser) {
+            protected Deserializer<HashMap<Object, Object>> createSpecific(Argument<Object> keyType, Argument<Object> valueType, Deserializer<?> valueDeser) {
+                return new HashMapDeserializer<>(valueDeser, keyType, valueType);
+            }
+
+        });
+        consumer.accept(new SpecificOnlyMapDeserializer<Object, Object, LinkedHashMap<Object, Object>>(LinkedHashMap.class) {
+
+            @Override
+            protected Deserializer<LinkedHashMap<Object, Object>> createSpecific(Argument<Object> keyType, Argument<Object> valueType, Deserializer<?> valueDeser) {
                 return new LinkedHashMapDeserializer<>(valueDeser, keyType, valueType);
             }
-        };
-    }
-
-    /**
-     * Deserializes hash maps.
-     *
-     * @param <K> The key type
-     * @param <V> The value type
-     * @return The hash map deserializer, never {@code null}
-     */
-    @Singleton
-    @NonNull
-    @Order(1002) // prioritize over linked hash map
-    protected <K, V> Deserializer<TreeMap<K, V>> treeMapDeserializer() {
-        return new SpecificOnlyMapDeserializer<>() {
 
             @Override
-            protected Deserializer<TreeMap<K, V>> createSpecific(Argument<K> keyType, Argument<V> valueType, Deserializer<? extends V> valueDeser) {
+            public int getOrder() {
+                return PREFERRED_MAP_ORDER;
+            }
+
+        });
+        consumer.accept(new SpecificOnlyMapDeserializer<Object, Object, TreeMap<Object, Object>>(TreeMap.class) {
+
+            @Override
+            protected Deserializer<TreeMap<Object, Object>> createSpecific(Argument<Object> keyType, Argument<Object> valueType, Deserializer<?> valueDeser) {
                 return new TreeMapDeserializer<>(valueDeser, keyType, valueType);
             }
-        };
-    }
 
-    /**
-     * Deserializes optional values.
-     *
-     * @param <V> The optional type
-     * @return The optional deserializer, never {@code null}
-     */
-    @Singleton
-    @NonNull
-    protected <V> Deserializer<Optional<V>> optionalDeserializer() {
-        return new OptionalDeserializer<>();
-    }
-
-    private static class OptionalDeserializer<V> implements CustomizableDeserializer<Optional<V>> {
-
-        @Override
-        public Deserializer<Optional<V>> createSpecific(DecoderContext context, Argument<? super Optional<V>> type) throws SerdeException {
-            @SuppressWarnings("unchecked") final Argument<V> generic =
-                (Argument<V>) type.getFirstTypeVariable().orElse(null);
-            if (generic == null) {
-                throw new SerdeException("Cannot deserialize raw optional");
-            }
-            final Deserializer<? extends V> deserializer = context.findDeserializer(generic)
-                .createSpecific(context, generic);
-
-            return new Deserializer<>() {
-
-                @Override
-                public Optional<V> deserialize(Decoder decoder, DecoderContext context, Argument<? super Optional<V>> type)
-                    throws IOException {
-                    if (decoder.decodeNull()) {
-                        return Optional.empty();
-                    } else {
-                        return Optional.ofNullable(
-                            deserializer.deserialize(
-                                decoder,
-                                context,
-                                generic
-                            )
-                        );
-                    }
-                }
-
-                @Override
-                public Optional<V> deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super Optional<V>> type) throws IOException {
-                    return deserialize(decoder, context, type);
-                }
-
-                @Override
-                public Optional<V> getDefaultValue(DecoderContext context, Argument<? super Optional<V>> type) {
-                    return Optional.empty();
-                }
-            };
-        }
-    }
-
-    private abstract static class SpecificOnlyMapDeserializer<K, V, M extends Map<K, V>> implements CustomizableDeserializer<M> {
-
-        @Override
-        public Deserializer<M> createSpecific(DecoderContext context, Argument<? super M> type) throws SerdeException {
-            final Argument<?>[] generics = type.getTypeParameters();
-            if (generics.length == 2) {
-                @SuppressWarnings("unchecked") final Argument<K> keyType = (Argument<K>) generics[0];
-                @SuppressWarnings("unchecked") final Argument<V> valueType = (Argument<V>) generics[1];
-                final Deserializer<? extends V> valueDeser = valueType.equalsType(Argument.OBJECT_ARGUMENT) ? null : context.findDeserializer(valueType)
-                    .createSpecific(context, valueType);
-                return createSpecific(keyType, valueType, valueDeser);
-            }
-            return new Deserializer<>() {
-
-                @Override
-                public M deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super M> type) throws IOException {
-                    // raw map
-                    final Object o = decoder.decodeArbitrary();
-                    if (type.isInstance(o)) {
-                        return (M) o;
-                    } else if (o instanceof Map) {
-                        final M map = getDefaultValue(decoderContext, type);
-                        map.putAll((Map) o);
-                        return map;
-                    } else {
-                        throw new SerdeException("Cannot deserialize map of type [" + type + "] from value: " + o);
-                    }
-                }
-
-            };
-        }
-
-        @NonNull
-        protected abstract Deserializer<M> createSpecific(Argument<K> keyType, Argument<V> valueType, Deserializer<? extends V> valueDeser);
-
-    }
-
-    private abstract static class SpecificOnlyCollectionDeserializer<E, C extends Collection<E>> implements CustomizableDeserializer<C> {
-
-        @Override
-        public Deserializer<C> createSpecific(DecoderContext context, Argument<? super C> type) throws SerdeException {
-            final Argument<?>[] generics = type.getTypeParameters();
-            if (ArrayUtils.isEmpty(generics)) {
-                throw new SerdeException("Cannot deserialize raw list");
-            }
-            @SuppressWarnings("unchecked") final Argument<E> collectionItemArgument = (Argument<E>) generics[0];
-            final Deserializer<? extends E> valueDeser = context.findDeserializer(collectionItemArgument)
-                .createSpecific(context, collectionItemArgument);
-
-            return createSpecific(type, collectionItemArgument, valueDeser);
-        }
-
-        protected abstract Deserializer<C> createSpecific(Argument<? super C> collectionArgument,
-                                                          Argument<E> collectionItemArgument,
-                                                          Deserializer<? extends E> valueDeser);
-
+        });
+        consumer.accept(new EnumSetDeserializer<>());
+        consumer.accept(new ConvertibleValuesDeserializer(conversionService));
     }
 
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/EnumSetDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/EnumSetDeserializer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.deserializers.collect;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.ArrayUtils;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.exceptions.SerdeException;
+import io.micronaut.serde.support.DeserializerRegistrar;
+
+import java.io.IOException;
+import java.util.EnumSet;
+
+/**
+ * Deserializer for enum sets.
+ *
+ * @param <E> The enum type
+ */
+@Internal
+final class EnumSetDeserializer<E extends Enum<E>> implements DeserializerRegistrar<EnumSet<E>> {
+
+    @Override
+    public EnumSet<E> deserialize(Decoder decoder, DecoderContext context, Argument<? super EnumSet<E>> type)
+        throws IOException {
+        final Argument<?>[] generics = type.getTypeParameters();
+        if (ArrayUtils.isEmpty(generics)) {
+            throw new SerdeException("Cannot deserialize raw EnumSet");
+        }
+        @SuppressWarnings("unchecked") final Argument<E> generic = (Argument<E>) generics[0];
+        final Decoder arrayDecoder = decoder.decodeArray();
+        Class<E> enumType = generic.getType();
+        EnumSet<E> enumSet = EnumSet.noneOf(enumType);
+        while (arrayDecoder.hasNextArrayValue()) {
+            enumSet.add(
+                Enum.valueOf(enumType, arrayDecoder.decodeString())
+            );
+        }
+        arrayDecoder.finishStructure();
+        return enumSet;
+    }
+
+    @Override
+    public Argument<EnumSet<E>> getType() {
+        return (Argument) Argument.of(EnumSet.class, Argument.ofTypeVariable(Enum.class, "E"));
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/HashMapDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/HashMapDeserializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.deserializers.collect;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Deserializer;
@@ -29,6 +30,7 @@ import java.util.HashMap;
  * @param <V> The map value type
  * @author Denis Stepanov
  */
+@Internal
 final class HashMapDeserializer<K, V> extends MapDeserializer<K, V, HashMap<K, V>> {
 
     HashMapDeserializer(Deserializer<? extends V> valueDeser, Argument<K> keyArgument, Argument<V> valueArgument) {

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/HashSetDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/HashSetDeserializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.deserializers.collect;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
@@ -29,6 +30,7 @@ import java.util.HashSet;
  * @param <E> The item type
  * @author Denis Stepanov
  */
+@Internal
 final class HashSetDeserializer<E> extends CollectionDeserializer<E, HashSet<E>> {
 
     HashSetDeserializer(Deserializer<? extends E> valueDeser, Argument<E> collectionItemArgument) {

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/LinkedHashMapDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/LinkedHashMapDeserializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.deserializers.collect;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Deserializer;
@@ -29,6 +30,7 @@ import java.util.LinkedHashMap;
  * @param <V> The map value type
  * @author Denis Stepanov
  */
+@Internal
 final class LinkedHashMapDeserializer<K, V> extends MapDeserializer<K, V, LinkedHashMap<K, V>> {
 
     LinkedHashMapDeserializer(Deserializer<? extends V> valueDeser, Argument<K> keyArgument, Argument<V> valueArgument) {

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/LinkedHashSetDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/LinkedHashSetDeserializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.deserializers.collect;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
@@ -29,6 +30,7 @@ import java.util.LinkedHashSet;
  * @param <E> The item type
  * @author Denis Stepanov
  */
+@Internal
 final class LinkedHashSetDeserializer<E> extends CollectionDeserializer<E, LinkedHashSet<E>> {
 
     LinkedHashSetDeserializer(Deserializer<? extends E> valueDeser, Argument<E> collectionItemArgument) {

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/LinkedListDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/LinkedListDeserializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.deserializers.collect;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
@@ -29,6 +30,7 @@ import java.util.LinkedList;
  * @param <E> The item type
  * @author Denis Stepanov
  */
+@Internal
 final class LinkedListDeserializer<E> extends CollectionDeserializer<E, LinkedList<E>> {
 
     LinkedListDeserializer(Deserializer<? extends E> valueDeser, Argument<E> collectionItemArgument) {

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/MapDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/MapDeserializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.deserializers.collect;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.convert.exceptions.ConversionErrorException;
 import io.micronaut.core.type.Argument;
@@ -33,6 +34,7 @@ import java.util.Map;
  * @param <V> The map value type
  * @author Denis Stepanov
  */
+@Internal
 abstract class MapDeserializer<K, V, M extends Map<K, V>> implements Deserializer<M> {
 
     private final Deserializer<? extends V> valueDeser;

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/SpecificOnlyCollectionDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/SpecificOnlyCollectionDeserializer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.deserializers.collect;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.ArrayUtils;
+import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.exceptions.SerdeException;
+import io.micronaut.serde.support.DeserializerRegistrar;
+import io.micronaut.serde.util.CustomizableDeserializer;
+
+import java.util.Collection;
+
+@Internal
+abstract class SpecificOnlyCollectionDeserializer<E, C extends Collection<E>> implements CustomizableDeserializer<C>, DeserializerRegistrar<C> {
+
+    private final Class<? extends Collection> type;
+
+    SpecificOnlyCollectionDeserializer(Class<? extends Collection> type) {
+        this.type = type;
+    }
+
+    @Override
+    public Deserializer<C> createSpecific(DecoderContext context, Argument<? super C> type) throws SerdeException {
+        final Argument<?>[] generics = type.getTypeParameters();
+        if (ArrayUtils.isEmpty(generics)) {
+            throw new SerdeException("Cannot deserialize raw list");
+        }
+        @SuppressWarnings("unchecked") final Argument<E> collectionItemArgument = (Argument<E>) generics[0];
+        final Deserializer<? extends E> valueDeser = context.findDeserializer(collectionItemArgument)
+            .createSpecific(context, collectionItemArgument);
+
+        return createSpecific(type, collectionItemArgument, valueDeser);
+    }
+
+    protected abstract Deserializer<C> createSpecific(Argument<? super C> collectionArgument,
+                                                      Argument<E> collectionItemArgument,
+                                                      Deserializer<? extends E> valueDeser);
+
+    @Override
+    public Argument<C> getType() {
+        return (Argument) Argument.of(type, Argument.ofTypeVariable(Object.class, "E"));
+    }
+
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/SpecificOnlyMapDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/SpecificOnlyMapDeserializer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.deserializers.collect;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.exceptions.SerdeException;
+import io.micronaut.serde.support.DeserializerRegistrar;
+import io.micronaut.serde.util.CustomizableDeserializer;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Internal
+abstract class SpecificOnlyMapDeserializer<K, V, M extends Map<K, V>> implements CustomizableDeserializer<M>, DeserializerRegistrar<M> {
+
+    private final Class<? extends Map> type;
+
+    SpecificOnlyMapDeserializer(Class<? extends Map> type) {
+        this.type = type;
+    }
+
+    @Override
+    public Deserializer<M> createSpecific(DecoderContext context, Argument<? super M> type) throws SerdeException {
+        final Argument<?>[] generics = type.getTypeParameters();
+        if (generics.length == 2) {
+            @SuppressWarnings("unchecked") final Argument<K> keyType = (Argument<K>) generics[0];
+            @SuppressWarnings("unchecked") final Argument<V> valueType = (Argument<V>) generics[1];
+            final Deserializer<? extends V> valueDeser = valueType.equalsType(Argument.OBJECT_ARGUMENT) ? null : context.findDeserializer(valueType)
+                .createSpecific(context, valueType);
+            return createSpecific(keyType, valueType, valueDeser);
+        }
+        return new Deserializer<>() {
+
+            @Override
+            public M deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super M> type) throws IOException {
+                // raw map
+                final Object o = decoder.decodeArbitrary();
+                if (type.isInstance(o)) {
+                    return (M) o;
+                } else if (o instanceof Map) {
+                    final M map = getDefaultValue(decoderContext, type);
+                    map.putAll((Map) o);
+                    return map;
+                } else {
+                    throw new SerdeException("Cannot deserialize map of type [" + type + "] from value: " + o);
+                }
+            }
+
+        };
+    }
+
+    @NonNull
+    protected abstract Deserializer<M> createSpecific(Argument<K> keyType, Argument<V> valueType, Deserializer<? extends V> valueDeser);
+
+    @Override
+    public Argument<M> getType() {
+        return (Argument) Argument.of(type, Argument.ofTypeVariable(Object.class, "K"), Argument.ofTypeVariable(Object.class, "V"));
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/StringListDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/StringListDeserializer.java
@@ -15,10 +15,11 @@
  */
 package io.micronaut.serde.support.deserializers.collect;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
-import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.support.DeserializerRegistrar;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -28,12 +29,8 @@ import java.util.ArrayList;
  *
  * @author Denis Stepanov
  */
-final class StringListDeserializer implements Deserializer<ArrayList<String>> {
-
-    static final StringListDeserializer INSTANCE = new StringListDeserializer();
-
-    private StringListDeserializer() {
-    }
+@Internal
+final class StringListDeserializer implements DeserializerRegistrar<ArrayList<String>> {
 
     @Override
     public ArrayList<String> deserialize(Decoder decoder, DecoderContext context, Argument<? super ArrayList<String>> type) throws IOException {
@@ -57,5 +54,10 @@ final class StringListDeserializer implements Deserializer<ArrayList<String>> {
     @Override
     public ArrayList<String> getDefaultValue(DecoderContext context, Argument<? super ArrayList<String>> type) {
         return new ArrayList<>();
+    }
+
+    @Override
+    public Argument<ArrayList<String>> getType() {
+        return (Argument) Argument.of(ArrayList.class, String.class);
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/TreeMapDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/TreeMapDeserializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.deserializers.collect;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Deserializer;
@@ -29,6 +30,7 @@ import java.util.TreeMap;
  * @param <V> The map value type
  * @author Denis Stepanov
  */
+@Internal
 final class TreeMapDeserializer<K, V> extends MapDeserializer<K, V, TreeMap<K, V>> {
 
     TreeMapDeserializer(Deserializer<? extends V> valueDeser, Argument<K> keyArgument, Argument<V> valueArgument) {

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/TreeSetDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/TreeSetDeserializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.deserializers.collect;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
@@ -29,6 +30,7 @@ import java.util.TreeSet;
  * @param <E> The item type
  * @author Denis Stepanov
  */
+@Internal
 final class TreeSetDeserializer<E> extends CollectionDeserializer<E, TreeSet<E>> {
 
     TreeSetDeserializer(Deserializer<? extends E> valueDeser, Argument<E> collectionItemArgument) {

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/BigDecimalSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/BigDecimalSerde.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+@Internal
+final class BigDecimalSerde implements SerdeRegistrar<BigDecimal>, NumberSerde<BigDecimal> {
+
+    @Override
+    public Argument<BigDecimal> getType() {
+        return Argument.of(BigDecimal.class);
+    }
+
+    @Override
+    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends BigDecimal> type, BigDecimal value)
+        throws IOException {
+        encoder.encodeBigDecimal(value);
+    }
+
+    @Override
+    public BigDecimal deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super BigDecimal> type)
+        throws IOException {
+        return decoder.decodeBigDecimal();
+    }
+
+    @Override
+    public BigDecimal deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super BigDecimal> type) throws IOException {
+        if (decoder.decodeNull()) {
+            return null;
+        }
+        return deserialize(decoder, context, type);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/BigIntegerSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/BigIntegerSerde.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+@Internal
+final class BigIntegerSerde implements SerdeRegistrar<BigInteger>, NumberSerde<BigInteger> {
+
+    @Override
+    public Argument<BigInteger> getType() {
+        return Argument.of(BigInteger.class);
+    }
+
+    @Override
+    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends BigInteger> type, BigInteger value)
+        throws IOException {
+        encoder.encodeBigInteger(value);
+    }
+
+    @Override
+    public BigInteger deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super BigInteger> type)
+        throws IOException {
+        return decoder.decodeBigInteger();
+    }
+
+    @Override
+    public BigInteger deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super BigInteger> type) throws IOException {
+        return decoder.decodeBigIntegerNullable();
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/BooleanArraySerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/BooleanArraySerde.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+@Internal
+final class BooleanArraySerde implements SerdeRegistrar<boolean[]> {
+    @Override
+    public boolean[] deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super boolean[]> type)
+        throws IOException {
+        final Decoder arrayDecoder = decoder.decodeArray();
+        boolean[] buffer = new boolean[50];
+        int index = 0;
+        while (arrayDecoder.hasNextArrayValue()) {
+            if (buffer.length == index) {
+                buffer = Arrays.copyOf(buffer, buffer.length * 2);
+            }
+            if (!arrayDecoder.decodeNull()) {
+                buffer[index] = arrayDecoder.decodeBoolean();
+            }
+            index++;
+        }
+        arrayDecoder.finishStructure();
+        return Arrays.copyOf(buffer, index);
+    }
+
+    @Override
+    public boolean[] deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super boolean[]> type) throws IOException {
+        if (decoder.decodeNull()) {
+            return null;
+        }
+        return deserialize(decoder, context, type);
+    }
+
+    @Override
+    public void serialize(Encoder encoder,
+                          EncoderContext context,
+                          Argument<? extends boolean[]> type, boolean[] value) throws IOException {
+        final Encoder arrayEncoder = encoder.encodeArray(type);
+        for (boolean i : value) {
+            arrayEncoder.encodeBoolean(i);
+        }
+        arrayEncoder.finishStructure();
+    }
+
+    @Override
+    public boolean isEmpty(EncoderContext context, boolean[] value) {
+        return value == null || value.length == 0;
+    }
+
+    @Override
+    public Argument<boolean[]> getType() {
+        return Argument.of(boolean[].class);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/BooleanSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/BooleanSerde.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+final class BooleanSerde implements SerdeRegistrar<Boolean> {
+    @Override
+    public Boolean deserialize(Decoder decoder,
+                               DecoderContext decoderContext,
+                               Argument<? super Boolean> type) throws IOException {
+        return decoder.decodeBoolean();
+    }
+
+    @Override
+    public Boolean deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super Boolean> type) throws IOException {
+        return decoder.decodeBooleanNullable();
+    }
+
+    @Override
+    public void serialize(Encoder encoder,
+                          EncoderContext context,
+                          Argument<? extends Boolean> type, Boolean value) throws IOException {
+        encoder.encodeBoolean(value);
+    }
+
+    @Override
+    public Argument<Boolean> getType() {
+        return Argument.of(Boolean.class);
+    }
+
+    @Override
+    public Iterable<Argument<?>> getTypes() {
+        return Arrays.asList(
+            getType(), Argument.BOOLEAN
+        );
+    }
+
+    @Nullable
+    @Override
+    public Boolean getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Boolean> type) {
+        return type.isPrimitive() ? false : null;
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/ByteArraySerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/ByteArraySerde.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.Serializer;
+import io.micronaut.serde.config.SerdeConfiguration;
+import io.micronaut.serde.exceptions.SerdeException;
+import io.micronaut.serde.support.SerdeRegistrar;
+import io.micronaut.serde.util.BinaryCodecUtil;
+
+import java.io.IOException;
+
+/**
+ * Serde for byte arrays. Nested class for binary compatibility.
+ */
+@Internal
+final class ByteArraySerde implements SerdeRegistrar<byte[]> {
+    private final boolean writeLegacyByteArrays;
+
+    public ByteArraySerde(SerdeConfiguration serdeConfiguration) {
+        this(serdeConfiguration.isWriteBinaryAsArray());
+    }
+
+    public ByteArraySerde(boolean writeLegacyByteArrays) {
+        this.writeLegacyByteArrays = writeLegacyByteArrays;
+    }
+
+    @Override
+    public @NonNull Serializer<byte[]> createSpecific(@NonNull EncoderContext context, @NonNull Argument<? extends byte[]> type) throws SerdeException {
+        return context.getSerdeConfiguration().map(ByteArraySerde::new).orElse(this);
+    }
+
+    @Override
+    public @NonNull Deserializer<byte[]> createSpecific(@NonNull DecoderContext context, @NonNull Argument<? super byte[]> type) throws SerdeException {
+        return context.getSerdeConfiguration().map(ByteArraySerde::new).orElse(this);
+    }
+
+    @Override
+    public byte[] deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super byte[]> type)
+        throws IOException {
+        return decoder.decodeBinary();
+    }
+
+    @Override
+    public byte[] deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super byte[]> type) throws IOException {
+        return decoder.decodeBinaryNullable();
+    }
+
+    @Override
+    public void serialize(Encoder encoder,
+                          EncoderContext context,
+                          Argument<? extends byte[]> type, byte[] value) throws IOException {
+        if (writeLegacyByteArrays) {
+            BinaryCodecUtil.encodeToArray(encoder, value);
+        } else {
+            encoder.encodeBinary(value);
+        }
+    }
+
+    @Override
+    public boolean isEmpty(EncoderContext context, byte[] value) {
+        return value == null || value.length == 0;
+    }
+
+    @Override
+    public Argument<byte[]> getType() {
+        return Argument.of(byte[].class);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/ByteBufferSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/ByteBufferSerde.java
@@ -21,7 +21,7 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Encoder;
 import io.micronaut.serde.Serde;
-import jakarta.inject.Singleton;
+import io.micronaut.serde.support.SerdeRegistrar;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -30,8 +30,8 @@ import java.nio.ByteBuffer;
  * {@link Serde} implementation of {@link java.nio.ByteBuffer}.
  * This is a based on `com.fasterxml.jackson.databind.ser.std.ByteBufferSerializer` which is licenced under the Apache 2.0 licence.
  */
-@Singleton
-public class ByteBufferSerde implements Serde<ByteBuffer> {
+public class ByteBufferSerde implements SerdeRegistrar<ByteBuffer> {
+
     @Override
     public @Nullable ByteBuffer deserialize(@NonNull Decoder decoder,
                                             @NonNull DecoderContext context,
@@ -49,5 +49,10 @@ public class ByteBufferSerde implements Serde<ByteBuffer> {
         ByteBuffer copy = ByteBuffer.allocate(slice.remaining());
         copy.put(slice);
         encoder.encodeBinary(copy.array());
+    }
+
+    @Override
+    public Argument<ByteBuffer> getType() {
+        return Argument.of(ByteBuffer.class);
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/ByteSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/ByteSerde.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+@Internal
+final class ByteSerde implements SerdeRegistrar<Byte>, NumberSerde<Byte> {
+    @Override
+    public Byte deserialize(Decoder decoder,
+                            DecoderContext decoderContext,
+                            Argument<? super Byte> type) throws IOException {
+        return decoder.decodeByte();
+    }
+
+    @Override
+    public Byte deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super Byte> type) throws IOException {
+        return decoder.decodeByteNullable();
+    }
+
+    @Override
+    public void serialize(Encoder encoder,
+                          EncoderContext context,
+                          Argument<? extends Byte> type, Byte value) throws IOException {
+        encoder.encodeByte(value);
+    }
+
+    @Override
+    public Argument<Byte> getType() {
+        return Argument.of(Byte.class);
+    }
+
+    @Override
+    public Iterable<Argument<?>> getTypes() {
+        return Arrays.asList(
+            getType(), Argument.BYTE
+        );
+    }
+
+    @Nullable
+    @Override
+    public Byte getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Byte> type) {
+        return type.isPrimitive() ? (byte) 0 : null;
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/CharArraySerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/CharArraySerde.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+@Internal
+final class CharArraySerde implements SerdeRegistrar<char[]> {
+    @Override
+    public char[] deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super char[]> type)
+        throws IOException {
+        final Decoder arrayDecoder = decoder.decodeArray();
+        char[] buffer = new char[100];
+        int index = 0;
+        while (arrayDecoder.hasNextArrayValue()) {
+            if (buffer.length == index) {
+                buffer = Arrays.copyOf(buffer, buffer.length * 2);
+            }
+            if (!arrayDecoder.decodeNull()) {
+                buffer[index] = arrayDecoder.decodeChar();
+            }
+            index++;
+        }
+        arrayDecoder.finishStructure();
+        return Arrays.copyOf(buffer, index);
+    }
+
+    @Override
+    public char[] deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super char[]> type) throws IOException {
+        if (decoder.decodeNull()) {
+            return null;
+        }
+        return deserialize(decoder, context, type);
+    }
+
+    @Override
+    public void serialize(Encoder encoder,
+                          EncoderContext context,
+                          Argument<? extends char[]> type, char[] value) throws IOException {
+        final Encoder arrayEncoder = encoder.encodeArray(type);
+        for (char i : value) {
+            arrayEncoder.encodeChar(i);
+        }
+        arrayEncoder.finishStructure();
+    }
+
+    @Override
+    public boolean isEmpty(EncoderContext context, char[] value) {
+        return value == null || value.length == 0;
+    }
+
+    @Override
+    public Argument<char[]> getType() {
+        return Argument.of(char[].class);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/CharSequenceSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/CharSequenceSerde.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+
+@Internal
+final class CharSequenceSerde implements SerdeRegistrar<CharSequence> {
+
+    @Override
+    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends CharSequence> type, CharSequence value) throws IOException {
+        encoder.encodeString(value.toString());
+    }
+
+    @Override
+    public CharSequence deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super CharSequence> type) throws IOException {
+        return decoder.decodeString();
+    }
+
+    @Override
+    public CharSequence deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super CharSequence> type) throws IOException {
+        return decoder.decodeStringNullable();
+    }
+
+    @Override
+    public boolean isEmpty(EncoderContext context, CharSequence value) {
+        return value == null || value.isEmpty();
+    }
+
+    @Override
+    public Argument<CharSequence> getType() {
+        return Argument.of(CharSequence.class);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/CharSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/CharSerde.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+@Internal
+final class CharSerde implements SerdeRegistrar<Character> {
+    @Override
+    public Character deserialize(Decoder decoder,
+                                 DecoderContext decoderContext,
+                                 Argument<? super Character> type) throws IOException {
+        return decoder.decodeChar();
+    }
+
+    @Override
+    public Character deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super Character> type) throws IOException {
+        return decoder.decodeCharNullable();
+    }
+
+    @Override
+    public void serialize(Encoder encoder,
+                          EncoderContext context,
+                          Argument<? extends Character> type, Character value) throws IOException {
+        encoder.encodeChar(value);
+    }
+
+    @Override
+    public Argument<Character> getType() {
+        return Argument.of(Character.class);
+    }
+
+    @Override
+    public Iterable<Argument<?>> getTypes() {
+        return Arrays.asList(
+            getType(), Argument.CHAR
+        );
+    }
+
+    @Nullable
+    @Override
+    public Character getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Character> type) {
+        return type.isPrimitive() ? (char) 0 : null;
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/CharsetSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/CharsetSerde.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+@Internal
+final class CharsetSerde implements SerdeRegistrar<Charset> {
+
+    @Override
+    public Argument<Charset> getType() {
+        return Argument.of(Charset.class);
+    }
+
+    @Override
+    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends Charset> type, Charset value)
+        throws IOException {
+        encoder.encodeString(value.name());
+    }
+
+    @Override
+    public Charset deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super Charset> type)
+        throws IOException {
+        return Charset.forName(decoder.decodeString());
+    }
+
+    @Override
+    public Charset deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super Charset> type) throws IOException {
+        if (decoder.decodeNull()) {
+            return null;
+        }
+        return deserialize(decoder, context, type);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/CoreSerdes.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/CoreSerdes.java
@@ -15,190 +15,30 @@
  */
 package io.micronaut.serde.support.serdes;
 
-import io.micronaut.context.annotation.BootstrapContextCompatible;
-import io.micronaut.context.annotation.Factory;
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Order;
-import io.micronaut.core.type.Argument;
-import io.micronaut.json.tree.JsonNode;
-import io.micronaut.serde.Decoder;
-import io.micronaut.serde.Encoder;
 import io.micronaut.serde.Serde;
-import jakarta.inject.Singleton;
 
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.time.Duration;
 import java.time.Period;
-import java.util.Map;
 
 /**
  * Factory class for core serdes.
  */
-@Factory
-@BootstrapContextCompatible
 public class CoreSerdes {
 
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
     public static final Serde<Duration> DURATION_SERDE = new DurationSerde();
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
     public static final Serde<Period> PERIOD_SERDE = new PeriodSerde();
+    /**
+     * @deprecated Internal serdes shouldn't be accessed as a static field
+     */
+    @Deprecated(since = "2.9.0")
     public static final Serde<CharSequence> CHAR_SEQUENCE_SERDE = new CharSequenceSerde();
 
-    /**
-     * Serde used for object arrays.
-     * @return The serde
-     */
-    @Singleton
-    @NonNull
-    @BootstrapContextCompatible
-    protected Serde<Object[]> objectArraySerde() {
-        return new ObjectArraySerde();
-    }
-
-    /**
-     * Serde for duration.
-     * @return Duration serde
-     */
-    @Singleton
-    @NonNull
-    @BootstrapContextCompatible
-    protected Serde<Duration> durationSerde() {
-        return DURATION_SERDE;
-    }
-
-    /**
-     * Serde for period.
-     * @return Period serde
-     */
-    @Singleton
-    @NonNull
-    @BootstrapContextCompatible
-    protected Serde<Period> periodSerde() {
-        return PERIOD_SERDE;
-    }
-
-    /**
-     * Serde for CharSequence.
-     * @return CharSequence serde
-     */
-    @Singleton
-    @NonNull
-    @BootstrapContextCompatible
-    @Order(100) // lower priority than string
-    protected Serde<CharSequence> charSequenceSerde() {
-        return CHAR_SEQUENCE_SERDE;
-    }
-
-    /**
-     * Serde for period.
-     * @return Period serde
-     */
-    @Singleton
-    @NonNull
-    @BootstrapContextCompatible
-    protected Serde<JsonNode> jsonNodeSerde() {
-        return new Serde<JsonNode>() {
-            @Override
-            public void serialize(Encoder encoder, EncoderContext context, Argument<? extends JsonNode> type, JsonNode value)
-                    throws IOException {
-                serialize0(encoder, value);
-            }
-
-            private void serialize0(Encoder encoder, JsonNode value) throws IOException {
-                if (value == null) {
-                    value = JsonNode.nullNode();
-                }
-                if (value.isNull()) {
-                    encoder.encodeNull();
-                } else if (value.isBoolean()) {
-                    encoder.encodeBoolean(value.getBooleanValue());
-                } else if (value.isString()) {
-                    encoder.encodeString(value.getStringValue());
-                } else if (value.isNumber()) {
-                    Number numberValue = value.getNumberValue();
-                    if (numberValue instanceof Integer || numberValue instanceof Byte || numberValue instanceof Short || numberValue instanceof Long) {
-                        encoder.encodeLong(numberValue.longValue());
-                    } else if (numberValue instanceof BigInteger bi) {
-                        encoder.encodeBigInteger(bi);
-                    } else if (numberValue instanceof BigDecimal bd) {
-                        encoder.encodeBigDecimal(bd);
-                    } else {
-                        // double, float, other number types
-                        encoder.encodeDouble(numberValue.doubleValue());
-                    }
-                } else if (value.isObject()) {
-                    Encoder objectEncoder = encoder.encodeObject(Argument.of(JsonNode.class));
-                    for (Map.Entry<String, JsonNode> entry : value.entries()) {
-                        objectEncoder.encodeKey(entry.getKey());
-                        serialize0(encoder, entry.getValue());
-                    }
-                    objectEncoder.finishStructure();
-                } else if (value.isArray()) {
-                    Encoder arrayEncoder = encoder.encodeArray(Argument.of(JsonNode.class));
-                    for (JsonNode entry : value.values()) {
-                        serialize0(encoder, entry);
-                    }
-                    arrayEncoder.finishStructure();
-                } else {
-                    throw new IllegalArgumentException("Unsupported JSON node");
-                }
-            }
-
-            @Override
-            public JsonNode deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super JsonNode> type)
-                    throws IOException {
-                return decoder.decodeNode();
-            }
-        };
-    }
-
-    private static class DurationSerde implements Serde<Duration> {
-        @Override
-        public void serialize(Encoder encoder, EncoderContext context, Argument<? extends Duration> type, Duration value)
-            throws IOException {
-            encoder.encodeLong(value.toNanos());
-        }
-
-        @Override
-        public Duration deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super Duration> type)
-            throws IOException {
-            return Duration.ofNanos(decoder.decodeLong());
-        }
-    }
-
-    private static class PeriodSerde implements Serde<Period> {
-        @Override
-        public void serialize(Encoder encoder, EncoderContext context, Argument<? extends Period> type, Period value)
-            throws IOException {
-            encoder.encodeString(value.toString());
-        }
-
-        @Override
-        public Period deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super Period> type)
-            throws IOException {
-            return Period.parse(decoder.decodeString());
-        }
-    }
-
-    private static final class CharSequenceSerde implements Serde<CharSequence> {
-        @Override
-        public void serialize(Encoder encoder, EncoderContext context, Argument<? extends CharSequence> type, CharSequence value) throws IOException {
-            encoder.encodeString(value.toString());
-        }
-
-        @Override
-        public CharSequence deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super CharSequence> type) throws IOException {
-            return decoder.decodeString();
-        }
-
-        @Override
-        public CharSequence deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super CharSequence> type) throws IOException {
-            return decoder.decodeStringNullable();
-        }
-
-        @Override
-        public boolean isEmpty(EncoderContext context, CharSequence value) {
-            return value == null || value.isEmpty();
-        }
-    }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/DateSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/DateSerde.java
@@ -15,14 +15,14 @@
  */
 package io.micronaut.serde.support.serdes;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Deserializer;
 import io.micronaut.serde.Encoder;
-import io.micronaut.serde.Serde;
 import io.micronaut.serde.Serializer;
 import io.micronaut.serde.exceptions.SerdeException;
-import jakarta.inject.Singleton;
+import io.micronaut.serde.support.SerdeRegistrar;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -31,8 +31,8 @@ import java.util.Date;
 /**
  * Serde for dates.
  */
-@Singleton
-final class DateSerde implements Serde<Date> {
+@Internal
+final class DateSerde implements SerdeRegistrar<Date> {
     private static final Argument<Instant> INSTANT_ARGUMENT = Argument.of(Instant.class);
     private final InstantSerde instantSerde;
 
@@ -90,5 +90,10 @@ final class DateSerde implements Serde<Date> {
                 decoderContext,
                 INSTANT_ARGUMENT
         ));
+    }
+
+    @Override
+    public Argument<Date> getType() {
+        return Argument.of(Date.class);
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/DoubleArraySerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/DoubleArraySerde.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+@Internal
+final class DoubleArraySerde implements SerdeRegistrar<double[]> {
+
+    @Override
+    public double[] deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super double[]> type)
+        throws IOException {
+        final Decoder arrayDecoder = decoder.decodeArray();
+        double[] buffer = new double[50];
+        int index = 0;
+        while (arrayDecoder.hasNextArrayValue()) {
+            if (buffer.length == index) {
+                buffer = Arrays.copyOf(buffer, buffer.length * 2);
+            }
+            if (!arrayDecoder.decodeNull()) {
+                buffer[index] = arrayDecoder.decodeDouble();
+            }
+            index++;
+        }
+        arrayDecoder.finishStructure();
+        return Arrays.copyOf(buffer, index);
+    }
+
+    @Override
+    public double[] deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super double[]> type) throws IOException {
+        if (decoder.decodeNull()) {
+            return null;
+        }
+        return deserialize(decoder, context, type);
+    }
+
+    @Override
+    public void serialize(Encoder encoder,
+                          EncoderContext context,
+                          Argument<? extends double[]> type, double[] value) throws IOException {
+        final Encoder arrayEncoder = encoder.encodeArray(type);
+        for (double i : value) {
+            arrayEncoder.encodeDouble(i);
+        }
+        arrayEncoder.finishStructure();
+    }
+
+    @Override
+    public boolean isEmpty(EncoderContext context, double[] value) {
+        return value == null || value.length == 0;
+    }
+
+    @Override
+    public Argument<double[]> getType() {
+        return Argument.of(double[].class);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/DoubleSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/DoubleSerde.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+@Internal
+final class DoubleSerde implements SerdeRegistrar<Double>, NumberSerde<Double> {
+
+    @Override
+    public Double deserialize(Decoder decoder,
+                              DecoderContext decoderContext,
+                              Argument<? super Double> type) throws IOException {
+        return decoder.decodeDouble();
+    }
+
+    @Override
+    public Double deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super Double> type) throws IOException {
+        return decoder.decodeDoubleNullable();
+    }
+
+    @Override
+    public void serialize(Encoder encoder,
+                          EncoderContext context,
+                          Argument<? extends Double> type, Double value) throws IOException {
+        encoder.encodeDouble(value);
+    }
+
+    @Override
+    public Argument<Double> getType() {
+        return Argument.of(Double.class);
+    }
+
+    @Override
+    public Iterable<Argument<?>> getTypes() {
+        return Arrays.asList(
+            getType(), Argument.DOUBLE
+        );
+    }
+
+    @Nullable
+    @Override
+    public Double getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Double> type) {
+        return type.isPrimitive() ? 0D : null;
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/DurationSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/DurationSerde.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.time.Duration;
+
+@Internal
+final class DurationSerde implements SerdeRegistrar<Duration> {
+    @Override
+    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends Duration> type, Duration value)
+        throws IOException {
+        encoder.encodeLong(value.toNanos());
+    }
+
+    @Override
+    public Duration deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super Duration> type)
+        throws IOException {
+        return Duration.ofNanos(decoder.decodeLong());
+    }
+
+    @Override
+    public Argument<Duration> getType() {
+        return Argument.of(Duration.class);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/FloatArraySerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/FloatArraySerde.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+@Internal
+final class FloatArraySerde implements SerdeRegistrar<float[]> {
+
+    @Override
+    public float[] deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super float[]> type)
+        throws IOException {
+        final Decoder arrayDecoder = decoder.decodeArray();
+        float[] buffer = new float[50];
+        int index = 0;
+        while (arrayDecoder.hasNextArrayValue()) {
+            if (buffer.length == index) {
+                buffer = Arrays.copyOf(buffer, buffer.length * 2);
+            }
+            if (!arrayDecoder.decodeNull()) {
+                buffer[index] = arrayDecoder.decodeFloat();
+            }
+            index++;
+        }
+        arrayDecoder.finishStructure();
+        return Arrays.copyOf(buffer, index);
+    }
+
+    @Override
+    public float[] deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super float[]> type) throws IOException {
+        if (decoder.decodeNull()) {
+            return null;
+        }
+        return deserialize(decoder, context, type);
+    }
+
+    @Override
+    public void serialize(Encoder encoder,
+                          EncoderContext context,
+                          Argument<? extends float[]> type, float[] value) throws IOException {
+        final Encoder arrayEncoder = encoder.encodeArray(type);
+        for (float i : value) {
+            arrayEncoder.encodeFloat(i);
+        }
+        arrayEncoder.finishStructure();
+    }
+
+    @Override
+    public boolean isEmpty(EncoderContext context, float[] value) {
+        return value == null || value.length == 0;
+    }
+
+    @Override
+    public Argument<float[]> getType() {
+        return Argument.of(float[].class);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/FloatSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/FloatSerde.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+@Internal
+final class FloatSerde implements SerdeRegistrar<Float>, NumberSerde<Float> {
+
+    @Override
+    public Float deserialize(Decoder decoder,
+                             DecoderContext decoderContext,
+                             Argument<? super Float> type) throws IOException {
+        return decoder.decodeFloat();
+    }
+
+    @Override
+    public Float deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super Float> type) throws IOException {
+        return decoder.decodeFloatNullable();
+    }
+
+    @Override
+    public void serialize(Encoder encoder,
+                          EncoderContext context,
+                          Argument<? extends Float> type, Float value) throws IOException {
+        encoder.encodeFloat(value);
+    }
+
+    @Override
+    public Argument<Float> getType() {
+        return Argument.of(Float.class);
+    }
+
+    @Override
+    public Iterable<Argument<?>> getTypes() {
+        return Arrays.asList(
+            getType(), Argument.FLOAT
+        );
+    }
+
+    @Nullable
+    @Override
+    public Float getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Float> type) {
+        return type.isPrimitive() ? 0F : null;
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/InetAddressSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/InetAddressSerde.java
@@ -25,7 +25,7 @@ import io.micronaut.serde.Serde;
 import io.micronaut.serde.Serializer;
 import io.micronaut.serde.config.SerdeConfiguration;
 import io.micronaut.serde.exceptions.SerdeException;
-import jakarta.inject.Singleton;
+import io.micronaut.serde.support.SerdeRegistrar;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -34,8 +34,7 @@ import java.net.InetAddress;
  * {@link Serde} implementation of {@link InetAddress}.
  * This is a based on `com.fasterxml.jackson.databind.ser.std.InetAddressSerializer` which is licenced under the Apache 2.0 licence.
  */
-@Singleton
-public class InetAddressSerde implements Serde<InetAddress> {
+public class InetAddressSerde implements SerdeRegistrar<InetAddress> {
 
     private final boolean asNumeric;
 
@@ -75,5 +74,10 @@ public class InetAddressSerde implements Serde<InetAddress> {
             }
         }
         encoder.encodeString(str);
+    }
+
+    @Override
+    public Argument<InetAddress> getType() {
+        return Argument.of(InetAddress.class);
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/InstantSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/InstantSerde.java
@@ -15,8 +15,9 @@
  */
 package io.micronaut.serde.support.serdes;
 
+import io.micronaut.core.type.Argument;
 import io.micronaut.serde.config.SerdeConfiguration;
-import jakarta.inject.Singleton;
+import io.micronaut.serde.support.SerdeRegistrar;
 
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
@@ -27,8 +28,7 @@ import java.time.temporal.TemporalQuery;
  *
  * @since 1.0.0
  */
-@Singleton
-public final class InstantSerde extends NumericSupportTemporalSerde<Instant> implements TemporalSerde<Instant> {
+public final class InstantSerde extends NumericSupportTemporalSerde<Instant> implements TemporalSerde<Instant>, SerdeRegistrar<Instant> {
 
     private static final TemporalQuery<Instant> QUERY = Instant::from;
 
@@ -59,5 +59,10 @@ public final class InstantSerde extends NumericSupportTemporalSerde<Instant> imp
     @Override
     protected DefaultFormattedTemporalSerde<Instant> createSpecific(SerdeConfiguration configuration) {
         return new InstantSerde(configuration);
+    }
+
+    @Override
+    public Argument<Instant> getType() {
+        return Argument.of(Instant.class);
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/IntArraySerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/IntArraySerde.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+@Internal
+final class IntArraySerde implements SerdeRegistrar<int[]> {
+
+    @Override
+    public int[] deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super int[]> type)
+        throws IOException {
+        final Decoder arrayDecoder = decoder.decodeArray();
+        int[] buffer = new int[50];
+        int index = 0;
+        while (arrayDecoder.hasNextArrayValue()) {
+            if (buffer.length == index) {
+                buffer = Arrays.copyOf(buffer, buffer.length * 2);
+            }
+            if (!arrayDecoder.decodeNull()) {
+                buffer[index] = arrayDecoder.decodeInt();
+            }
+            index++;
+        }
+        arrayDecoder.finishStructure();
+        return Arrays.copyOf(buffer, index);
+    }
+
+    @Override
+    public int[] deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super int[]> type) throws IOException {
+        if (decoder.decodeNull()) {
+            return null;
+        }
+        return deserialize(decoder, context, type);
+    }
+
+    @Override
+    public void serialize(Encoder encoder,
+                          EncoderContext context,
+                          Argument<? extends int[]> type, int[] value) throws IOException {
+        final Encoder arrayEncoder = encoder.encodeArray(type);
+        for (int i : value) {
+            arrayEncoder.encodeInt(i);
+        }
+        arrayEncoder.finishStructure();
+    }
+
+    @Override
+    public boolean isEmpty(EncoderContext context, int[] value) {
+        return value == null || value.length == 0;
+    }
+
+    @Override
+    public Argument<int[]> getType() {
+        return Argument.of(int[].class);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/IntegerSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/IntegerSerde.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+@Internal
+final class IntegerSerde implements SerdeRegistrar<Integer>, NumberSerde<Integer> {
+
+    @Override
+    public Integer deserialize(Decoder decoder,
+                               DecoderContext decoderContext,
+                               Argument<? super Integer> type) throws IOException {
+        return decoder.decodeInt();
+    }
+
+    @Override
+    public Integer deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super Integer> type) throws IOException {
+        return decoder.decodeIntNullable();
+    }
+
+    @Override
+    public void serialize(Encoder encoder,
+                          EncoderContext context,
+                          Argument<? extends Integer> type, Integer value) throws IOException {
+        encoder.encodeInt(value);
+    }
+
+    @Override
+    public Argument<Integer> getType() {
+        return Argument.of(Integer.class);
+    }
+
+    @Override
+    public Iterable<Argument<?>> getTypes() {
+        return Arrays.asList(
+            getType(), Argument.INT
+        );
+    }
+
+    @Nullable
+    @Override
+    public Integer getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Integer> type) {
+        return type.isPrimitive() ? 0 : null;
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/JsonNodeSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/JsonNodeSerde.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.Argument;
+import io.micronaut.json.tree.JsonNode;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Map;
+
+@Internal
+final class JsonNodeSerde implements SerdeRegistrar<JsonNode> {
+
+    @Override
+    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends JsonNode> type, JsonNode value)
+        throws IOException {
+        serialize0(encoder, value);
+    }
+
+    private void serialize0(Encoder encoder, JsonNode value) throws IOException {
+        if (value == null) {
+            value = JsonNode.nullNode();
+        }
+        if (value.isNull()) {
+            encoder.encodeNull();
+        } else if (value.isBoolean()) {
+            encoder.encodeBoolean(value.getBooleanValue());
+        } else if (value.isString()) {
+            encoder.encodeString(value.getStringValue());
+        } else if (value.isNumber()) {
+            Number numberValue = value.getNumberValue();
+            if (numberValue instanceof Integer || numberValue instanceof Byte || numberValue instanceof Short || numberValue instanceof Long) {
+                encoder.encodeLong(numberValue.longValue());
+            } else if (numberValue instanceof BigInteger bi) {
+                encoder.encodeBigInteger(bi);
+            } else if (numberValue instanceof BigDecimal bd) {
+                encoder.encodeBigDecimal(bd);
+            } else {
+                // double, float, other number types
+                encoder.encodeDouble(numberValue.doubleValue());
+            }
+        } else if (value.isObject()) {
+            Encoder objectEncoder = encoder.encodeObject(Argument.of(JsonNode.class));
+            for (Map.Entry<String, JsonNode> entry : value.entries()) {
+                objectEncoder.encodeKey(entry.getKey());
+                serialize0(encoder, entry.getValue());
+            }
+            objectEncoder.finishStructure();
+        } else if (value.isArray()) {
+            Encoder arrayEncoder = encoder.encodeArray(Argument.of(JsonNode.class));
+            for (JsonNode entry : value.values()) {
+                serialize0(encoder, entry);
+            }
+            arrayEncoder.finishStructure();
+        } else {
+            throw new IllegalArgumentException("Unsupported JSON node");
+        }
+    }
+
+    @Override
+    public JsonNode deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super JsonNode> type)
+        throws IOException {
+        return decoder.decodeNode();
+    }
+
+    @Override
+    public Argument<JsonNode> getType() {
+        return Argument.of(JsonNode.class);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/LocalDateSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/LocalDateSerde.java
@@ -15,9 +15,10 @@
  */
 package io.micronaut.serde.support.serdes;
 
+import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Encoder;
 import io.micronaut.serde.config.SerdeConfiguration;
-import jakarta.inject.Singleton;
+import io.micronaut.serde.support.SerdeRegistrar;
 
 import java.io.IOException;
 import java.time.DateTimeException;
@@ -30,8 +31,7 @@ import java.time.temporal.TemporalQuery;
  * Local date serde. Slightly different to {@link NumericSupportTemporalSerde}, we only support one
  * unit (epoch day)
  */
-@Singleton
-public final class LocalDateSerde extends DefaultFormattedTemporalSerde<LocalDate> implements TemporalSerde<LocalDate> {
+public final class LocalDateSerde extends DefaultFormattedTemporalSerde<LocalDate> implements TemporalSerde<LocalDate>, SerdeRegistrar<LocalDate> {
     private final boolean writeNumeric;
 
     /**
@@ -73,5 +73,10 @@ public final class LocalDateSerde extends DefaultFormattedTemporalSerde<LocalDat
             throw exc;
         }
         return LocalDate.ofEpochDay(l);
+    }
+
+    @Override
+    public Argument<LocalDate> getType() {
+        return Argument.of(LocalDate.class);
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/LocalDateTimeSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/LocalDateTimeSerde.java
@@ -15,8 +15,9 @@
  */
 package io.micronaut.serde.support.serdes;
 
+import io.micronaut.core.type.Argument;
 import io.micronaut.serde.config.SerdeConfiguration;
-import jakarta.inject.Singleton;
+import io.micronaut.serde.support.SerdeRegistrar;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -27,9 +28,8 @@ import java.time.temporal.TemporalQuery;
  *
  * @since 1.0.0
  */
-@Singleton
 public final class LocalDateTimeSerde extends DefaultFormattedTemporalSerde<LocalDateTime>
-        implements TemporalSerde<LocalDateTime> {
+        implements TemporalSerde<LocalDateTime>, SerdeRegistrar<LocalDateTime> {
 
     LocalDateTimeSerde(SerdeConfiguration configuration) {
         super(configuration, DateTimeFormatter.ISO_DATE_TIME);
@@ -43,5 +43,10 @@ public final class LocalDateTimeSerde extends DefaultFormattedTemporalSerde<Loca
     @Override
     protected DefaultFormattedTemporalSerde<LocalDateTime> createSpecific(SerdeConfiguration configuration) {
         return new LocalDateTimeSerde(configuration);
+    }
+
+    @Override
+    public Argument<LocalDateTime> getType() {
+        return Argument.of(LocalDateTime.class);
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/LocalTimeSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/LocalTimeSerde.java
@@ -15,8 +15,9 @@
  */
 package io.micronaut.serde.support.serdes;
 
+import io.micronaut.core.type.Argument;
 import io.micronaut.serde.config.SerdeConfiguration;
-import jakarta.inject.Singleton;
+import io.micronaut.serde.support.SerdeRegistrar;
 
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
@@ -28,8 +29,7 @@ import java.time.temporal.TemporalQuery;
  *
  * @since 1.0.0
  */
-@Singleton
-public final class LocalTimeSerde extends NumericSupportTemporalSerde<LocalTime> {
+public final class LocalTimeSerde extends NumericSupportTemporalSerde<LocalTime> implements SerdeRegistrar<LocalTime> {
     /**
      * Allows configuring a default time format for temporal date/time types.
      *
@@ -62,5 +62,10 @@ public final class LocalTimeSerde extends NumericSupportTemporalSerde<LocalTime>
     @Override
     protected DefaultFormattedTemporalSerde<LocalTime> createSpecific(SerdeConfiguration configuration) {
         return new LocalTimeSerde(configuration);
+    }
+
+    @Override
+    public Argument<LocalTime> getType() {
+        return Argument.of(LocalTime.class);
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/LocaleSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/LocaleSerde.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.StringUtils;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.util.Locale;
+
+@Internal
+final class LocaleSerde implements SerdeRegistrar<Locale> {
+
+    @Override
+    public Argument<Locale> getType() {
+        return Argument.of(Locale.class);
+    }
+
+    @Override
+    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends Locale> type, Locale value)
+        throws IOException {
+        encoder.encodeString(value.toLanguageTag());
+    }
+
+    @Override
+    public Locale deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super Locale> type)
+        throws IOException {
+        return StringUtils.parseLocale(decoder.decodeString());
+    }
+
+    @Override
+    public Locale deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super Locale> type) throws IOException {
+        if (decoder.decodeNull()) {
+            return null;
+        }
+        return deserialize(decoder, context, type);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/LongArraySerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/LongArraySerde.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+final class LongArraySerde implements SerdeRegistrar<long[]> {
+
+    @Override
+    public long[] deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super long[]> type)
+        throws IOException {
+        final Decoder arrayDecoder = decoder.decodeArray();
+        long[] buffer = new long[50];
+        int index = 0;
+        while (arrayDecoder.hasNextArrayValue()) {
+            if (buffer.length == index) {
+                buffer = Arrays.copyOf(buffer, buffer.length * 2);
+            }
+            if (!arrayDecoder.decodeNull()) {
+                buffer[index] = arrayDecoder.decodeLong();
+            }
+            index++;
+        }
+        arrayDecoder.finishStructure();
+        return Arrays.copyOf(buffer, index);
+    }
+
+    @Override
+    public long[] deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super long[]> type) throws IOException {
+        if (decoder.decodeNull()) {
+            return null;
+        }
+        return deserialize(decoder, context, type);
+    }
+
+    @Override
+    public void serialize(Encoder encoder,
+                          EncoderContext context,
+                          Argument<? extends long[]> type, long[] value) throws IOException {
+        final Encoder arrayEncoder = encoder.encodeArray(type);
+        for (long i : value) {
+            arrayEncoder.encodeLong(i);
+        }
+        arrayEncoder.finishStructure();
+    }
+
+    @Override
+    public boolean isEmpty(EncoderContext context, long[] value) {
+        return value == null || value.length == 0;
+    }
+
+    @Override
+    public Argument<long[]> getType() {
+        return Argument.of(long[].class);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/LongSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/LongSerde.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+final class LongSerde implements SerdeRegistrar<Long>, NumberSerde<Long> {
+    @Override
+    public Long deserialize(Decoder decoder,
+                            DecoderContext decoderContext,
+                            Argument<? super Long> type) throws IOException {
+        return decoder.decodeLong();
+    }
+
+    @Override
+    public Long deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super Long> type) throws IOException {
+        return decoder.decodeLongNullable();
+    }
+
+    @Override
+    public void serialize(Encoder encoder,
+                          EncoderContext context,
+                          Argument<? extends Long> type, Long value) throws IOException {
+        encoder.encodeLong(value);
+    }
+
+    @Override
+    public Argument<Long> getType() {
+        return Argument.of(Long.class);
+    }
+
+    @Override
+    public Iterable<Argument<?>> getTypes() {
+        return Arrays.asList(
+            getType(), Argument.LONG
+        );
+    }
+
+    @Nullable
+    @Override
+    public Long getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Long> type) {
+        return type.isPrimitive() ? 0L : null;
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/ObjectArraySerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/ObjectArraySerde.java
@@ -17,9 +17,9 @@ package io.micronaut.serde.support.serdes;
 
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Deserializer;
-import io.micronaut.serde.Serde;
 import io.micronaut.serde.Serializer;
 import io.micronaut.serde.exceptions.SerdeException;
+import io.micronaut.serde.support.SerdeRegistrar;
 import io.micronaut.serde.util.CustomizableDeserializer;
 import io.micronaut.serde.util.CustomizableSerializer;
 
@@ -29,11 +29,11 @@ import io.micronaut.serde.util.CustomizableSerializer;
  * @author graemerocher
  * @since 1.0.0
  */
-public class ObjectArraySerde implements Serde<Object[]>, CustomizableSerializer<Object[]>, CustomizableDeserializer<Object[]> {
+public class ObjectArraySerde implements SerdeRegistrar<Object[]>, CustomizableSerializer<Object[]>, CustomizableDeserializer<Object[]> {
+
     @Override
     public Deserializer<Object[]> createSpecific(DecoderContext context, Argument<? super Object[]> type)
             throws SerdeException {
-
         final Argument<Object> componentType = Argument.of((Class<Object>) type.getType().getComponentType());
         final Deserializer<?> deserializer = context.findDeserializer(componentType).createSpecific(context, componentType);
         return new CustomizedObjectArrayDeserializer(componentType, deserializer);
@@ -41,12 +41,13 @@ public class ObjectArraySerde implements Serde<Object[]>, CustomizableSerializer
 
     @Override
     public Serializer<Object[]> createSpecific(EncoderContext context, Argument<? extends Object[]> type) throws SerdeException {
-        Class<?> arrayItemType = type.getType().getComponentType();
-        if (arrayItemType == String.class) {
-            return (Serializer) StringArraySerializer.INSTANCE;
-        }
-        final Argument<Object> componentType = Argument.of((Class<Object>) arrayItemType);
+        final Argument<Object> componentType = Argument.of((Class<Object>) type.getType().getComponentType());
         final Serializer<? super Object> serializer = context.findSerializer(componentType).createSpecific(context, componentType);
         return new CustomizedObjectArraySerializer(componentType, serializer);
+    }
+
+    @Override
+    public Argument<Object[]> getType() {
+        return Argument.of(Object[].class);
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/OffsetDateTimeSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/OffsetDateTimeSerde.java
@@ -15,8 +15,9 @@
  */
 package io.micronaut.serde.support.serdes;
 
+import io.micronaut.core.type.Argument;
 import io.micronaut.serde.config.SerdeConfiguration;
-import jakarta.inject.Singleton;
+import io.micronaut.serde.support.SerdeRegistrar;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -26,8 +27,7 @@ import java.time.temporal.TemporalQuery;
 /**
  * Serde for OffsetDateTime.
  */
-@Singleton
-public final class OffsetDateTimeSerde extends NumericSupportTemporalSerde<OffsetDateTime> {
+public final class OffsetDateTimeSerde extends NumericSupportTemporalSerde<OffsetDateTime> implements SerdeRegistrar<OffsetDateTime> {
     /**
      * Allows configuring a default time format for temporal date/time types.
      *
@@ -67,5 +67,10 @@ public final class OffsetDateTimeSerde extends NumericSupportTemporalSerde<Offse
     @Override
     protected DefaultFormattedTemporalSerde<OffsetDateTime> createSpecific(SerdeConfiguration configuration) {
         return new OffsetDateTimeSerde(configuration);
+    }
+
+    @Override
+    public Argument<OffsetDateTime> getType() {
+        return Argument.of(OffsetDateTime.class);
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/OptionalDoubleSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/OptionalDoubleSerde.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.util.OptionalDouble;
+
+@Internal
+final class OptionalDoubleSerde implements SerdeRegistrar<OptionalDouble> {
+
+    @Override
+    public void serialize(Encoder encoder,
+                          EncoderContext context,
+                          Argument<? extends OptionalDouble> type, OptionalDouble value) throws IOException {
+        if (value.isPresent()) {
+            encoder.encodeDouble(value.getAsDouble());
+        } else {
+            encoder.encodeNull();
+        }
+    }
+
+    @Override
+    public OptionalDouble deserialize(Decoder decoder,
+                                      DecoderContext context,
+                                      Argument<? super OptionalDouble> type) throws IOException {
+        if (decoder.decodeNull()) {
+            return OptionalDouble.empty();
+        } else {
+            return OptionalDouble.of(decoder.decodeDouble());
+        }
+    }
+
+    @Override
+    public OptionalDouble deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super OptionalDouble> type) throws IOException {
+        return deserialize(decoder, context, type);
+    }
+
+    @Override
+    public boolean isEmpty(EncoderContext context, OptionalDouble value) {
+        return value == null || value.isEmpty();
+    }
+
+    @Override
+    public boolean isAbsent(EncoderContext context, OptionalDouble value) {
+        return value == null || value.isEmpty();
+    }
+
+    @Override
+    public OptionalDouble getDefaultValue(DecoderContext context, Argument<? super OptionalDouble> type) {
+        return OptionalDouble.empty();
+    }
+
+    @Override
+    public Argument<OptionalDouble> getType() {
+        return Argument.of(OptionalDouble.class);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/OptionalIntSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/OptionalIntSerde.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.util.OptionalInt;
+
+@Internal
+final class OptionalIntSerde implements SerdeRegistrar<OptionalInt> {
+
+    @Override
+    public void serialize(Encoder encoder,
+                          EncoderContext context,
+                          Argument<? extends OptionalInt> type, OptionalInt value) throws IOException {
+        if (value.isPresent()) {
+            encoder.encodeInt(value.getAsInt());
+        } else {
+            encoder.encodeNull();
+        }
+    }
+
+    @Override
+    public OptionalInt deserialize(Decoder decoder, DecoderContext context, Argument<? super OptionalInt> type)
+        throws IOException {
+        if (decoder.decodeNull()) {
+            return OptionalInt.empty();
+        } else {
+            return OptionalInt.of(
+                decoder.decodeInt()
+            );
+        }
+    }
+
+    @Override
+    public OptionalInt deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super OptionalInt> type) throws IOException {
+        return deserialize(decoder, context, type);
+    }
+
+    @Override
+    public OptionalInt getDefaultValue(DecoderContext context, Argument<? super OptionalInt> type) {
+        return OptionalInt.empty();
+    }
+
+    @Override
+    public boolean isEmpty(EncoderContext context, OptionalInt value) {
+        return value == null || value.isEmpty();
+    }
+
+    @Override
+    public boolean isAbsent(EncoderContext context, OptionalInt value) {
+        return value == null || value.isEmpty();
+    }
+
+    @Override
+    public Argument<OptionalInt> getType() {
+        return Argument.of(OptionalInt.class);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/OptionalLongSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/OptionalLongSerde.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.util.OptionalLong;
+
+@Internal
+final class OptionalLongSerde implements SerdeRegistrar<OptionalLong> {
+
+    @Override
+    public void serialize(Encoder encoder,
+                          EncoderContext context,
+                          Argument<? extends OptionalLong> type, OptionalLong value) throws IOException {
+        if (value.isPresent()) {
+            encoder.encodeLong(value.getAsLong());
+        } else {
+            encoder.encodeNull();
+        }
+    }
+
+    @Override
+    public OptionalLong deserialize(Decoder decoder, DecoderContext context, Argument<? super OptionalLong> type)
+        throws IOException {
+        if (decoder.decodeNull()) {
+            return OptionalLong.empty();
+        } else {
+            return OptionalLong.of(decoder.decodeLong());
+        }
+    }
+
+    @Override
+    public OptionalLong deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super OptionalLong> type) throws IOException {
+        return deserialize(decoder, context, type);
+    }
+
+    @Override
+    public OptionalLong getDefaultValue(DecoderContext context, Argument<? super OptionalLong> type) {
+        return OptionalLong.empty();
+    }
+
+    @Override
+    public boolean isEmpty(EncoderContext context, OptionalLong value) {
+        return value == null || value.isEmpty();
+    }
+
+    @Override
+    public boolean isAbsent(EncoderContext context, OptionalLong value) {
+        return value == null || value.isEmpty();
+    }
+
+    @Override
+    public Argument<OptionalLong> getType() {
+        return Argument.of(OptionalLong.class);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/PeriodSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/PeriodSerde.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.time.Period;
+
+@Internal
+final class PeriodSerde implements SerdeRegistrar<Period> {
+
+    @Override
+    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends Period> type, Period value)
+        throws IOException {
+        encoder.encodeString(value.toString());
+    }
+
+    @Override
+    public Period deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super Period> type)
+        throws IOException {
+        return Period.parse(decoder.decodeString());
+    }
+
+    @Override
+    public Argument<Period> getType() {
+        return Argument.of(Period.class);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/Serdes.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/Serdes.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.serde.SerdeIntrospections;
+import io.micronaut.serde.config.SerdeConfiguration;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Internal Serdes registrar.
+ *
+ * @author Denis Stepanov
+ * @since 2.9.0
+ */
+@Internal
+public final class Serdes {
+
+    public static final IntegerSerde INTEGER_SERDE = new IntegerSerde();
+    public static final LongSerde LONG_SERDE = new LongSerde();
+    public static final ShortSerde SHORT_SERDE = new ShortSerde();
+    public static final FloatSerde FLOAT_SERDE = new FloatSerde();
+    public static final ByteSerde BYTE_SERDE = new ByteSerde();
+    public static final DoubleSerde DOUBLE_SERDE = new DoubleSerde();
+    public static final OptionalIntSerde OPTIONAL_INT_SERDE = new OptionalIntSerde();
+    public static final OptionalDoubleSerde OPTIONAL_DOUBLE_SERDE = new OptionalDoubleSerde();
+    public static final OptionalLongSerde OPTIONAL_LONG_SERDE = new OptionalLongSerde();
+    public static final BigDecimalSerde BIG_DECIMAL_SERDE = new BigDecimalSerde();
+    public static final BigIntegerSerde BIG_INTEGER_SERDE = new BigIntegerSerde();
+    public static final UUIDSerde UUID_SERDE = new UUIDSerde();
+    public static final URLSerde URL_SERDE = new URLSerde();
+    public static final URISerde URI_SERDE = new URISerde();
+    public static final CharsetSerde CHARSET_SERDE = new CharsetSerde();
+    public static final TimeZoneSerde TIME_ZONE_SERDE = new TimeZoneSerde();
+    public static final LocaleSerde LOCALE_SERDE = new LocaleSerde();
+    public static final IntArraySerde INT_ARRAY_SERDE = new IntArraySerde();
+    public static final LongArraySerde LONG_ARRAY_SERDE = new LongArraySerde();
+    public static final FloatArraySerde FLOAT_ARRAY_SERDE = new FloatArraySerde();
+    public static final ShortArraySerde SHORT_ARRAY_SERDE = new ShortArraySerde();
+    public static final DoubleArraySerde DOUBLE_ARRAY_SERDE = new DoubleArraySerde();
+    public static final BooleanArraySerde BOOLEAN_ARRAY_SERDE = new BooleanArraySerde();
+    public static final ByteArraySerde BYTE_ARRAY_SERDE = new ByteArraySerde(true);
+    public static final CharArraySerde CHAR_ARRAY_SERDE = new CharArraySerde();
+
+    public static final StringSerde STRING_SERDE = new StringSerde();
+
+    public static final BooleanSerde BOOLEAN_SERDE = new BooleanSerde();
+    public static final CharSerde CHAR_SERDE = new CharSerde();
+    public static final List<SerdeRegistrar<?>> LEGACY_DEFAULT_SERDES = List.of(
+        BOOLEAN_SERDE,
+        BYTE_SERDE,
+        CHAR_SERDE,
+        DOUBLE_SERDE,
+        FLOAT_SERDE,
+        INTEGER_SERDE,
+        LONG_SERDE,
+        SHORT_SERDE,
+        STRING_SERDE,
+        OPTIONAL_INT_SERDE,
+        OPTIONAL_DOUBLE_SERDE,
+        OPTIONAL_LONG_SERDE,
+        BIG_DECIMAL_SERDE,
+        BIG_INTEGER_SERDE,
+        UUID_SERDE,
+        URL_SERDE,
+        URI_SERDE,
+        CHARSET_SERDE,
+        TIME_ZONE_SERDE,
+        LOCALE_SERDE,
+        INT_ARRAY_SERDE,
+        LONG_ARRAY_SERDE,
+        FLOAT_ARRAY_SERDE,
+        SHORT_ARRAY_SERDE,
+        DOUBLE_ARRAY_SERDE,
+        BOOLEAN_ARRAY_SERDE,
+        CHAR_ARRAY_SERDE
+    );
+
+    private static final List<SerdeRegistrar<?>> SERDES = List.of(
+        new DurationSerde(),
+        new JsonNodeSerde(),
+        new PeriodSerde(),
+        new ByteBufferSerde(),
+        new StringArraySerde(),
+        new OptionalSerde<>()
+    );
+
+    public static void register(SerdeConfiguration serdeConfiguration,
+                                SerdeIntrospections introspections,
+                                Consumer<SerdeRegistrar<?>> consumer) {
+        LEGACY_DEFAULT_SERDES.forEach(consumer);
+        consumer.accept(new ByteArraySerde(serdeConfiguration));
+        SERDES.forEach(consumer);
+        InstantSerde instantSerde = new InstantSerde(serdeConfiguration);
+        consumer.accept(instantSerde);
+        consumer.accept(new DateSerde(instantSerde));
+        LocalDateSerde localDateSerde = new LocalDateSerde(serdeConfiguration);
+        consumer.accept(localDateSerde);
+        consumer.accept(new LocalTimeSerde(serdeConfiguration));
+        consumer.accept(new LocalDateTimeSerde(serdeConfiguration));
+        consumer.accept(new OffsetDateTimeSerde(serdeConfiguration));
+        consumer.accept(new SqlDateSerde(localDateSerde));
+        consumer.accept(new SqlTimestampSerde(instantSerde));
+        consumer.accept(new YearSerde());
+        consumer.accept(new ZonedDateTimeSerde(serdeConfiguration));
+        consumer.accept(new EnumSerde<>(introspections));
+        consumer.accept(new InetAddressSerde(serdeConfiguration));
+    }
+
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/ShortArraySerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/ShortArraySerde.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+@Internal
+final class ShortArraySerde implements SerdeRegistrar<short[]> {
+    @Override
+    public short[] deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super short[]> type)
+        throws IOException {
+        final Decoder arrayDecoder = decoder.decodeArray();
+        short[] buffer = new short[50];
+        int index = 0;
+        while (arrayDecoder.hasNextArrayValue()) {
+            if (buffer.length == index) {
+                buffer = Arrays.copyOf(buffer, buffer.length * 2);
+            }
+            if (!arrayDecoder.decodeNull()) {
+                buffer[index] = arrayDecoder.decodeShort();
+            }
+            index++;
+        }
+        arrayDecoder.finishStructure();
+        return Arrays.copyOf(buffer, index);
+    }
+
+    @Override
+    public short[] deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super short[]> type) throws IOException {
+        if (decoder.decodeNull()) {
+            return null;
+        }
+        return deserialize(decoder, context, type);
+    }
+
+    @Override
+    public void serialize(Encoder encoder,
+                          EncoderContext context,
+                          Argument<? extends short[]> type, short[] value) throws IOException {
+        final Encoder arrayEncoder = encoder.encodeArray(type);
+        for (short i : value) {
+            arrayEncoder.encodeShort(i);
+        }
+        arrayEncoder.finishStructure();
+    }
+
+    @Override
+    public boolean isEmpty(EncoderContext context, short[] value) {
+        return value == null || value.length == 0;
+    }
+
+    @Override
+    public Argument<short[]> getType() {
+        return Argument.of(short[].class);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/ShortSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/ShortSerde.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+@Internal
+final class ShortSerde implements SerdeRegistrar<Short>, NumberSerde<Short> {
+    @Override
+    public Short deserialize(Decoder decoder,
+                             DecoderContext decoderContext,
+                             Argument<? super Short> type) throws IOException {
+        return decoder.decodeShort();
+    }
+
+    @Override
+    public Short deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super Short> type) throws IOException {
+        return decoder.decodeShortNullable();
+    }
+
+    @Override
+    public void serialize(Encoder encoder,
+                          EncoderContext context,
+                          Argument<? extends Short> type, Short value) throws IOException {
+        encoder.encodeShort(value);
+    }
+
+    @Override
+    public Argument<Short> getType() {
+        return Argument.of(Short.class);
+    }
+
+    @Override
+    public Iterable<Argument<?>> getTypes() {
+        return Arrays.asList(
+            getType(), Argument.SHORT
+        );
+    }
+
+    @Nullable
+    @Override
+    public Short getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Short> type) {
+        return type.isPrimitive() ? (short) 0 : null;
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/SqlDateSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/SqlDateSerde.java
@@ -15,15 +15,13 @@
  */
 package io.micronaut.serde.support.serdes;
 
-import io.micronaut.context.annotation.Secondary;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Deserializer;
 import io.micronaut.serde.Encoder;
-import io.micronaut.serde.Serde;
 import io.micronaut.serde.Serializer;
 import io.micronaut.serde.exceptions.SerdeException;
-import jakarta.inject.Singleton;
+import io.micronaut.serde.support.SerdeRegistrar;
 
 import java.io.IOException;
 import java.sql.Date;
@@ -34,9 +32,7 @@ import java.time.LocalDate;
  *
  * @since 1.0.0
  */
-@Singleton
-@Secondary
-final class SqlDateSerde implements Serde<Date> {
+final class SqlDateSerde implements SerdeRegistrar<Date> {
     private static final Argument<LocalDate> LOCAL_DATE_ARGUMENT = Argument.of(LocalDate.class);
     private final LocalDateSerde localDateSerde;
 
@@ -104,5 +100,10 @@ final class SqlDateSerde implements Serde<Date> {
             return Date.valueOf(localDate);
         }
         return null;
+    }
+
+    @Override
+    public Argument<Date> getType() {
+        return Argument.of(Date.class);
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/SqlTimestampSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/SqlTimestampSerde.java
@@ -15,15 +15,13 @@
  */
 package io.micronaut.serde.support.serdes;
 
-import io.micronaut.context.annotation.Secondary;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Deserializer;
 import io.micronaut.serde.Encoder;
-import io.micronaut.serde.Serde;
 import io.micronaut.serde.Serializer;
 import io.micronaut.serde.exceptions.SerdeException;
-import jakarta.inject.Singleton;
+import io.micronaut.serde.support.SerdeRegistrar;
 
 import java.io.IOException;
 import java.sql.Timestamp;
@@ -32,9 +30,7 @@ import java.time.Instant;
 /**
  * Serde for SQL timestamps.
  */
-@Singleton
-@Secondary
-final class SqlTimestampSerde implements Serde<Timestamp> {
+final class SqlTimestampSerde implements SerdeRegistrar<Timestamp> {
     private static final Argument<Instant> INSTANT_ARGUMENT = Argument.of(Instant.class);
     private final InstantSerde instantSerde;
 
@@ -91,6 +87,11 @@ final class SqlTimestampSerde implements Serde<Timestamp> {
                 decoderContext,
                 INSTANT_ARGUMENT
         ));
+    }
+
+    @Override
+    public Argument<Timestamp> getType() {
+        return Argument.of(Timestamp.class);
     }
 }
 

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/StringSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/StringSerde.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+
+@Internal
+final class StringSerde implements SerdeRegistrar<String> {
+
+    @Override
+    public Argument<String> getType() {
+        return Argument.of(String.class);
+    }
+
+    @Override
+    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends String> type, String value)
+        throws IOException {
+        encoder.encodeString(value);
+    }
+
+    @Override
+    public String deserialize(Decoder decoder, DecoderContext context, Argument<? super String> type) throws IOException {
+        return decoder.decodeString();
+    }
+
+    @Override
+    public String deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super String> type) throws IOException {
+        return decoder.decodeStringNullable();
+    }
+
+    @Override
+    public boolean isEmpty(EncoderContext context, String value) {
+        return value == null || value.isEmpty();
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/TimeZoneSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/TimeZoneSerde.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.util.TimeZone;
+
+@Internal
+final class TimeZoneSerde implements SerdeRegistrar<TimeZone> {
+
+    @Override
+    public Argument<TimeZone> getType() {
+        return Argument.of(TimeZone.class);
+    }
+
+    @Override
+    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends TimeZone> type, TimeZone value)
+        throws IOException {
+        encoder.encodeString(value.getID());
+    }
+
+    @Override
+    public TimeZone deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super TimeZone> type)
+        throws IOException {
+        return TimeZone.getTimeZone(decoder.decodeString());
+    }
+
+    @Override
+    public TimeZone deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super TimeZone> type) throws IOException {
+        if (decoder.decodeNull()) {
+            return null;
+        }
+        return deserialize(decoder, context, type);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/URISerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/URISerde.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.net.URI;
+
+@Internal
+final class URISerde implements SerdeRegistrar<URI> {
+
+    @Override
+    public Argument<URI> getType() {
+        return Argument.of(URI.class);
+    }
+
+    @Override
+    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends URI> type, URI value)
+        throws IOException {
+        encoder.encodeString(value.toString());
+    }
+
+    @Override
+    public URI deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super URI> type)
+        throws IOException {
+        return URI.create(decoder.decodeString());
+    }
+
+    @Override
+    public URI deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super URI> type) throws IOException {
+        if (decoder.decodeNull()) {
+            return null;
+        }
+        return deserialize(decoder, context, type);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/URLSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/URLSerde.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.net.URL;
+
+@Internal
+final class URLSerde implements SerdeRegistrar<URL> {
+
+    @Override
+    public Argument<URL> getType() {
+        return Argument.of(URL.class);
+    }
+
+    @Override
+    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends URL> type, URL value)
+        throws IOException {
+        encoder.encodeString(value.toString());
+    }
+
+    @Override
+    public URL deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super URL> type)
+        throws IOException {
+        return new URL(decoder.decodeString());
+    }
+
+    @Override
+    public URL deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super URL> type) throws IOException {
+        if (decoder.decodeNull()) {
+            return null;
+        }
+        return deserialize(decoder, context, type);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/UUIDSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/UUIDSerde.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Internal
+final class UUIDSerde implements SerdeRegistrar<UUID> {
+
+    @Override
+    public Argument<UUID> getType() {
+        return Argument.of(UUID.class);
+    }
+
+    @Override
+    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends UUID> type, UUID value)
+        throws IOException {
+        encoder.encodeString(value.toString());
+    }
+
+    @Override
+    public UUID deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super UUID> type)
+        throws IOException {
+        return UUID.fromString(decoder.decodeString());
+    }
+
+    @Override
+    public UUID deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super UUID> type) throws IOException {
+        if (decoder.decodeNull()) {
+            return null;
+        }
+        return deserialize(decoder, context, type);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/YearSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/YearSerde.java
@@ -18,7 +18,7 @@ package io.micronaut.serde.support.serdes;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Encoder;
-import jakarta.inject.Singleton;
+import io.micronaut.serde.support.SerdeRegistrar;
 
 import java.io.IOException;
 import java.time.Year;
@@ -30,8 +30,7 @@ import java.time.temporal.TemporalQuery;
  *
  * @since 1.0.0
  */
-@Singleton
-public class YearSerde implements TemporalSerde<Year> {
+public class YearSerde implements TemporalSerde<Year>, SerdeRegistrar<Year> {
     @Override
     public void serialize(Encoder encoder, EncoderContext context, Argument<? extends Year> type, Year value) throws IOException {
         encoder.encodeInt(value.getValue());
@@ -46,5 +45,10 @@ public class YearSerde implements TemporalSerde<Year> {
     public Year deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super Year> type)
             throws IOException {
         return Year.of(decoder.decodeInt());
+    }
+
+    @Override
+    public Argument<Year> getType() {
+        return Argument.of(Year.class);
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/ZonedDateTimeSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/ZonedDateTimeSerde.java
@@ -15,8 +15,9 @@
  */
 package io.micronaut.serde.support.serdes;
 
+import io.micronaut.core.type.Argument;
 import io.micronaut.serde.config.SerdeConfiguration;
-import jakarta.inject.Singleton;
+import io.micronaut.serde.support.SerdeRegistrar;
 
 import java.time.Instant;
 import java.time.ZonedDateTime;
@@ -28,10 +29,9 @@ import java.time.temporal.TemporalQuery;
  *
  * @since 1.0.0
  */
-@Singleton
 public final class ZonedDateTimeSerde
     extends NumericSupportTemporalSerde<ZonedDateTime>
-        implements TemporalSerde<ZonedDateTime> {
+        implements TemporalSerde<ZonedDateTime>, SerdeRegistrar<ZonedDateTime> {
 
     ZonedDateTimeSerde(SerdeConfiguration configuration) {
         super(configuration, DateTimeFormatter.ISO_ZONED_DATE_TIME, SerdeConfiguration.NumericTimeUnit.MILLISECONDS);
@@ -60,5 +60,10 @@ public final class ZonedDateTimeSerde
     @Override
     protected DefaultFormattedTemporalSerde<ZonedDateTime> createSpecific(SerdeConfiguration configuration) {
         return new ZonedDateTimeSerde(configuration);
+    }
+
+    @Override
+    public Argument<ZonedDateTime> getType() {
+        return Argument.of(ZonedDateTime.class);
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/CoreSerializers.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/CoreSerializers.java
@@ -15,70 +15,24 @@
  */
 package io.micronaut.serde.support.serializers;
 
-import io.micronaut.context.annotation.Factory;
-import io.micronaut.core.annotation.Order;
-import io.micronaut.core.type.Argument;
-import io.micronaut.serde.Encoder;
-import io.micronaut.serde.Serializer;
-import jakarta.inject.Singleton;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.serde.config.SerializationConfiguration;
+import io.micronaut.serde.support.SerializerRegistrar;
 
-import java.io.IOException;
-import java.util.Map;
+import java.util.function.Consumer;
 
 /**
- * Factory class for core serializers.
+ * Core serializers.
  */
-@Factory
+@Internal
 public final class CoreSerializers {
 
-    @Singleton
-    @Order(1000) // prioritize over character
-    Serializer<String> stringSerializer() {
-        return new Serializer<String>() {
-            @Override
-            public void serialize(Encoder encoder,
-                                  EncoderContext context,
-                                  Argument<? extends String> type, String value) throws IOException {
-                encoder.encodeString(value);
-            }
-
-            @Override
-            public boolean isEmpty(EncoderContext context, String value) {
-                return value == null || value.isEmpty();
-            }
-        };
-    }
-
-    /**
-     * A serializer for all instances of {@link java.lang.Character}.
-     *
-     * @return A Character serializer
-     */
-    @Singleton
-    Serializer<Character> charSerializer() {
-        return (encoder, context, type, value) -> encoder.encodeChar(value);
-    }
-
-    /**
-     * A serializer for all instances of {@link java.lang.Boolean}.
-     *
-     * @return A boolean serializer
-     */
-    @Singleton
-    Serializer<Boolean> booleanSerializer() {
-        return (encoder, context, type, value) -> encoder.encodeBoolean(value);
-    }
-
-    /**
-     * A serializer for maps.
-     *
-     * @param <K> The key type
-     * @param <V> The value type
-     * @return A bit decimal serializer
-     */
-    @Singleton
-    <K, V> Serializer<Map<K, V>> mapSerializer() {
-        return new CustomizedMapSerializer<>();
+    public static void register(SerializationConfiguration serializationConfiguration, Consumer<SerializerRegistrar<?>> consumer) {
+        consumer.accept(new CustomizedMapSerializer<>());
+        consumer.accept(new IterableSerializer<>());
+        consumer.accept(new OptionalMultiValuesSerializer<>(serializationConfiguration));
+        consumer.accept(new OptionalValuesSerializer<>());
+        consumer.accept(new StreamSerializer<>());
     }
 
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedIterableSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedIterableSerializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.serializers;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Encoder;
 import io.micronaut.serde.Serializer;
@@ -29,6 +30,7 @@ import java.util.Collection;
  * @author Denis Stepanov
  * @since 1.0
  */
+@Internal
 final class CustomizedIterableSerializer<T> implements Serializer<Iterable<T>> {
 
     private final Argument<T> generic;
@@ -41,11 +43,11 @@ final class CustomizedIterableSerializer<T> implements Serializer<Iterable<T>> {
 
     @Override
     public void serialize(Encoder encoder, EncoderContext context, Argument<? extends Iterable<T>> type, Iterable<T> value)
-            throws IOException {
+        throws IOException {
         try (Encoder array = encoder.encodeArray(type)) {
             for (T t : value) {
                 if (t == null) {
-                    encoder.encodeNull();
+                    array.encodeNull();
                 } else {
                     componentSerializer.serialize(array, context, generic, t);
                 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedMapSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedMapSerializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.serializers;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.convert.exceptions.ConversionErrorException;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
@@ -23,6 +24,7 @@ import io.micronaut.serde.Encoder;
 import io.micronaut.serde.ObjectSerializer;
 import io.micronaut.serde.Serializer;
 import io.micronaut.serde.exceptions.SerdeException;
+import io.micronaut.serde.support.SerializerRegistrar;
 import io.micronaut.serde.util.CustomizableSerializer;
 
 import java.io.IOException;
@@ -35,11 +37,12 @@ import java.util.Map;
  * @param <V> The value type
  * @author Denis Stepanov
  */
-final class CustomizedMapSerializer<K, V> implements CustomizableSerializer<Map<K, V>> {
+@Internal
+final class CustomizedMapSerializer<K, V> implements CustomizableSerializer<Map<K, V>>, SerializerRegistrar<Map<K, V>> {
 
     @Override
     public ObjectSerializer<Map<K, V>> createSpecific(EncoderContext context, Argument<? extends Map<K, V>> type) throws SerdeException {
-        final Argument[] generics = type.getTypeParameters();
+        final Argument<?>[] generics = type.getTypeParameters();
         final boolean hasGenerics = ArrayUtils.isNotEmpty(generics) && generics.length != 2;
         if (hasGenerics) {
             final Argument<V> valueGeneric = (Argument<V>) generics[1];
@@ -132,4 +135,8 @@ final class CustomizedMapSerializer<K, V> implements CustomizableSerializer<Map<
         }
     }
 
+    @Override
+    public Argument<Map<K, V>> getType() {
+        return (Argument) Argument.mapOf(Argument.ofTypeVariable(Object.class, "K"), Argument.ofTypeVariable(Object.class, "V"));
+    }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/IterableSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/IterableSerializer.java
@@ -15,18 +15,19 @@
  */
 package io.micronaut.serde.support.serializers;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Serializer;
 import io.micronaut.serde.exceptions.SerdeException;
+import io.micronaut.serde.support.SerializerRegistrar;
 import io.micronaut.serde.util.CustomizableSerializer;
-import jakarta.inject.Singleton;
 
 /**
  * A serializer for any iterable.
  * @param <T> The generic type
  */
-@Singleton
-final class IterableSerializer<T> implements CustomizableSerializer<Iterable<T>> {
+@Internal
+final class IterableSerializer<T> implements CustomizableSerializer<Iterable<T>>, SerializerRegistrar<Iterable<T>> {
     @Override
     public Serializer<Iterable<T>> createSpecific(EncoderContext context, Argument<? extends Iterable<T>> type)
             throws SerdeException {
@@ -43,4 +44,8 @@ final class IterableSerializer<T> implements CustomizableSerializer<Iterable<T>>
         return new RuntimeValueIterableSerializer<>();
     }
 
+    @Override
+    public Argument<Iterable<T>> getType() {
+        return (Argument) Argument.of(Iterable.class, Argument.ofTypeVariable(Object.class, "T"));
+    }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/OptionalMultiValuesSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/OptionalMultiValuesSerializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.serializers;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.value.OptionalMultiValues;
@@ -23,8 +24,8 @@ import io.micronaut.serde.ObjectSerializer;
 import io.micronaut.serde.Serializer;
 import io.micronaut.serde.config.SerializationConfiguration;
 import io.micronaut.serde.exceptions.SerdeException;
+import io.micronaut.serde.support.SerializerRegistrar;
 import io.micronaut.serde.util.CustomizableSerializer;
-import jakarta.inject.Singleton;
 
 import java.io.IOException;
 import java.util.List;
@@ -36,8 +37,8 @@ import java.util.Optional;
  *
  * @param <V> The value type
  */
-@Singleton
-final class OptionalMultiValuesSerializer<V> implements CustomizableSerializer<OptionalMultiValues<V>> {
+@Internal
+final class OptionalMultiValuesSerializer<V> implements CustomizableSerializer<OptionalMultiValues<V>>, SerializerRegistrar<OptionalMultiValues<V>> {
     private final boolean alwaysSerializeErrorsAsList;
 
     public OptionalMultiValuesSerializer(SerializationConfiguration jacksonConfiguration) {
@@ -110,4 +111,8 @@ final class OptionalMultiValuesSerializer<V> implements CustomizableSerializer<O
         };
     }
 
+    @Override
+    public Argument<OptionalMultiValues<V>> getType() {
+        return (Argument) Argument.of(OptionalMultiValues.class, Argument.ofTypeVariable(Object.class, "V"));
+    }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/OptionalValuesSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/OptionalValuesSerializer.java
@@ -15,21 +15,22 @@
  */
 package io.micronaut.serde.support.serializers;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.core.value.OptionalValues;
 import io.micronaut.serde.Encoder;
 import io.micronaut.serde.Serializer;
 import io.micronaut.serde.exceptions.SerdeException;
+import io.micronaut.serde.support.SerializerRegistrar;
 import io.micronaut.serde.util.CustomizableSerializer;
-import jakarta.inject.Singleton;
 
 import java.io.IOException;
 import java.util.Objects;
 import java.util.Optional;
 
-@Singleton
-class OptionalValuesSerializer<V> implements CustomizableSerializer<OptionalValues<V>> {
+@Internal
+final class OptionalValuesSerializer<V> implements CustomizableSerializer<OptionalValues<V>>, SerializerRegistrar<OptionalValues<V>> {
 
     @Override
     public io.micronaut.serde.ObjectSerializer<OptionalValues<V>> createSpecific(EncoderContext context, Argument<? extends OptionalValues<V>> type) throws SerdeException {
@@ -70,5 +71,10 @@ class OptionalValuesSerializer<V> implements CustomizableSerializer<OptionalValu
     @Override
     public boolean isEmpty(EncoderContext context, OptionalValues<V> value) {
         return value.isEmpty();
+    }
+
+    @Override
+    public Argument<OptionalValues<V>> getType() {
+        return (Argument) Argument.of(OptionalValues.class, Argument.ofTypeVariable(Object.class, "V"));
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/RuntimeValueIterableSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/RuntimeValueIterableSerializer.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.serializers;
 
+import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Encoder;
 import io.micronaut.serde.Serializer;
@@ -28,6 +29,7 @@ import java.util.Collection;
  * @param <T> The iterable type
  * @author Denis Stepanov
  */
+@Internal
 final class RuntimeValueIterableSerializer<T> implements Serializer<Iterable<T>> {
 
     @Override
@@ -39,7 +41,7 @@ final class RuntimeValueIterableSerializer<T> implements Serializer<Iterable<T>>
         Argument<T> generic = null;
         for (T t : value) {
             if (t == null) {
-                encoder.encodeNull();
+                childEncoder.encodeNull();
                 continue;
             }
             if (lastValueClass != t.getClass() || componentSerializer == null) {
@@ -57,8 +59,8 @@ final class RuntimeValueIterableSerializer<T> implements Serializer<Iterable<T>>
         if (value == null) {
             return true;
         }
-        if (value instanceof Collection) {
-            return ((Collection<T>) value).isEmpty();
+        if (value instanceof Collection<?> collection) {
+            return collection.isEmpty();
         } else {
             return !value.iterator().hasNext();
         }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/StringIterableSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/StringIterableSerializer.java
@@ -36,7 +36,7 @@ final class StringIterableSerializer implements Serializer<Iterable<String>> {
         final Encoder childEncoder = encoder.encodeArray(type);
         for (String value : values) {
             if (value == null) {
-                encoder.encodeNull();
+                childEncoder.encodeNull();
                 continue;
             }
             childEncoder.encodeString(value);
@@ -49,8 +49,8 @@ final class StringIterableSerializer implements Serializer<Iterable<String>> {
         if (value == null) {
             return true;
         }
-        if (value instanceof Collection) {
-            return ((Collection<String>) value).isEmpty();
+        if (value instanceof Collection<?> collection) {
+            return collection.isEmpty();
         } else {
             return !value.iterator().hasNext();
         }

--- a/serde-support/src/test/groovy/io/micronaut/serde/support/serdes/BeanContextSerdeSpec.groovy
+++ b/serde-support/src/test/groovy/io/micronaut/serde/support/serdes/BeanContextSerdeSpec.groovy
@@ -1,0 +1,57 @@
+package io.micronaut.serde.support.serdes
+
+import io.micronaut.context.BeanContext
+import io.micronaut.core.type.Argument
+import io.micronaut.serde.Serde
+import io.micronaut.serde.support.deserializers.ObjectDeserializer
+import io.micronaut.serde.support.serializers.ObjectSerializer
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+import java.time.Duration
+
+@MicronautTest
+class BeanContextSerdeSpec extends Specification {
+    @Inject BeanContext beanContext
+
+    void "test retrieving serdes from the bean context"() {
+        when:
+        def result = beanContext.getBean(Argument.of(Serde, Duration))
+
+        then:
+        result.getClass() == DurationSerde
+    }
+
+    void "test retrieving object serializer from the bean context"() {
+        when:
+        beanContext.getBean(ObjectSerializer)
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "test retrieving object deserializer from the bean context"() {
+        when:
+        beanContext.getBean(ObjectDeserializer)
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "test retrieving object array serde from the bean context"() {
+        when:
+        beanContext.getBean(ObjectArraySerde)
+
+        then:
+        noExceptionThrown()
+    }
+
+    void "test retrieving byte array serde from the bean context"() {
+        when:
+        def byteArraySerde = beanContext.getBean(Argument.of(Serde, byte[]))
+
+        then:
+        byteArraySerde.getClass() == ByteArraySerde
+    }
+}


### PR DESCRIPTION
This should improve the startup.

I have extracted all of the serdes defined in the `DefaultSerdeRegistry` into own package.