### PR TITLE
Support ignoring constructor/record parameter

### DIFF
--- a/doc-examples/example-kotlin/src/test/kotlin/example/SerdeableWithIgnoredNonSerdeableFieldTest.kt
+++ b/doc-examples/example-kotlin/src/test/kotlin/example/SerdeableWithIgnoredNonSerdeableFieldTest.kt
@@ -1,0 +1,27 @@
+package example
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import io.micronaut.serde.ObjectMapper
+import io.micronaut.serde.annotation.Serdeable
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Test
+
+@MicronautTest
+class SerdeableWithIgnoredNonSerdeableFieldTest {
+
+    @Test
+    fun test(objectMapper: ObjectMapper) {
+        val original = SerdeableWithIgnoredNonSerdeable(NonSerdeable("value"))
+
+        val serialized = objectMapper.writeValueAsString(original)
+        val deserialized = objectMapper.readValue(serialized, SerdeableWithIgnoredNonSerdeable::class.java)
+
+        assert(deserialized == original.copy(ignoredNonSerdeable = null))
+    }
+
+}
+
+@Serdeable
+data class SerdeableWithIgnoredNonSerdeable(@field:JsonIgnore val ignoredNonSerdeable: NonSerdeable? = null)
+
+data class NonSerdeable(val value: String)

--- a/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonIgnoreSpec.groovy
+++ b/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonIgnoreSpec.groovy
@@ -69,6 +69,36 @@ class Test {
         context.close()
     }
 
+    void "json ignore on a bean"() {
+        given:
+        def context = buildContext('example.Test', '''
+package example;
+
+import com.fasterxml.jackson.annotation.*;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.Serdeable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Introspected(accessKind = Introspected.AccessKind.FIELD)
+class Test {
+    @JsonIgnore
+    public Ignored foo;
+    public String bar;
+}
+class Ignored {
+}
+''', [:])
+
+        def des = jsonMapper.readValue('{"foo": "1", "bar": "2"}', typeUnderTest)
+
+        expect:
+        des.foo == null
+        des.bar == "2"
+
+        cleanup:
+        context.close()
+    }
+
     void "test @JsonIgnoreType"() {
         given:
         def context = buildContext("""

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeJsonIgnoreSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeJsonIgnoreSpec.groovy
@@ -8,4 +8,76 @@ class SerdeJsonIgnoreSpec extends JsonIgnoreSpec {
     protected String unknownPropertyMessage(String propertyName, String className) {
         return "Unknown property [$propertyName] encountered during deserialization of type: ${NameUtils.getSimpleName(className)}"
     }
+
+    void "json ignore on a constructor parameter"() {
+        given:
+            def context = buildContext('example.Test', '''
+package example;
+
+import com.fasterxml.jackson.annotation.*;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class Test{
+    @JsonIgnore
+    private final Ignored foo;
+    private final String bar;
+
+    @JsonCreator
+    public Test(@JsonProperty("foo") Ignored foo, @JsonProperty("bar") String bar) {
+        this.foo = foo;
+        this.bar = bar;
+    }
+
+    public example.Ignored getFoo() {
+        return foo;
+    }
+
+    public String getBar() {
+        return bar;
+    }
+
+}
+class Ignored {
+}
+''')
+
+            def des = jsonMapper.readValue('{"foo": "1", "bar": "2"}', typeUnderTest)
+
+        expect:
+            des.foo == null
+            des.bar == "2"
+
+        cleanup:
+            context.close()
+    }
+
+    void "json ignore on a record parameter"() {
+        given:
+            def context = buildContext('example.Test', '''
+package example;
+
+import com.fasterxml.jackson.annotation.*;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+record Test(@JsonIgnore @JsonProperty("foo") Ignored foo, @JsonProperty("bar") String bar) {
+}
+class Ignored {
+}
+''')
+
+            def des = jsonMapper.readValue('{"foo": "1", "bar": "2"}', typeUnderTest)
+
+        expect:
+            des.foo == null
+            des.bar == "2"
+
+        cleanup:
+            context.close()
+    }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBean.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBean.java
@@ -185,7 +185,8 @@ final class DeserBean<T> {
             PropertyNamingStrategy propertyNamingStrategy = getPropertyNamingStrategy(annotationMetadata, decoderContext, entityPropertyNamingStrategy);
             final String propertyName = resolveName(serdeArgumentConf, constructorArgument, annotationMetadata, propertyNamingStrategy);
 
-            if (isIgnored(annotationMetadata) || (allowPropertyPredicate != null && !allowPropertyPredicate.test(propertyName))) {
+            boolean isIgnored = isIgnored(annotationMetadata) || (allowPropertyPredicate != null && !allowPropertyPredicate.test(propertyName));
+            if (isIgnored) {
                 ignoredProperties.add(propertyName);
             }
 
@@ -209,7 +210,7 @@ final class DeserBean<T> {
                 i,
                 propertyName,
                 constructorWithPropertyArgument,
-                introspection.getProperty(propertyName).orElse(null),
+                isIgnored ? null : introspection.getProperty(propertyName).orElse(null),
                 null,
                 unwrapped,
                 null
@@ -482,7 +483,9 @@ final class DeserBean<T> {
     }
 
     private void initProperty(DerProperty<T, Object> property, Deserializer.DecoderContext decoderContext) throws SerdeException {
-        property.deserializer = findDeserializer(decoderContext, property.argument);
+        if (property.beanProperty != null) {
+            property.deserializer = findDeserializer(decoderContext, property.argument);
+        }
     }
 
     private PropertyNamingStrategy getPropertyNamingStrategy(AnnotationMetadata annotationMetadata,

--- a/test-suite-tck-jackson-databind/src/test/groovy/io/micronaut/serde/tck/jackson/databind/DatabindJsonIgnoreSpec.groovy
+++ b/test-suite-tck-jackson-databind/src/test/groovy/io/micronaut/serde/tck/jackson/databind/DatabindJsonIgnoreSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.serde.tck.jackson.databind
 
 import io.micronaut.context.ApplicationContextBuilder
 import io.micronaut.serde.jackson.JsonIgnoreSpec
+import spock.lang.PendingFeature
 
 class DatabindJsonIgnoreSpec extends JsonIgnoreSpec {
 
@@ -15,6 +16,80 @@ class DatabindJsonIgnoreSpec extends JsonIgnoreSpec {
     @Override
     protected String unknownPropertyMessage(String propertyName, String className) {
         return """Unrecognized field "$propertyName" (class $className), not marked as ignorable"""
+    }
+
+    @PendingFeature(reason = "Jackson doesn't support ignored record values")
+    void "json ignore on a record parameter"() {
+        given:
+            def context = buildContext('example.Test', '''
+package example;
+
+import com.fasterxml.jackson.annotation.*;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+record Test(@JsonIgnore @JsonProperty("foo") Ignored foo, @JsonProperty("bar") String bar) {
+}
+class Ignored {
+}
+''')
+
+            def des = jsonMapper.readValue('{"foo": {}, "bar": "2"}', typeUnderTest)
+
+        expect:
+            des.foo == null
+            des.bar == "2"
+
+        cleanup:
+            context.close()
+    }
+
+    @PendingFeature(reason = "Jackson doesn't support ignored constructor values")
+    void "json ignore on a constructor parameter"() {
+        given:
+            def context = buildContext('example.Test', '''
+package example;
+
+import com.fasterxml.jackson.annotation.*;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class Test{
+    @JsonIgnore
+    private final Ignored foo;
+    private final String bar;
+
+    @JsonCreator
+    public Test(@JsonProperty("foo") Ignored foo, @JsonProperty("bar") String bar) {
+        this.foo = foo;
+        this.bar = bar;
+    }
+
+    public example.Ignored getFoo() {
+        return foo;
+    }
+
+    public String getBar() {
+        return bar;
+    }
+
+}
+class Ignored {
+}
+''')
+
+            def des = jsonMapper.readValue('{"foo": {}, "bar": "2"}', typeUnderTest)
+
+        expect:
+            des.foo == null
+            des.bar == "2"
+
+        cleanup:
+            context.close()
     }
 
 }


### PR DESCRIPTION
Fixes https://github.com/micronaut-projects/micronaut-serialization/issues/803

NOTE: Jackson doesn't support this kind of scenario