### PR TITLE
Improve Enum handling parity with Jackson

### DIFF
--- a/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonValueSpec.groovy
+++ b/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonValueSpec.groovy
@@ -31,9 +31,9 @@ class Foo {
 @Serdeable
 enum MyEnum {
 
-    VALUE1("value1"),
-    VALUE2("value2"),
-    VALUE3("value3");
+    VALUE1("value_1"),
+    VALUE2("value_2"),
+    VALUE3("value_3");
 
     private final String value;
 
@@ -52,16 +52,21 @@ enum MyEnum {
         when:
             String json = jsonMapper.writeValueAsString(testBean)
         then:
-            '{"myEnum":"value2"}' == json
+            '{"myEnum":"value_2"}' == json
 
         when:
             def foo = jsonMapper.readValue(json, testBean.class)
 
         then:
             foo.myEnum == enumValue2
+
+        when:
+            jsonMapper.readValue('{"myEnum":"invalid"}', testBean.class)
+        then:
+            thrown IOException
     }
 
-    void "@JsonValue on field"() throws IOException {
+    void "enum @JsonValue on field"() throws IOException {
         given:
             def context = buildContext('''
 package example;
@@ -82,9 +87,9 @@ class Foo {
 }
 @Serdeable
 enum MyEnum {
-    VALUE1("value1"),
-    VALUE2("value2"),
-    VALUE3("value3");
+    VALUE1("value_1"),
+    VALUE2("value_2"),
+    VALUE3("value_3");
     @JsonValue
     private final String value;
     MyEnum(String value) {
@@ -100,13 +105,18 @@ enum MyEnum {
         when:
             String json = jsonMapper.writeValueAsString(testBean)
         then:
-            '{"myEnum":"value2"}' == json
+            '{"myEnum":"value_2"}' == json
 
         when:
             def foo = jsonMapper.readValue(json, testBean.class)
 
         then:
             foo.myEnum == enumValue2
+
+        when:
+            jsonMapper.readValue('{"myEnum":"invalid"}', testBean.class)
+        then:
+            thrown IOException
     }
 
     void "@JsonValue on constructor"() throws IOException {

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/object/EnumSerdeSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/object/EnumSerdeSpec.groovy
@@ -167,4 +167,422 @@ enum EnumWithDefaultValue {
         cleanup:
         compiled.close()
     }
+
+    def 'test deserialize EnumSet for Enum with @JsonValue on property'() {
+        given:
+        def context = buildContext('''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.Set;
+
+@Serdeable
+class Test {
+    private Set<MyEnum> enumSet;
+
+    public Set<MyEnum> getEnumSet() {
+        return enumSet;
+    }
+
+    public void setEnumSet(Set<MyEnum> enumSet) {
+        this.enumSet = enumSet;
+    }
+}
+
+@Serdeable
+enum MyEnum {
+    VALUE1("value_1"),
+    VALUE2("value_2"),
+    VALUE3("value_3");
+
+    @JsonValue
+    private final String value;
+
+    MyEnum(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}
+''')
+        when:
+        def json = '{"enumSet":["value_1","value_3"]}'
+        def result = jsonMapper.readValue(json, argumentOf(context, 'test.Test'))
+
+        then:
+        result.enumSet instanceof EnumSet
+        result.enumSet == EnumSet.of(getEnum(context, 'test.MyEnum.VALUE1'), getEnum(context, 'test.MyEnum.VALUE3'))
+
+        cleanup:
+        context.close()
+    }
+
+    def 'test deserialize EnumSet for Enum with @JsonValue on getter'() {
+        given:
+        def context = buildContext('''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.Set;
+
+@Serdeable
+class Test {
+    private Set<MyEnum> enumSet;
+
+    public Set<MyEnum> getEnumSet() {
+        return enumSet;
+    }
+
+    public void setEnumSet(Set<MyEnum> enumSet) {
+        this.enumSet = enumSet;
+    }
+}
+
+@Serdeable
+enum MyEnum {
+    VALUE1("value_1"),
+    VALUE2("value_2"),
+    VALUE3("value_3");
+
+    private final String value;
+
+    MyEnum(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}
+''')
+        when:
+        def json = '{"enumSet":["value_1","value_3"]}'
+        def result = jsonMapper.readValue(json, argumentOf(context, 'test.Test'))
+
+        then:
+        result.enumSet instanceof EnumSet
+        result.enumSet == EnumSet.of(getEnum(context, 'test.MyEnum.VALUE1'), getEnum(context, 'test.MyEnum.VALUE3'))
+
+        cleanup:
+        context.close()
+    }
+
+    def 'test deserialize EnumSet for Enum with @JsonProperty'() {
+        given:
+        def context = buildContext('''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.Set;
+
+@Serdeable
+class Test {
+    private Set<MyEnum> enumSet;
+
+    public Set<MyEnum> getEnumSet() {
+        return enumSet;
+    }
+
+    public void setEnumSet(Set<MyEnum> enumSet) {
+        this.enumSet = enumSet;
+    }
+}
+
+@Serdeable
+enum MyEnum {
+    @JsonProperty("value_1") VALUE1,
+    @JsonProperty("value_2") VALUE2,
+    @JsonProperty("value_3") VALUE3
+}
+''')
+        when:
+        def json = '{"enumSet":["value_1","value_3"]}'
+        def result = jsonMapper.readValue(json, argumentOf(context, 'test.Test'))
+
+        then:
+        result.enumSet instanceof EnumSet
+        result.enumSet == EnumSet.of(getEnum(context, 'test.MyEnum.VALUE1'), getEnum(context, 'test.MyEnum.VALUE3'))
+
+        cleanup:
+        context.close()
+    }
+
+    def 'test deserialize EnumSet for Enum with @JsonCreator'() {
+        given:
+        def context = buildContext('''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.Objects;
+import java.util.Arrays;
+import java.util.Set;
+
+@Serdeable
+class Test {
+    private Set<MyEnum> enumSet;
+
+    public Set<MyEnum> getEnumSet() {
+        return enumSet;
+    }
+
+    public void setEnumSet(Set<MyEnum> enumSet) {
+        this.enumSet = enumSet;
+    }
+}
+
+@Serdeable
+enum MyEnum {
+    VALUE1("value_1"),
+    VALUE2("value_2"),
+    VALUE3("value_3");
+
+    private final String value;
+
+    MyEnum(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static MyEnum create(String value) {
+        return Arrays.stream(values())
+            .filter(val -> Objects.equals(val.value, value))
+            .findFirst()
+            .orElse(null);
+    }
+}
+''')
+        when:
+        def json = '{"enumSet":["value_1","value_3"]}'
+        def result = jsonMapper.readValue(json, argumentOf(context, 'test.Test'))
+
+        then:
+        result.enumSet instanceof EnumSet
+        result.enumSet == EnumSet.of(getEnum(context, 'test.MyEnum.VALUE1'), getEnum(context, 'test.MyEnum.VALUE3'))
+
+        cleanup:
+        context.close()
+    }
+
+    def 'test deserialize EnumMap for Enum with @JsonValue on property'() {
+        given:
+        def context = buildContext('''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.Objects;
+import java.util.Arrays;
+import java.util.Map;
+
+@Serdeable
+class Test {
+    private Map<MyEnum, Object> enumMap;
+
+    public Map<MyEnum, Object> getEnumMap() {
+        return enumMap;
+    }
+
+    public void setEnumMap(Map<MyEnum, Object> enumMap) {
+        this.enumMap = enumMap;
+    }
+}
+
+@Serdeable
+enum MyEnum {
+    VALUE1("value_1"),
+    VALUE2("value_2"),
+    VALUE3("value_3");
+
+    @JsonValue
+    private final String value;
+
+    MyEnum(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}
+''')
+        when:
+        def json = '{"enumMap":{"value_1":"abc","value_3":123}}'
+        def result = jsonMapper.readValue(json, argumentOf(context, 'test.Test'))
+
+        then:
+        result.enumMap instanceof EnumMap
+        result.enumMap == new EnumMap([(getEnum(context, 'test.MyEnum.VALUE1')): "abc", (getEnum(context, 'test.MyEnum.VALUE3')): 123])
+
+        cleanup:
+        context.close()
+    }
+
+    def 'test deserialize EnumMap for Enum with @JsonValue on getter'() {
+        given:
+        def context = buildContext('''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.Objects;
+import java.util.Arrays;
+import java.util.Map;
+
+@Serdeable
+class Test {
+    private Map<MyEnum, Object> enumMap;
+
+    public Map<MyEnum, Object> getEnumMap() {
+        return enumMap;
+    }
+
+    public void setEnumMap(Map<MyEnum, Object> enumMap) {
+        this.enumMap = enumMap;
+    }
+}
+
+@Serdeable
+enum MyEnum {
+    VALUE1("value_1"),
+    VALUE2("value_2"),
+    VALUE3("value_3");
+
+    private final String value;
+
+    MyEnum(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+}
+''')
+        when:
+        def json = '{"enumMap":{"value_1":"abc","value_3":123}}'
+        def result = jsonMapper.readValue(json, argumentOf(context, 'test.Test'))
+
+        then:
+        result.enumMap instanceof EnumMap
+        result.enumMap == new EnumMap([(getEnum(context, 'test.MyEnum.VALUE1')): "abc", (getEnum(context, 'test.MyEnum.VALUE3')): 123])
+
+        cleanup:
+        context.close()
+    }
+
+    def 'test deserialize EnumMap for Enum with @JsonProperty'() {
+        given:
+        def context = buildContext('''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.Objects;
+import java.util.Arrays;
+import java.util.Map;
+
+@Serdeable
+class Test {
+    private Map<MyEnum, Object> enumMap;
+
+    public Map<MyEnum, Object> getEnumMap() {
+        return enumMap;
+    }
+
+    public void setEnumMap(Map<MyEnum, Object> enumMap) {
+        this.enumMap = enumMap;
+    }
+}
+
+@Serdeable
+enum MyEnum {
+    @JsonProperty("value_1") VALUE1,
+    @JsonProperty("value_2") VALUE2,
+    @JsonProperty("value_3") VALUE3
+}
+''')
+        when:
+        def json = '{"enumMap":{"value_1":"abc","value_3":123}}'
+        def result = jsonMapper.readValue(json, argumentOf(context, 'test.Test'))
+
+        then:
+        result.enumMap instanceof EnumMap
+        result.enumMap == new EnumMap([(getEnum(context, 'test.MyEnum.VALUE1')): "abc", (getEnum(context, 'test.MyEnum.VALUE3')): 123])
+
+        cleanup:
+        context.close()
+    }
+
+    def 'test deserialize EnumMap for Enum with @JsonCreator'() {
+        given:
+        def context = buildContext('''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.Objects;
+import java.util.Arrays;
+import java.util.Map;
+
+@Serdeable
+class Test {
+    private Map<MyEnum, Object> enumMap;
+
+    public Map<MyEnum, Object> getEnumMap() {
+        return enumMap;
+    }
+
+    public void setEnumMap(Map<MyEnum, Object> enumMap) {
+        this.enumMap = enumMap;
+    }
+}
+
+@Serdeable
+enum MyEnum {
+    VALUE1("value_1"),
+    VALUE2("value_2"),
+    VALUE3("value_3");
+
+    private final String value;
+
+    MyEnum(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static MyEnum create(String value) {
+        return Arrays.stream(values())
+            .filter(val -> Objects.equals(val.value, value))
+            .findFirst()
+            .orElse(null);
+    }
+}
+''')
+        when:
+        def json = '{"enumMap":{"value_1":"abc","value_3":123}}'
+        def result = jsonMapper.readValue(json, argumentOf(context, 'test.Test'))
+
+        then:
+        result.enumMap instanceof EnumMap
+        result.enumMap == new EnumMap([(getEnum(context, 'test.MyEnum.VALUE1')): "abc", (getEnum(context, 'test.MyEnum.VALUE3')): 123])
+
+        cleanup:
+        context.close()
+    }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/CoreCollectionsDeserializers.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/CoreCollectionsDeserializers.java
@@ -135,6 +135,7 @@ public final class CoreCollectionsDeserializers {
 
         });
         consumer.accept(new EnumSetDeserializer<>());
+        consumer.accept(new EnumMapDeserializer<>());
         consumer.accept(new ConvertibleValuesDeserializer(conversionService));
     }
 

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/EnumMapDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/EnumMapDeserializer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.deserializers.collect;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.ArrayUtils;
+import io.micronaut.json.tree.JsonNode;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.LimitingStream;
+import io.micronaut.serde.LimitingStream.RemainingLimits;
+import io.micronaut.serde.exceptions.SerdeException;
+import io.micronaut.serde.support.DeserializerRegistrar;
+import io.micronaut.serde.support.util.JsonNodeDecoder;
+import io.micronaut.serde.util.CustomizableDeserializer;
+
+import java.util.EnumMap;
+
+/**
+ * Deserializer for enum maps.
+ *
+ * @param <E> The enum type
+ * @param <V> Value type
+ */
+@Internal
+final class EnumMapDeserializer<E extends Enum<E>, V> implements CustomizableDeserializer<EnumMap<E, V>>, DeserializerRegistrar<EnumMap<E, V>> {
+    @Override
+    public Deserializer<EnumMap<E, V>> createSpecific(DecoderContext context, Argument<? super EnumMap<E, V>> type) throws SerdeException {
+        final Argument<?>[] generics = type.getTypeParameters();
+        if (ArrayUtils.isEmpty(generics) || generics.length != 2) {
+            throw new SerdeException("Cannot deserialize raw EnumMap");
+        }
+        @SuppressWarnings("unchecked") final Argument<E> enumType = (Argument<E>) generics[0];
+        @SuppressWarnings("unchecked") final Argument<V> valueType = (Argument<V>) generics[1];
+        final Deserializer<? extends V> valueDeser = valueType.equalsType(Argument.OBJECT_ARGUMENT) ? null : context.findDeserializer(valueType)
+            .createSpecific(context, valueType);
+        final Deserializer<? extends E> enumDeser = context.findDeserializer(enumType).createSpecific(context, enumType);
+        return (decoder, decoderContext, mapType) -> {
+            final EnumMap<E, V> map = new EnumMap<>(enumType.getType());
+            final RemainingLimits remainingLimits = decoderContext.getSerdeConfiguration().map(LimitingStream::limitsFromConfiguration).orElse(LimitingStream.DEFAULT_LIMITS);
+            final Decoder objectDecoder = decoder.decodeObject(mapType);
+            String key = objectDecoder.decodeKey();
+            while (key != null) {
+                JsonNodeDecoder keyDecoder = JsonNodeDecoder.create(JsonNode.createStringNode(key), remainingLimits);
+                E k = enumDeser.deserialize(keyDecoder, decoderContext, enumType);
+                if (valueDeser == null) {
+                    map.put(k, (V) objectDecoder.decodeArbitrary());
+                } else {
+                    map.put(k, valueDeser.deserializeNullable(objectDecoder, decoderContext, valueType));
+                }
+                key = objectDecoder.decodeKey();
+            }
+            objectDecoder.finishStructure();
+            return map;
+        };
+    }
+
+    @Override
+    public Argument<EnumMap<E, V>> getType() {
+        return (Argument) Argument.of(EnumMap.class, Argument.ofTypeVariable(Enum.class, "E"), Argument.ofTypeVariable(Object.class, "V"));
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/EnumSetDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/EnumSetDeserializer.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Deserializer;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.DeserializerRegistrar;
 
@@ -44,9 +45,10 @@ final class EnumSetDeserializer<E extends Enum<E>> implements DeserializerRegist
         final Decoder arrayDecoder = decoder.decodeArray();
         Class<E> enumType = generic.getType();
         EnumSet<E> enumSet = EnumSet.noneOf(enumType);
+        Deserializer<? extends E> enumDeser = context.findDeserializer(enumType).createSpecific(context, generic);
         while (arrayDecoder.hasNextArrayValue()) {
             enumSet.add(
-                Enum.valueOf(enumType, arrayDecoder.decodeString())
+                enumDeser.deserialize(arrayDecoder, context, generic)
             );
         }
         arrayDecoder.finishStructure();

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/EnumSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/EnumSerde.java
@@ -15,10 +15,12 @@
  */
 package io.micronaut.serde.support.serdes;
 
+import io.micronaut.core.annotation.Creator;
 import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.beans.BeanIntrospection;
 import io.micronaut.core.beans.BeanMethod;
 import io.micronaut.core.beans.BeanProperty;
+import io.micronaut.core.beans.EnumBeanIntrospection;
 import io.micronaut.core.beans.exceptions.IntrospectionException;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
@@ -32,6 +34,10 @@ import io.micronaut.serde.support.SerdeRegistrar;
 
 import java.io.IOException;
 import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Serde for handling enums.
@@ -64,23 +70,51 @@ final class EnumSerde<E extends Enum<E>> implements SerdeRegistrar<E> {
         }
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     @NonNull
     public Deserializer<E> createSpecific(@NonNull DecoderContext context, @NonNull Argument<? super E> type) {
         try {
             BeanIntrospection<? super E> deserializableIntrospection = introspections.getDeserializableIntrospection(type);
-            Argument<?>[] constructorArguments = deserializableIntrospection.getConstructorArguments();
-            if (constructorArguments.length != 1) {
-                throw new SerdeException("Creator method for Enums must accept exactly 1 argument");
+            if (deserializableIntrospection.getConstructor().isAnnotationPresent(Creator.class)) {
+                return createEnumCreatorDeserializer(context, deserializableIntrospection);
             }
-            Argument<Object> argumentType = (Argument<Object>) constructorArguments[0];
-            Deserializer<Object> argumentDeserializer = (Deserializer<Object>) context.findDeserializer(argumentType);
-
-            return new EnumCreatorDeserializer<E>(argumentType, argumentDeserializer, deserializableIntrospection, argumentType.isNullable());
+            if (deserializableIntrospection instanceof EnumBeanIntrospection<? super E> enumIntrospection) {
+                for (BeanMethod<? super E, Object> beanMethod : deserializableIntrospection.getBeanMethods()) {
+                    if (beanMethod.getAnnotationMetadata().hasDeclaredAnnotation(SerdeConfig.SerValue.class)) {
+                        Argument<Object> valueType = beanMethod.getReturnType().asArgument();
+                        Deserializer<?> valueDeserializer = context.findDeserializer(valueType);
+                        return new EnumValueDeserializer<E>(valueType, valueDeserializer, enumIntrospection, beanMethod::invoke, valueType.isNullable());
+                    }
+                }
+                for (BeanProperty<? super E, Object> beanProperty : deserializableIntrospection.getBeanProperties()) {
+                    if (beanProperty.getAnnotationMetadata().hasDeclaredAnnotation(SerdeConfig.SerValue.class)) {
+                        var valueType = beanProperty.asArgument();
+                        Deserializer<?> valueDeserializer = context.findDeserializer(valueType);
+                        return new EnumValueDeserializer<E>(valueType, valueDeserializer, enumIntrospection, beanProperty::get, valueType.isNullable());
+                    }
+                }
+                boolean hasPropertyAnnotation = enumIntrospection.getConstants().stream()
+                    .anyMatch(enumConstant -> enumConstant.stringValue(SerdeConfig.class, SerdeConfig.PROPERTY).isPresent());
+                if (hasPropertyAnnotation) {
+                    return new EnumPropertyDeserializer<E>(enumIntrospection);
+                }
+            }
+            return createEnumCreatorDeserializer(context, deserializableIntrospection);
         } catch (IntrospectionException | SerdeException e) {
             return this;
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private EnumCreatorDeserializer<E> createEnumCreatorDeserializer(DecoderContext context, BeanIntrospection<? super E> deserializableIntrospection) throws SerdeException {
+        Argument<?>[] constructorArguments = deserializableIntrospection.getConstructorArguments();
+        if (constructorArguments.length != 1) {
+            throw new SerdeException("Creator method for Enums must accept exactly 1 argument");
+        }
+        Argument<Object> argumentType = (Argument<Object>) constructorArguments[0];
+        Deserializer<Object> argumentDeserializer = (Deserializer<Object>) context.findDeserializer(argumentType);
+
+        return new EnumCreatorDeserializer<E>(argumentType, argumentDeserializer, deserializableIntrospection, argumentType.isNullable());
     }
 
     @Override
@@ -112,6 +146,13 @@ final class EnumSerde<E extends Enum<E>> implements SerdeRegistrar<E> {
                             valueSerializer.serialize(encoder, subContext, subType, result);
                         }
                     };
+                }
+            }
+            if (si instanceof EnumBeanIntrospection<? extends E> enumIntrospection) {
+                boolean hasPropertyAnnotation = enumIntrospection.getConstants().stream()
+                    .anyMatch(enumConstant -> enumConstant.stringValue(SerdeConfig.class, SerdeConfig.PROPERTY).isPresent());
+                if (hasPropertyAnnotation) {
+                    return new EnumPropertySerializer<>(enumIntrospection);
                 }
             }
             return this;
@@ -185,5 +226,108 @@ final class EnumCreatorDeserializer<E extends Enum<E>> implements Deserializer<E
             return null;
         }
         return transform(v);
+    }
+}
+
+final class EnumValueDeserializer<E extends Enum<E>> implements Deserializer<E> {
+
+    private final Argument<Object> valueType;
+    private final Deserializer<?> valueDeserializer;
+    private final EnumBeanIntrospection<? super E> enumIntrospection;
+    private final Function<E, Object> valueExtractor;
+    private final boolean allowNull;
+
+    public EnumValueDeserializer(Argument<Object> valueType, Deserializer<?> valueDeserializer, EnumBeanIntrospection<? super E> enumIntrospection, Function<E, Object> valueExtractor, boolean allowNull) {
+        this.valueType = valueType;
+        this.valueDeserializer = valueDeserializer;
+        this.enumIntrospection = enumIntrospection;
+        this.valueExtractor = valueExtractor;
+        this.allowNull = allowNull;
+    }
+
+    @NonNull
+    private E transform(@NonNull Decoder decoder, Object value) throws IOException {
+        for (EnumBeanIntrospection.EnumConstant<? super E> enumConstant : enumIntrospection.getConstants()) {
+            E enumValue = (E) enumConstant.getValue();
+            Object extractedValue = valueExtractor.apply(enumValue);
+            if (Objects.equals(extractedValue, value)) {
+                return enumValue;
+            }
+        }
+
+        var allowedValues = enumIntrospection.getConstants().stream()
+            .map(EnumBeanIntrospection.EnumConstant::getValue)
+            .map(enumValue -> valueExtractor.apply((E) enumValue))
+            .map(Object::toString)
+            .collect(Collectors.joining(", "));
+
+        throw decoder.createDeserializationException("Expected one of [%s] but was '%s'".formatted(allowedValues, value), value);
+    }
+
+    @Override
+    public E deserialize(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super E> type) throws IOException {
+        return transform(decoder, valueDeserializer.deserialize(decoder, context, valueType));
+    }
+
+    @Override
+    public E deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super E> type) throws IOException {
+        Object v = valueDeserializer.deserializeNullable(decoder, context, valueType);
+        if (!allowNull && v == null) {
+            return null;
+        }
+        return transform(decoder, v);
+    }
+}
+
+final class EnumPropertySerializer<E extends Enum<E>> implements Serializer<E> {
+
+    private final EnumBeanIntrospection<? extends E> enumIntrospection;
+
+    EnumPropertySerializer(EnumBeanIntrospection<? extends E> enumIntrospection) {
+        this.enumIntrospection = enumIntrospection;
+    }
+
+    @Override
+    public void serialize(@NonNull Encoder encoder, @NonNull EncoderContext context, @NonNull Argument<? extends E> type, E value) throws IOException {
+        for (EnumBeanIntrospection.EnumConstant<? extends E> enumConstant : enumIntrospection.getConstants()) {
+            if (enumConstant.getValue() == value) {
+                encoder.encodeString(enumConstant.stringValue(SerdeConfig.class, SerdeConfig.PROPERTY).orElse(value.name()));
+            }
+        }
+    }
+}
+
+final class EnumPropertyDeserializer<E extends Enum<E>> implements Deserializer<E> {
+
+    private final EnumBeanIntrospection<? super E> enumIntrospection;
+
+    EnumPropertyDeserializer(EnumBeanIntrospection<? super E> enumIntrospection) {
+        this.enumIntrospection = enumIntrospection;
+    }
+
+
+    @Override
+    public E deserialize(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super E> type) throws IOException {
+        var value = decoder.decodeString();
+
+        for (EnumBeanIntrospection.EnumConstant<? super E> enumConstant : enumIntrospection.getConstants()) {
+            Optional<String> matchingProperty = enumConstant.stringValue(SerdeConfig.class, SerdeConfig.PROPERTY).filter(propertyValue -> propertyValue.equals(value));
+            if (matchingProperty.isPresent()) {
+                return (E) enumConstant.getValue();
+            }
+        }
+
+        @SuppressWarnings("rawtypes") final Class t = type.getType();
+        try {
+            return (E) Enum.valueOf(t, value);
+        } catch (IllegalArgumentException e) {
+            // try upper case
+            try {
+                return (E) Enum.valueOf(t, value.toUpperCase(Locale.ENGLISH));
+            } catch (Exception ex) {
+                // throw original
+                throw e;
+            }
+        }
     }
 }


### PR DESCRIPTION
Improve enum serialization and deserialization to move closer to parity with Jackson

* Additional Jackson annotations support:
  * deserialize enums with `@JsonValue`
  * serialize and deserialize enums with `@JsonProperty`
  * This follows the same precedence in evaluation as Jackson:
     * serialize: @JsonValue > @JsonProperty
     * deserialize: @JsonCreator > @JsonValue > @JsonProperty

* Improved `EnumSet` de/serialization of contained enums

* Added support for `EnumMap`