### PR TITLE
Fix JsonNumber bson serialization

### DIFF
--- a/serde-bson/src/main/java/io/micronaut/serde/bson/BsonReaderDecoder.java
+++ b/serde-bson/src/main/java/io/micronaut/serde/bson/BsonReaderDecoder.java
@@ -280,6 +280,11 @@ public final class BsonReaderDecoder extends AbstractDecoderPerStructureStreamDe
     }
 
     @Override
+    protected BigDecimal getBigDecimalFromNumber(Number number) {
+        return ((Decimal128) number).bigDecimalValue();
+    }
+
+    @Override
     public byte @NonNull [] decodeBinary() throws IOException {
         if (currentBsonType == BsonType.BINARY) {
             return decodeCustom(parser -> ((BsonReaderDecoder) parser).bsonReader.readBinaryData().getData());

--- a/serde-bson/src/main/java/io/micronaut/serde/bson/BsonReaderDecoder.java
+++ b/serde-bson/src/main/java/io/micronaut/serde/bson/BsonReaderDecoder.java
@@ -281,7 +281,10 @@ public final class BsonReaderDecoder extends AbstractDecoderPerStructureStreamDe
 
     @Override
     protected BigDecimal getBigDecimalFromNumber(Number number) {
-        return ((Decimal128) number).bigDecimalValue();
+        if (number instanceof Decimal128 decimal128) {
+            return decimal128.bigDecimalValue();
+        }
+        return super.getBigDecimalFromNumber(number);
     }
 
     @Override

--- a/serde-bson/src/main/java/io/micronaut/serde/bson/BsonWriterEncoder.java
+++ b/serde-bson/src/main/java/io/micronaut/serde/bson/BsonWriterEncoder.java
@@ -150,7 +150,6 @@ public final class BsonWriterEncoder extends LimitingStream implements Encoder {
     @Override
     public void encodeBigInteger(BigInteger value) {
         encodeBigDecimal(new BigDecimal(value));
-        postEncodeValue();
     }
 
     @Override

--- a/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonBinaryBasicSerdeSpec.groovy
+++ b/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonBinaryBasicSerdeSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.serde.bson
 
 import io.micronaut.core.type.Argument
 import io.micronaut.json.JsonMapper
+import io.micronaut.json.tree.JsonNode
 import io.micronaut.serde.AbstractBasicSerdeSpec
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
@@ -45,5 +46,24 @@ class BsonBinaryBasicSerdeSpec extends AbstractBasicSerdeSpec implements BsonBin
         def expected = obj
         assert result == expected
         return result == expected
+    }
+
+    def "validate json node including type"() {
+        when:
+            def result = serializeDeserializeAs(
+                JsonNode.createObjectNode(["v": jsonNode]), Argument.of(JsonNode.class)).get("v")
+        then:
+            result.value == jsonNode.value && result.value.class == jsonNode.value.class
+
+        where:
+            // the type doesn't match for float and big integer as bson encodes them as double and big decimal
+            jsonNode << [
+                JsonNode.createBooleanNode(true),
+                JsonNode.createNumberNode(123),
+                JsonNode.createNumberNode(234L),
+                JsonNode.createNumberNode(123.234D),
+                JsonNode.createNumberNode(BigDecimal.valueOf(12345.12345)),
+                JsonNode.createStringNode("Hello"),
+            ]
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/AbstractStreamDecoder.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/AbstractStreamDecoder.java
@@ -403,6 +403,19 @@ public abstract class AbstractStreamDecoder extends LimitingStream implements De
     protected abstract Number getBestNumber() throws IOException;
 
     /**
+     * Converts the number, probably retrieved by calling {@link #getBestNumber()}, to a {@link BigDecimal},
+     * when it is not one of {@link Byte}, {@link Short}, {@link Integer}, {@link Long}, {@link Float},
+     * {@link Double}, {@link BigInteger}, {@link BigDecimal}
+     *
+     * @param number The number value
+     * @return The number as a big decimal
+     * @throws UnsupportedOperationException If custom number types are not expected
+     */
+    protected BigDecimal getBigDecimalFromNumber(Number number) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Decode the current {@link TokenType#NUMBER} value as a numeric {@link JsonNode}. Called for no other token type.
      * Default implementation tries to construct a node from {@link #getBestNumber()}.
      * @return The number value
@@ -424,7 +437,7 @@ public abstract class AbstractStreamDecoder extends LimitingStream implements De
             return JsonNode.createNumberNode((BigDecimal) number);
         } else {
             // fallback, unknown number type
-            return JsonNode.createNumberNode(getBigDecimal());
+            return JsonNode.createNumberNode(getBigDecimalFromNumber(number));
         }
     }
 

--- a/serde-support/src/main/java/io/micronaut/serde/support/AbstractStreamDecoder.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/AbstractStreamDecoder.java
@@ -403,16 +403,25 @@ public abstract class AbstractStreamDecoder extends LimitingStream implements De
     protected abstract Number getBestNumber() throws IOException;
 
     /**
-     * Converts the number, probably retrieved by calling {@link #getBestNumber()}, to a {@link BigDecimal},
-     * when it is not one of {@link Byte}, {@link Short}, {@link Integer}, {@link Long}, {@link Float},
-     * {@link Double}, {@link BigInteger}, {@link BigDecimal}
+     * Converts the number, probably retrieved by calling {@link #getBestNumber()}, to a {@link BigDecimal}.
      *
      * @param number The number value
      * @return The number as a big decimal
-     * @throws UnsupportedOperationException If custom number types are not expected
      */
     protected BigDecimal getBigDecimalFromNumber(Number number) {
-        throw new UnsupportedOperationException();
+        if (number instanceof BigDecimal bigDecimal) {
+            return bigDecimal;
+        }
+        if (number instanceof BigInteger bigInteger) {
+            return new BigDecimal(bigInteger);
+        }
+        if (number instanceof Double aDouble) {
+            return new BigDecimal(aDouble);
+        }
+        if (number instanceof Float aFloat) {
+            return new BigDecimal(aFloat);
+        }
+        return new BigDecimal(number.longValue());
     }
 
     /**

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/JsonNodeSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/JsonNodeSerde.java
@@ -48,8 +48,14 @@ final class JsonNodeSerde implements SerdeRegistrar<JsonNode> {
             encoder.encodeString(value.getStringValue());
         } else if (value.isNumber()) {
             Number numberValue = value.getNumberValue();
-            if (numberValue instanceof Integer || numberValue instanceof Byte || numberValue instanceof Short || numberValue instanceof Long) {
+            if (numberValue instanceof Integer) {
+                encoder.encodeInt(numberValue.intValue());
+            } else if (numberValue instanceof Long) {
                 encoder.encodeLong(numberValue.longValue());
+            } else if (numberValue instanceof Short) {
+                encoder.encodeShort(numberValue.shortValue());
+            } else if (numberValue instanceof Byte) {
+                encoder.encodeByte(numberValue.byteValue());
             } else if (numberValue instanceof BigInteger bi) {
                 encoder.encodeBigInteger(bi);
             } else if (numberValue instanceof BigDecimal bd) {


### PR DESCRIPTION
- Always use the right number type when serializing, so formats that support the type info can deserialize to the correct type. Currently, if you serialize an `int JsonNumber`, when deserializing you get a `long JsonNumber`.
- Fix fallback deserialization of custom `Number` implementations. The bson decoder advances when `getBigDecimal` is called - so, in the second call you either get an exception or one of the fields is swallowed.
- Fix element index increment when serializing `BigInteger`. Increment is already done by `encodeBigDecimal`.