### PR TITLE
Do not wrap IOExceptions in SerdeException

### DIFF
--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/ErrorCatchingDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/ErrorCatchingDeserializer.java
@@ -52,7 +52,7 @@ class ErrorCatchingDeserializer<T> implements Deserializer<T> {
             throw new SerdeException("Infinite recursion deserializing type: " + type, e);
         } catch (IntrospectionException e) {
             throw new SerdeException("Error deserializing. No deserializing found for type: " + type, e);
-        } catch (SerdeException e) {
+        } catch (IOException e) {
             throw e;
         } catch (Exception e) {
             throw new SerdeException("Error deserializing type: " + type, e);
@@ -67,7 +67,7 @@ class ErrorCatchingDeserializer<T> implements Deserializer<T> {
             throw new SerdeException("Infinite recursion deserializing type: " + type.getType(), e);
         } catch (IntrospectionException e) {
             throw new SerdeException("Error deserializing. No deserializing found for type: " + type, e);
-        } catch (SerdeException e) {
+        } catch (IOException e) {
             throw e;
         } catch (Exception e) {
             throw new SerdeException("Error deserializing type: " + type, e);

--- a/serde-tck-tests/src/main/java/io/micronaut/serde/tck/tests/JsonSyntaxExceptionTest.java
+++ b/serde-tck-tests/src/main/java/io/micronaut/serde/tck/tests/JsonSyntaxExceptionTest.java
@@ -1,0 +1,31 @@
+package io.micronaut.serde.tck.tests;
+
+import io.micronaut.core.type.Argument;
+import io.micronaut.json.JsonMapper;
+import io.micronaut.json.JsonSyntaxException;
+import io.micronaut.serde.annotation.Serdeable;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@MicronautTest(startApplication = false)
+public class JsonSyntaxExceptionTest {
+    @Test
+    public void testSyntaxException(JsonMapper jsonMapper) throws IOException {
+        String string = "{foo}";
+        byte[] bytes = string.getBytes(StandardCharsets.UTF_8);
+        Assertions.assertThrows(JsonSyntaxException.class, () -> jsonMapper.readValue(string, MyType.class));
+        Assertions.assertThrows(JsonSyntaxException.class, () -> jsonMapper.readValue(string, MyType.class));
+        Assertions.assertThrows(JsonSyntaxException.class, () -> jsonMapper.readValue(string, Argument.of(MyType.class)));
+        Assertions.assertThrows(JsonSyntaxException.class, () -> jsonMapper.readValue(bytes, Argument.of(MyType.class)));
+        Assertions.assertThrows(JsonSyntaxException.class, () -> jsonMapper.readValue(new ByteArrayInputStream(bytes), Argument.of(MyType.class)));
+        Assertions.assertThrows(JsonSyntaxException.class, () -> jsonMapper.readValue(new ByteArrayInputStream(bytes), MyType.class));
+    }
+
+    @Serdeable
+    record MyType(String foo) {}
+}

--- a/serde-tck-tests/src/main/java/io/micronaut/serde/tck/tests/JsonSyntaxExceptionTest.java
+++ b/serde-tck-tests/src/main/java/io/micronaut/serde/tck/tests/JsonSyntaxExceptionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.micronaut.serde.tck.tests;
 
 import io.micronaut.core.type.Argument;


### PR DESCRIPTION
IOExceptions, such as stream read errors or syntax errors should be thrown as-is, as declared on the Deserializer interface.

Fixes #941 