### PR TITLE
Allow access to serde registry from ObjectMapper

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/ObjectMapper.java
+++ b/serde-api/src/main/java/io/micronaut/serde/ObjectMapper.java
@@ -68,6 +68,15 @@ public interface ObjectMapper extends JsonMapper {
     }
 
     /**
+     * Returns the {@link SerdeRegistry} used by this object mapper, if possible.
+     *
+     * @return The serde registry
+     */
+    default @NonNull SerdeRegistry getSerdeRegistry() {
+        throw new UnsupportedOperationException("No accessible SerdeRegistry");
+    }
+
+    /**
      * Get the default ObjectMapper instance.
      *
      * <p>Note that this method returns

--- a/serde-api/src/main/java/io/micronaut/serde/ObjectMappers.java
+++ b/serde-api/src/main/java/io/micronaut/serde/ObjectMappers.java
@@ -103,6 +103,11 @@ final class ObjectMappers {
         return new ObjectMapper.CloseableObjectMapper() {
 
             @Override
+            public SerdeRegistry getSerdeRegistry() {
+                return objectMapper.getSerdeRegistry();
+            }
+
+            @Override
             public <T> T readValueFromTree(JsonNode tree, Argument<T> type) throws IOException {
                 return objectMapper.readValueFromTree(tree, type);
             }

--- a/serde-bson/src/main/java/io/micronaut/serde/bson/AbstractBsonMapper.java
+++ b/serde-bson/src/main/java/io/micronaut/serde/bson/AbstractBsonMapper.java
@@ -68,6 +68,11 @@ public abstract class AbstractBsonMapper implements ObjectMapper {
         this.decoderContext = registry.newDecoderContext(view);
     }
 
+    @Override
+    public SerdeRegistry getSerdeRegistry() {
+        return this.registry;
+    }
+
     protected abstract BsonReader createBsonReader(ByteBuffer byteBuffer);
 
     protected abstract AbstractBsonWriter createBsonWriter(OutputStream bsonOutput) throws IOException;

--- a/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonJsonMapper.java
+++ b/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonJsonMapper.java
@@ -125,6 +125,11 @@ public final class JacksonJsonMapper implements JacksonObjectMapper {
         this.specificSerializer = serializer;
     }
 
+    @Override
+    public SerdeRegistry getSerdeRegistry() {
+        return this.registry;
+    }
+
     @NonNull
     @Override
     public JsonMapper createSpecific(@NonNull Argument<?> type) {

--- a/serde-jsonp/src/main/java/io/micronaut/serde/json/stream/JsonStreamMapper.java
+++ b/serde-jsonp/src/main/java/io/micronaut/serde/json/stream/JsonStreamMapper.java
@@ -84,6 +84,11 @@ public class JsonStreamMapper implements ObjectMapper {
     }
 
     @Override
+    public SerdeRegistry getSerdeRegistry() {
+        return this.registry;
+    }
+
+    @Override
     public ObjectMapper cloneWithConfiguration(@Nullable SerdeConfiguration configuration, @Nullable SerializationConfiguration serializationConfiguration, @Nullable DeserializationConfiguration deserializationConfiguration) {
         return new JsonStreamMapper(registry.cloneWithConfiguration(configuration, serializationConfiguration, deserializationConfiguration), configuration == null ? serdeConfiguration : configuration, view);
     }

--- a/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/AbstractOracleJdbcJsonObjectMapper.java
+++ b/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/AbstractOracleJdbcJsonObjectMapper.java
@@ -73,6 +73,11 @@ abstract class AbstractOracleJdbcJsonObjectMapper implements ObjectMapper {
         this.view = view;
     }
 
+    @Override
+    public SerdeRegistry getSerdeRegistry() {
+        return this.registry;
+    }
+
     abstract OracleJsonParser getJsonParser(InputStream inputStream);
 
     abstract OracleJsonGenerator createJsonGenerator(OutputStream outputStream);


### PR DESCRIPTION
currently if you create an `ObjectMapper` there is no way to access the associated `SerdeRegistry`. Some implementations (like in Micronaut Data) that create the default mapper need access to this. This simple PR adds a getter to retrieve it.