### PR TITLE
Build time initialize DiscriminatorValueKind inner enum

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
@@ -16,6 +16,7 @@
 package io.micronaut.serde.config.annotation;
 
 import io.micronaut.context.annotation.Executable;
+import io.micronaut.core.annotation.BuildTimeInit;
 import io.micronaut.core.annotation.Internal;
 
 import java.lang.annotation.ElementType;
@@ -348,6 +349,7 @@ public @interface SerdeConfig {
         /**
          * The discriminator value kind.
          */
+        @BuildTimeInit("io.micronaut.serde.config.annotation.SerdeConfig$SerSubtyped$DiscriminatorValueKind")
         enum DiscriminatorValueKind {
             CLASS_NAME, CLASS_SIMPLE_NAME, NAME, MINIMAL_CLASS
         }


### PR DESCRIPTION
Since `DiscriminatorValueKind` enum is used as annotation value, the class needs to be build-time initialized.