### PR TITLE
Favor record constructor over builder for records

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ oracle-jdbc-driver = "23.6.0.24.10"
 jetbrains-annotations = "24.1.0"
 jmh = "1.37"
 groovy = "4.0.22"
+lombok = "1.18.36"
 
 micronaut = "4.7.12"
 micronaut-platform = "4.7.4"
@@ -48,6 +49,8 @@ jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "j
 aws-lambda-events = { module = "com.amazonaws:aws-lambda-java-events", version.ref = "aws-lambda-events" }
 aws-lambda-serialization = { module = "com.amazonaws:aws-lambda-java-serialization", version.ref = "aws-lambda-serialization" }
 graal-svm = { module = "org.graalvm.sdk:nativeimage", version.ref = "graal-svm" }
+lombok = { module = "org.projectlombok:lombok", version.ref = "lombok" }
+
 microstream-storage-restclient = { module = "one.microstream:microstream-storage-restclient", version.ref = "microstream-storage-restclient" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }

--- a/serde-jackson/build.gradle.kts
+++ b/serde-jackson/build.gradle.kts
@@ -17,6 +17,8 @@ dependencies {
     testAnnotationProcessor(projects.micronautSerdeProcessor)
 
     testCompileOnly(mn.micronaut.inject.groovy)
+    testImplementation(libs.lombok)
+    testAnnotationProcessor(libs.lombok)
 
     testImplementation(projects.micronautSerdeProcessor)
     testImplementation(projects.micronautSerdeTck)

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/lombok/DeserializeLombokBuilderSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/lombok/DeserializeLombokBuilderSpec.groovy
@@ -1,0 +1,28 @@
+package io.micronaut.serde.jackson.lombok
+
+import io.micronaut.serde.ObjectMapper
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Issue
+import spock.lang.Specification
+
+@MicronautTest
+class DeserializeLombokBuilderSpec extends Specification {
+    @Inject
+    ObjectMapper objectMapper
+
+    @Issue('https://github.com/micronaut-projects/micronaut-core/issues/11538')
+    void "test deserialize record with @Builder annotation"() {
+        when:
+        MyDTO myDTO = objectMapper.readValue(
+                '{ "id": 1, "common_field": "any", "common_field2": 10 }',
+                MyDTO
+        )
+
+        then:
+        myDTO != null
+        myDTO.id() == 1
+        myDTO.commonDTO().commonField() == 'any'
+        myDTO.commonDTO().commonField2() == 10
+    }
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/lombok/CommonDTO.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/lombok/CommonDTO.java
@@ -1,0 +1,15 @@
+package io.micronaut.serde.jackson.lombok;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.Serdeable;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Introspected
+@Serdeable.Deserializable
+public record CommonDTO(
+    @JsonProperty("common_field") @NotBlank String commonField,
+    @JsonProperty("common_field2") @NotNull Integer commonField2) {
+}
+

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/lombok/MyDTO.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/lombok/MyDTO.java
@@ -1,0 +1,17 @@
+package io.micronaut.serde.jackson.lombok;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.Serdeable;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+@Introspected
+@Serdeable.Deserializable
+public record MyDTO(
+    @JsonProperty("id") @NotNull Integer id,
+    @JsonUnwrapped @NotNull @Valid CommonDTO commonDTO) {
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBean.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBean.java
@@ -140,7 +140,9 @@ final class DeserBean<T> {
             .enumValue(Creator.class, "mode", SerdeConfig.SerCreatorMode.class)
             .orElse(null);
         delegating = creatorMode == SerdeConfig.SerCreatorMode.DELEGATING;
-        hasBuilder = introspection.hasBuilder();
+        hasBuilder = introspection.hasBuilder() &&
+            // always deserialize with record constructor
+            !introspection.getBeanType().isRecord();
         final Argument<?>[] constructorArguments = hasBuilder ? introspection.builder().getBuildMethodArguments() : introspection.getConstructorArguments();
         creatorSize = constructorArguments.length;
         PropertyNamingStrategy entityPropertyNamingStrategy = getPropertyNamingStrategy(introspection, decoderContext, defaultPropertyNamingStrategy);


### PR DESCRIPTION
With records the record components define the annotations necessary for deserialization so deserialisation should ignore the builder. Fixes https://github.com/micronaut-projects/micronaut-core/issues/11538 which is a regression.