### PR TITLE
@JsonIgnoreProperties and others should work on collection types

### DIFF
--- a/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonIgnoreSpec.groovy
+++ b/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonIgnoreSpec.groovy
@@ -240,6 +240,77 @@ class Test {
         context.close()
     }
 
+    void "test @JsonIgnoreProperties on collections"() {
+        given:
+        def context = buildContext('test.Parent', """
+package test;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.Map;
+import java.util.List;
+
+@Serdeable
+class Parent {
+    @JsonIgnoreProperties("ignored")
+    private Map<String, Test> map;
+    @JsonIgnoreProperties("ignored")
+    private List<Test> list;
+    public Map<String, Test> getMap() {
+        return map;
+    }
+    public void setMap(Map<String, Test> map) {
+        this.map = map;
+    }
+    public List<Test> getList() {
+        return list;
+    }
+    public void setList(List<Test> list) {
+        this.list = list;
+    }
+}
+
+@Serdeable
+class Test {
+    private String value;
+    private boolean ignored;
+    public void setValue(String value) {
+        this.value = value;
+    }
+    public String getValue() {
+        return value;
+    }
+
+    public void setIgnored(boolean b) {
+        this.ignored = b;
+    }
+
+    public boolean isIgnored() {
+        return ignored;
+    }
+}
+""")
+        def testInstance = newInstance(context, 'test.Test', [value: 'test'])
+        def parent = newInstance(context, 'test.Parent', [map:[foo:testInstance], list:[testInstance]])
+
+
+        when:
+        def result = writeJson(jsonMapper, parent)
+
+        then:
+        result == '{"map":{"foo":{"value":"test"}},"list":[{"value":"test"}]}'
+
+        when:"deserialization happens"
+        def value = jsonMapper.readValue('{"map":{"foo":{"value":"test", "ignored":true}},"list":[{"value":"test", "ignored":true}]}',  parent.getClass())
+
+        then:"the property is ignored for the purposes of deserialization"
+        value.map.foo.ignored == false
+        value.list[0].ignored == false
+
+        cleanup:
+        context.close()
+    }
+
     void "test simple @JsonIncludeProperties"() {
         given:
         def context = buildContext('test.Test', """

--- a/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonIgnoreSpec.groovy
+++ b/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonIgnoreSpec.groovy
@@ -290,7 +290,7 @@ class Test {
     }
 }
 """)
-        def testInstance = newInstance(context, 'test.Test', [value: 'test'])
+        def testInstance = newInstance(context, 'test.Test', [value: 'test', ignored:true])
         def parent = newInstance(context, 'test.Parent', [map:[foo:testInstance], list:[testInstance]])
 
 

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/SpecificOnlyCollectionDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/SpecificOnlyCollectionDeserializer.java
@@ -19,8 +19,10 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.config.annotation.SerdeConfig;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.DeserializerRegistrar;
+import io.micronaut.serde.support.util.SerdeArgumentConf;
 import io.micronaut.serde.util.CustomizableDeserializer;
 
 import java.util.Collection;
@@ -40,7 +42,10 @@ abstract class SpecificOnlyCollectionDeserializer<E, C extends Collection<E>> im
         if (ArrayUtils.isEmpty(generics)) {
             throw new SerdeException("Cannot deserialize raw list");
         }
-        @SuppressWarnings("unchecked") final Argument<E> collectionItemArgument = (Argument<E>) generics[0];
+        @SuppressWarnings("unchecked") Argument<E> collectionItemArgument = (Argument<E>) generics[0];
+        if (type.getAnnotationMetadata().hasStereotype(SerdeConfig.class)) {
+            collectionItemArgument = SerdeArgumentConf.reconstructGenericWithParentMetadata(type, collectionItemArgument);
+        }
         final Deserializer<? extends E> valueDeser = context.findDeserializer(collectionItemArgument)
             .createSpecific(context, collectionItemArgument);
 

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/SpecificOnlyCollectionDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/SpecificOnlyCollectionDeserializer.java
@@ -19,7 +19,6 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
 import io.micronaut.serde.Deserializer;
-import io.micronaut.serde.config.annotation.SerdeConfig;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.DeserializerRegistrar;
 import io.micronaut.serde.support.util.SerdeArgumentConf;
@@ -42,10 +41,7 @@ abstract class SpecificOnlyCollectionDeserializer<E, C extends Collection<E>> im
         if (ArrayUtils.isEmpty(generics)) {
             throw new SerdeException("Cannot deserialize raw list");
         }
-        @SuppressWarnings("unchecked") Argument<E> collectionItemArgument = (Argument<E>) generics[0];
-        if (type.getAnnotationMetadata().hasStereotype(SerdeConfig.class)) {
-            collectionItemArgument = SerdeArgumentConf.reconstructGenericWithParentMetadata(type, collectionItemArgument);
-        }
+        @SuppressWarnings("unchecked") final Argument<E> collectionItemArgument = SerdeArgumentConf.reconstructGenericWithParentMetadata(type, (Argument<E>) generics[0]);
         final Deserializer<? extends E> valueDeser = context.findDeserializer(collectionItemArgument)
             .createSpecific(context, collectionItemArgument);
 

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/SpecificOnlyMapDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/SpecificOnlyMapDeserializer.java
@@ -20,8 +20,10 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.config.annotation.SerdeConfig;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.DeserializerRegistrar;
+import io.micronaut.serde.support.util.SerdeArgumentConf;
 import io.micronaut.serde.util.CustomizableDeserializer;
 
 import java.io.IOException;
@@ -41,7 +43,10 @@ abstract class SpecificOnlyMapDeserializer<K, V, M extends Map<K, V>> implements
         final Argument<?>[] generics = type.getTypeParameters();
         if (generics.length == 2) {
             @SuppressWarnings("unchecked") final Argument<K> keyType = (Argument<K>) generics[0];
-            @SuppressWarnings("unchecked") final Argument<V> valueType = (Argument<V>) generics[1];
+            @SuppressWarnings("unchecked") Argument<V> valueType = (Argument<V>) generics[1];
+            if (type.getAnnotationMetadata().hasStereotype(SerdeConfig.class)) {
+                valueType = SerdeArgumentConf.reconstructGenericWithParentMetadata(type, valueType);
+            }
             final Deserializer<? extends V> valueDeser = valueType.equalsType(Argument.OBJECT_ARGUMENT) ? null : context.findDeserializer(valueType)
                 .createSpecific(context, valueType);
             return createSpecific(keyType, valueType, valueDeser);

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/SpecificOnlyMapDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/SpecificOnlyMapDeserializer.java
@@ -20,7 +20,6 @@ import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Deserializer;
-import io.micronaut.serde.config.annotation.SerdeConfig;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.DeserializerRegistrar;
 import io.micronaut.serde.support.util.SerdeArgumentConf;
@@ -43,10 +42,7 @@ abstract class SpecificOnlyMapDeserializer<K, V, M extends Map<K, V>> implements
         final Argument<?>[] generics = type.getTypeParameters();
         if (generics.length == 2) {
             @SuppressWarnings("unchecked") final Argument<K> keyType = (Argument<K>) generics[0];
-            @SuppressWarnings("unchecked") Argument<V> valueType = (Argument<V>) generics[1];
-            if (type.getAnnotationMetadata().hasStereotype(SerdeConfig.class)) {
-                valueType = SerdeArgumentConf.reconstructGenericWithParentMetadata(type, valueType);
-            }
+            @SuppressWarnings("unchecked") Argument<V> valueType = SerdeArgumentConf.reconstructGenericWithParentMetadata(type, (Argument<V>) generics[1]);
             final Deserializer<? extends V> valueDeser = valueType.equalsType(Argument.OBJECT_ARGUMENT) ? null : context.findDeserializer(valueType)
                 .createSpecific(context, valueType);
             return createSpecific(keyType, valueType, valueDeser);

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/SpecificOnlyMapDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/SpecificOnlyMapDeserializer.java
@@ -42,7 +42,7 @@ abstract class SpecificOnlyMapDeserializer<K, V, M extends Map<K, V>> implements
         final Argument<?>[] generics = type.getTypeParameters();
         if (generics.length == 2) {
             @SuppressWarnings("unchecked") final Argument<K> keyType = (Argument<K>) generics[0];
-            @SuppressWarnings("unchecked") Argument<V> valueType = SerdeArgumentConf.reconstructGenericWithParentMetadata(type, (Argument<V>) generics[1]);
+            @SuppressWarnings("unchecked") final Argument<V> valueType = SerdeArgumentConf.reconstructGenericWithParentMetadata(type, (Argument<V>) generics[1]);
             final Deserializer<? extends V> valueDeser = valueType.equalsType(Argument.OBJECT_ARGUMENT) ? null : context.findDeserializer(valueType)
                 .createSpecific(context, valueType);
             return createSpecific(keyType, valueType, valueDeser);

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedMapSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedMapSerializer.java
@@ -54,7 +54,7 @@ final class CustomizedMapSerializer<K, V> implements CustomizableSerializer<Map<
             final boolean isStringKey = keyGeneric.getType().equals(String.class) || CharSequence.class.isAssignableFrom(keyGeneric.getType());
             // if there are annotations on the map property we need to combine the annotation metadata with the generic.
             @SuppressWarnings("unchecked")
-            Argument<V> valueGeneric = SerdeArgumentConf.reconstructGenericWithParentMetadata(type, (Argument<V>) generics[1]);
+            final Argument<V> valueGeneric = SerdeArgumentConf.reconstructGenericWithParentMetadata(type, (Argument<V>) generics[1]);
 
             final Serializer<V> valSerializer = (Serializer<V>) context.findSerializer(valueGeneric).createSpecific(context, valueGeneric);
             return new ObjectSerializer<>() {

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedMapSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedMapSerializer.java
@@ -25,9 +25,11 @@ import io.micronaut.json.tree.JsonNode;
 import io.micronaut.serde.Encoder;
 import io.micronaut.serde.ObjectSerializer;
 import io.micronaut.serde.Serializer;
+import io.micronaut.serde.config.annotation.SerdeConfig;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.SerializerRegistrar;
 import io.micronaut.serde.support.util.JsonNodeEncoder;
+import io.micronaut.serde.support.util.SerdeArgumentConf;
 import io.micronaut.serde.util.CustomizableSerializer;
 
 import java.io.IOException;
@@ -51,8 +53,13 @@ final class CustomizedMapSerializer<K, V> implements CustomizableSerializer<Map<
             final Argument<K> keyGeneric = (Argument<K>) generics[0];
             final Serializer<K> keySerializer = findKeySerializer(context, keyGeneric);
             final boolean isStringKey = keyGeneric.getType().equals(String.class) || CharSequence.class.isAssignableFrom(keyGeneric.getType());
-            final Argument<V> valueGeneric = (Argument<V>) generics[1];
+            Argument<V> valueGeneric = (Argument<V>) generics[1];
+            // if there are annotations on the map property we need to combine the annotation metadata with the generic.
+            if (type.getAnnotationMetadata().hasStereotype(SerdeConfig.class)) {
+                valueGeneric = SerdeArgumentConf.reconstructGenericWithParentMetadata(type, valueGeneric);
+            }
             final Serializer<V> valSerializer = (Serializer<V>) context.findSerializer(valueGeneric).createSpecific(context, valueGeneric);
+            Argument<V> finalValueGeneric = valueGeneric;
             return new ObjectSerializer<>() {
 
                 @Override
@@ -77,7 +84,7 @@ final class CustomizedMapSerializer<K, V> implements CustomizableSerializer<Map<
                         if (v == null) {
                             encoder.encodeNull();
                         } else {
-                            valSerializer.serialize(encoder, context, valueGeneric, v);
+                            valSerializer.serialize(encoder, context, finalValueGeneric, v);
                         }
                     }
                 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedMapSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedMapSerializer.java
@@ -25,7 +25,6 @@ import io.micronaut.json.tree.JsonNode;
 import io.micronaut.serde.Encoder;
 import io.micronaut.serde.ObjectSerializer;
 import io.micronaut.serde.Serializer;
-import io.micronaut.serde.config.annotation.SerdeConfig;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.SerializerRegistrar;
 import io.micronaut.serde.support.util.JsonNodeEncoder;
@@ -53,13 +52,11 @@ final class CustomizedMapSerializer<K, V> implements CustomizableSerializer<Map<
             final Argument<K> keyGeneric = (Argument<K>) generics[0];
             final Serializer<K> keySerializer = findKeySerializer(context, keyGeneric);
             final boolean isStringKey = keyGeneric.getType().equals(String.class) || CharSequence.class.isAssignableFrom(keyGeneric.getType());
-            Argument<V> valueGeneric = (Argument<V>) generics[1];
             // if there are annotations on the map property we need to combine the annotation metadata with the generic.
-            if (type.getAnnotationMetadata().hasStereotype(SerdeConfig.class)) {
-                valueGeneric = SerdeArgumentConf.reconstructGenericWithParentMetadata(type, valueGeneric);
-            }
+            @SuppressWarnings("unchecked")
+            Argument<V> valueGeneric = SerdeArgumentConf.reconstructGenericWithParentMetadata(type, (Argument<V>) generics[1]);
+
             final Serializer<V> valSerializer = (Serializer<V>) context.findSerializer(valueGeneric).createSpecific(context, valueGeneric);
-            Argument<V> finalValueGeneric = valueGeneric;
             return new ObjectSerializer<>() {
 
                 @Override
@@ -84,7 +81,7 @@ final class CustomizedMapSerializer<K, V> implements CustomizableSerializer<Map<
                         if (v == null) {
                             encoder.encodeNull();
                         } else {
-                            valSerializer.serialize(encoder, context, finalValueGeneric, v);
+                            valSerializer.serialize(encoder, context, valueGeneric, v);
                         }
                     }
                 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/IterableSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/IterableSerializer.java
@@ -17,9 +17,12 @@ package io.micronaut.serde.support.serializers;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
+import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.serde.Serializer;
+import io.micronaut.serde.config.annotation.SerdeConfig;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.SerializerRegistrar;
+import io.micronaut.serde.support.util.SerdeArgumentConf;
 import io.micronaut.serde.util.CustomizableSerializer;
 
 /**
@@ -33,9 +36,13 @@ final class IterableSerializer<T> implements CustomizableSerializer<Iterable<T>>
             throws SerdeException {
         final Argument<?>[] generics = type.getTypeParameters();
         if (generics.length > 0) {
-            @SuppressWarnings("unchecked") final Argument<T> generic = (Argument<T>) generics[0];
+            @SuppressWarnings("unchecked") Argument<T> generic = (Argument<T>) generics[0];
             if (generic.getType() == String.class) {
                 return (Serializer) StringIterableSerializer.INSTANCE;
+            }
+            // if there are annotations on the collection property we need to combine the annotation metadata with the generic.
+            if (type.getAnnotationMetadata().hasStereotype(SerdeConfig.class)) {
+                generic = SerdeArgumentConf.reconstructGenericWithParentMetadata(type, generic);
             }
             Serializer<? super T> componentSerializer = context.findSerializer(generic)
                     .createSpecific(context, generic);

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/IterableSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/IterableSerializer.java
@@ -17,13 +17,12 @@ package io.micronaut.serde.support.serializers;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
-import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.serde.Serializer;
-import io.micronaut.serde.config.annotation.SerdeConfig;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.SerializerRegistrar;
-import io.micronaut.serde.support.util.SerdeArgumentConf;
 import io.micronaut.serde.util.CustomizableSerializer;
+
+import static io.micronaut.serde.support.util.SerdeArgumentConf.reconstructGenericWithParentMetadata;
 
 /**
  * A serializer for any iterable.
@@ -36,14 +35,11 @@ final class IterableSerializer<T> implements CustomizableSerializer<Iterable<T>>
             throws SerdeException {
         final Argument<?>[] generics = type.getTypeParameters();
         if (generics.length > 0) {
-            @SuppressWarnings("unchecked") Argument<T> generic = (Argument<T>) generics[0];
+            @SuppressWarnings("unchecked") final Argument<T> generic = reconstructGenericWithParentMetadata(type, (Argument<T>) generics[0]);
             if (generic.getType() == String.class) {
                 return (Serializer) StringIterableSerializer.INSTANCE;
             }
             // if there are annotations on the collection property we need to combine the annotation metadata with the generic.
-            if (type.getAnnotationMetadata().hasStereotype(SerdeConfig.class)) {
-                generic = SerdeArgumentConf.reconstructGenericWithParentMetadata(type, generic);
-            }
             Serializer<? super T> componentSerializer = context.findSerializer(generic)
                     .createSpecific(context, generic);
             return new CustomizedIterableSerializer<>(generic, componentSerializer);

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/IterableSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/IterableSerializer.java
@@ -35,11 +35,11 @@ final class IterableSerializer<T> implements CustomizableSerializer<Iterable<T>>
             throws SerdeException {
         final Argument<?>[] generics = type.getTypeParameters();
         if (generics.length > 0) {
+            // if there are annotations on the collection property we need to combine the annotation metadata with the generic.
             @SuppressWarnings("unchecked") final Argument<T> generic = reconstructGenericWithParentMetadata(type, (Argument<T>) generics[0]);
             if (generic.getType() == String.class) {
                 return (Serializer) StringIterableSerializer.INSTANCE;
             }
-            // if there are annotations on the collection property we need to combine the annotation metadata with the generic.
             Serializer<? super T> componentSerializer = context.findSerializer(generic)
                     .createSpecific(context, generic);
             return new CustomizedIterableSerializer<>(generic, componentSerializer);

--- a/serde-support/src/main/java/io/micronaut/serde/support/util/SerdeArgumentConf.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/util/SerdeArgumentConf.java
@@ -23,6 +23,7 @@ import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.inject.annotation.MutableAnnotationMetadata;
 import io.micronaut.serde.config.annotation.SerdeConfig;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -81,6 +82,22 @@ public final class SerdeArgumentConf {
         }
         this.order = order;
         this.subtypeInfo = SubtypeInfo.createForProperty(annotationMetadata);
+    }
+
+    /**
+     * Reconstruct the generic type with parent metadata if necessary.
+     * @param parentType The parent type
+     * @param valueGeneric The generic
+     * @return The new argument
+     * @param <V> The value generic
+     */
+    public static <V> @NotNull Argument<V> reconstructGenericWithParentMetadata(@NotNull Argument<?> parentType, @NotNull Argument<V> valueGeneric) {
+        return Argument.of(
+            valueGeneric.getType(),
+            valueGeneric.getName(),
+            new AnnotationMetadataHierarchy(true, parentType.getAnnotationMetadata(), valueGeneric.getAnnotationMetadata()),
+            valueGeneric.getTypeParameters()
+        );
     }
 
     /**

--- a/serde-support/src/main/java/io/micronaut/serde/support/util/SerdeArgumentConf.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/util/SerdeArgumentConf.java
@@ -17,13 +17,13 @@ package io.micronaut.serde.support.util;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
 import io.micronaut.inject.annotation.MutableAnnotationMetadata;
 import io.micronaut.serde.config.annotation.SerdeConfig;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -91,7 +91,7 @@ public final class SerdeArgumentConf {
      * @return The new argument
      * @param <V> The value generic
      */
-    public static <V> @NotNull Argument<V> reconstructGenericWithParentMetadata(@NotNull Argument<?> parentType, @NotNull Argument<V> valueGeneric) {
+    public static <V> @NonNull Argument<V> reconstructGenericWithParentMetadata(@NonNull Argument<?> parentType, @NonNull Argument<V> valueGeneric) {
         if (parentType.getAnnotationMetadata().hasStereotype(SerdeConfig.class)) {
             AnnotationMetadataHierarchy reconstructed = new AnnotationMetadataHierarchy(true, parentType.getAnnotationMetadata(), valueGeneric.getAnnotationMetadata());
             return valueGeneric

--- a/serde-support/src/main/java/io/micronaut/serde/support/util/SerdeArgumentConf.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/util/SerdeArgumentConf.java
@@ -92,12 +92,12 @@ public final class SerdeArgumentConf {
      * @param <V> The value generic
      */
     public static <V> @NotNull Argument<V> reconstructGenericWithParentMetadata(@NotNull Argument<?> parentType, @NotNull Argument<V> valueGeneric) {
-        return Argument.of(
-            valueGeneric.getType(),
-            valueGeneric.getName(),
-            new AnnotationMetadataHierarchy(true, parentType.getAnnotationMetadata(), valueGeneric.getAnnotationMetadata()),
-            valueGeneric.getTypeParameters()
-        );
+        if (parentType.getAnnotationMetadata().hasStereotype(SerdeConfig.class)) {
+            AnnotationMetadataHierarchy reconstructed = new AnnotationMetadataHierarchy(true, parentType.getAnnotationMetadata(), valueGeneric.getAnnotationMetadata());
+            return valueGeneric
+                .withAnnotationMetadata(reconstructed);
+        }
+        return valueGeneric;
     }
 
     /**


### PR DESCRIPTION
Contrary to the way Jackson works @JsonIgnoreProperties is not respected on map/collection types. This fixes that by combing the metadata.