### PR TITLE
Support `@JsonInclude(NON_DEFAULT)`

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/Serializer.java
+++ b/serde-api/src/main/java/io/micronaut/serde/Serializer.java
@@ -90,6 +90,18 @@ public interface Serializer<T> {
     }
 
     /**
+     * Used for {@code JsonInclude.Include#NON_DEFAULT} checking.
+     *
+     * @param context The encoder context
+     * @param value The check to check
+     * @return Return {@code true} if the value is the default value
+     * @since 1.14
+     */
+    default boolean isDefault(@NonNull EncoderContext context, @NonNull T value) {
+        return false;
+    }
+
+    /**
      * Context object passes to the
      * {@link #serialize(Encoder, EncoderContext, Argument, Object)}  method.
      */

--- a/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
@@ -403,6 +403,13 @@ public @interface SerdeConfig {
         NON_EMPTY,
 
         /**
+         * Value that indicates that properties are included unless their value is the default value
+         * of the property type as defined by its Java implementation.
+         * All values considered "empty" (as per NON_EMPTY) are also excluded.
+         */
+        NON_DEFAULT,
+
+        /**
          * Ignore the property.
          */
         NEVER

--- a/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonIncludeSpec.groovy
+++ b/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonIncludeSpec.groovy
@@ -18,8 +18,12 @@ package io.micronaut.serde.jackson
 
 import spock.lang.Unroll
 
+import java.sql.Date
+import java.sql.Timestamp
+
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.ALWAYS
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_ABSENT
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_DEFAULT
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL
 
@@ -275,6 +279,32 @@ record Test(
         NON_EMPTY  | "Map<String, String>" | null             | '{}'
         NON_EMPTY  | "Map<String, String>" | ["test": "test"] | '{"test":{"test":"test"}}'
 
+        NON_DEFAULT| "String"              | "test"           | '{"test":"test"}'
+        NON_DEFAULT| "String"              | null             | '{}'
+        NON_DEFAULT| "java.util.List"      | null             | '{}'
+        NON_DEFAULT| "Boolean"             | false            | '{}'
+        NON_DEFAULT| "boolean"             | false            | '{}'
+        NON_DEFAULT| "Integer"             | 0                | '{}'
+        NON_DEFAULT| "int"                 | 0                | '{}'
+        NON_DEFAULT| "Long"                | 0                | '{}'
+        NON_DEFAULT| "long"                | 0                | '{}'
+        NON_DEFAULT| "Double"              | 0                | '{}'
+        NON_DEFAULT| "double"              | 0                | '{}'
+        NON_DEFAULT| "Float"               | 0                | '{}'
+        NON_DEFAULT| "float"               | 0                | '{}'
+        NON_DEFAULT| "Byte"                | 0 as byte        | '{}'
+        NON_DEFAULT| "byte"                | 0 as byte        | '{}'
+        NON_DEFAULT| "Short"               | 0 as short       | '{}'
+        NON_DEFAULT| "short"               | 0 as short       | '{}'
+        NON_DEFAULT| "Character"           | 0 as char        | '{}'
+        NON_DEFAULT| "char"                | 0 as char        | '{}'
+        NON_DEFAULT| "java.util.Date"      | new java.util.Date(0) | '{}'
+        NON_DEFAULT| "java.sql.Date"       | new Date(0)           | '{}'
+        NON_DEFAULT| "java.sql.Timestamp"  | new Timestamp(0)      | '{}'
+        NON_DEFAULT| "java.math.BigInteger"| BigInteger.valueOf(0) | '{"test":0}'
+        NON_DEFAULT| "java.lang.Number"    | 0                     | '{"test":0}'
+        NON_DEFAULT| "int[]"               | new int[0]            | '{}'
+
     }
 
     @Unroll
@@ -306,16 +336,44 @@ record Test(
         include    | type                  | value            | result
         ALWAYS     | "String"              | ""               | '{"test":""}'
         ALWAYS     | "String"              | null             | '{"test":null}'
+        ALWAYS     | "java.util.List"      | null             | '{"test":null}'
         ALWAYS     | "String"              | "test"           | '{"test":"test"}'
         NON_NULL   | "String"              | ""               | '{"test":""}'
         NON_NULL   | "String"              | null             | '{}'
+        NON_NULL   | "java.util.List"      | null             | '{}'
         NON_NULL   | "String"              | "test"           | '{"test":"test"}'
         NON_ABSENT | "String"              | ""               | '{"test":""}'
         NON_ABSENT | "String"              | null             | '{}'
+        NON_ABSENT | "java.util.List"      | null             | '{}'
         NON_ABSENT | "String"              | "test"           | '{"test":"test"}'
         NON_EMPTY  | "String"              | ""               | '{}'
         NON_EMPTY  | "String"              | null             | '{}'
+        NON_EMPTY  | "java.util.List"      | null             | '{}'
         NON_EMPTY  | "String"              | "test"           | '{"test":"test"}'
-
+        NON_DEFAULT| "String"              | "test"           | '{"test":"test"}'
+        NON_DEFAULT| "String"              | null             | '{}'
+        NON_DEFAULT| "java.util.List"      | null             | '{}'
+        NON_DEFAULT| "Boolean"             | false            | '{}'
+        NON_DEFAULT| "boolean"             | false            | '{}'
+        NON_DEFAULT| "Integer"             | 0                | '{}'
+        NON_DEFAULT| "int"                 | 0                | '{}'
+        NON_DEFAULT| "Long"                | 0                | '{}'
+        NON_DEFAULT| "long"                | 0                | '{}'
+        NON_DEFAULT| "Double"              | 0                | '{}'
+        NON_DEFAULT| "double"              | 0                | '{}'
+        NON_DEFAULT| "Float"               | 0                | '{}'
+        NON_DEFAULT| "float"               | 0                | '{}'
+        NON_DEFAULT| "Byte"                | 0 as byte        | '{}'
+        NON_DEFAULT| "byte"                | 0 as byte        | '{}'
+        NON_DEFAULT| "Short"               | 0 as short       | '{}'
+        NON_DEFAULT| "short"               | 0 as short       | '{}'
+        NON_DEFAULT| "Character"           | 0 as char        | '{}'
+        NON_DEFAULT| "char"                | 0 as char        | '{}'
+        NON_DEFAULT| "java.util.Date"      | new java.util.Date(0) | '{}'
+        NON_DEFAULT| "java.sql.Date"       | new Date(0)           | '{}'
+        NON_DEFAULT| "java.sql.Timestamp"  | new Timestamp(0)      | '{}'
+        NON_DEFAULT| "java.math.BigInteger"| BigInteger.valueOf(0) | '{"test":0}'
+        NON_DEFAULT| "java.lang.Number"    | 0                     | '{"test":0}'
+        NON_DEFAULT| "int[]"               | new int[0]            | '{}'
     }
 }

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeJsonIncludeSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeJsonIncludeSpec.groovy
@@ -1,6 +1,7 @@
 package io.micronaut.serde.jackson.annotation
 
 import io.micronaut.serde.jackson.JsonIncludeSpec
+import spock.lang.PendingFeature
 import spock.lang.Unroll
 
 class SerdeJsonIncludeSpec extends JsonIncludeSpec {
@@ -104,6 +105,48 @@ class Test {
             "OptionalInt"      | [value: OptionalInt.empty()]    | '{"value":null}'
             "OptionalDouble"   | [value: OptionalDouble.empty()] | '{"value":null}'
             "OptionalLong"     | [value: OptionalLong.empty()]   | '{"value":null}'
+    }
+
+    @PendingFeature(reason = "Databind in a case of @JsonInclude(NON_DEFAULT) on a class also compares the defaults of the empty bean")
+    @Unroll
+    void "test @JsonInclude(NON_DEFAULT) on class"() {
+        given:
+            def context = buildContext('test.Test', """
+package test;
+
+import java.util.*;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.micronaut.serde.annotation.Serdeable;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.*;
+
+@Serdeable
+@JsonInclude(NON_DEFAULT)
+class Test {
+    private String value = "abc";
+    public void setValue(String value) {
+        this.value = value;
+    }
+    public String getValue() {
+        return value;
+    }
+}
+""")
+        when:
+            def bean = newInstance(context, 'test.Test')
+            bean.value = value
+            String json = writeJson(jsonMapper, bean)
+        then:
+            json == result
+
+        cleanup:
+            context.close()
+
+        where:
+            value | result
+            null  | """{"value":null}"""
+            "abc"  | """{}"""
+            "xyz"  | """{"value":"xyz"}"""
     }
 
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/BooleanSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/BooleanSerde.java
@@ -46,6 +46,11 @@ final class BooleanSerde implements SerdeRegistrar<Boolean> {
     }
 
     @Override
+    public boolean isDefault(EncoderContext context, Boolean value) {
+        return !value;
+    }
+
+    @Override
     public Argument<Boolean> getType() {
         return Argument.of(Boolean.class);
     }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/ByteSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/ByteSerde.java
@@ -48,6 +48,11 @@ final class ByteSerde implements SerdeRegistrar<Byte>, NumberSerde<Byte> {
     }
 
     @Override
+    public boolean isDefault(EncoderContext context, Byte value) {
+        return value.equals((byte) 0);
+    }
+
+    @Override
     public Argument<Byte> getType() {
         return Argument.of(Byte.class);
     }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/CharSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/CharSerde.java
@@ -48,6 +48,11 @@ final class CharSerde implements SerdeRegistrar<Character> {
     }
 
     @Override
+    public boolean isDefault(EncoderContext context, Character value) {
+        return value.equals('\0');
+    }
+
+    @Override
     public Argument<Character> getType() {
         return Argument.of(Character.class);
     }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/DateSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/DateSerde.java
@@ -47,11 +47,21 @@ final class DateSerde implements SerdeRegistrar<Date> {
                 encoderContext, argument
         );
         if (specific != instantSerde) {
-            return (encoder, context, t, value) -> specific.serialize(
-                    encoder,
-                    context,
-                    argument, value.toInstant()
-            );
+            return new Serializer<>() {
+                @Override
+                public void serialize(Encoder encoder, EncoderContext context, Argument<? extends Date> t, Date value) throws IOException {
+                    specific.serialize(
+                        encoder,
+                        context,
+                        argument, value.toInstant()
+                    );
+                }
+
+                @Override
+                public boolean isDefault(EncoderContext context, Date value) {
+                    return value.getTime() == 0L;
+                }
+            };
         }
         return this;
     }
@@ -90,6 +100,11 @@ final class DateSerde implements SerdeRegistrar<Date> {
                 decoderContext,
                 INSTANT_ARGUMENT
         ));
+    }
+
+    @Override
+    public boolean isDefault(EncoderContext context, Date value) {
+        return value.getTime() == 0L;
     }
 
     @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/DoubleSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/DoubleSerde.java
@@ -49,6 +49,11 @@ final class DoubleSerde implements SerdeRegistrar<Double>, NumberSerde<Double> {
     }
 
     @Override
+    public boolean isDefault(EncoderContext context, Double value) {
+        return value.equals(0D);
+    }
+
+    @Override
     public Argument<Double> getType() {
         return Argument.of(Double.class);
     }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/FloatSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/FloatSerde.java
@@ -49,6 +49,11 @@ final class FloatSerde implements SerdeRegistrar<Float>, NumberSerde<Float> {
     }
 
     @Override
+    public boolean isDefault(EncoderContext context, Float value) {
+        return value.equals(0F);
+    }
+
+    @Override
     public Argument<Float> getType() {
         return Argument.of(Float.class);
     }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/IntegerSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/IntegerSerde.java
@@ -49,6 +49,11 @@ final class IntegerSerde implements SerdeRegistrar<Integer>, NumberSerde<Integer
     }
 
     @Override
+    public boolean isDefault(EncoderContext context, Integer value) {
+        return value.equals(0);
+    }
+
+    @Override
     public Argument<Integer> getType() {
         return Argument.of(Integer.class);
     }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/LongSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/LongSerde.java
@@ -62,4 +62,9 @@ final class LongSerde implements SerdeRegistrar<Long>, NumberSerde<Long> {
     public Long getDefaultValue(@NonNull DecoderContext context, @NonNull Argument<? super Long> type) {
         return type.isPrimitive() ? 0L : null;
     }
+
+    @Override
+    public boolean isDefault(EncoderContext context, Long value) {
+        return value.equals(0L);
+    }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/ShortSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/ShortSerde.java
@@ -48,6 +48,11 @@ final class ShortSerde implements SerdeRegistrar<Short>, NumberSerde<Short> {
     }
 
     @Override
+    public boolean isDefault(EncoderContext context, Short value) {
+        return value.equals((short) 0);
+    }
+
+    @Override
     public Argument<Short> getType() {
         return Argument.of(Short.class);
     }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/SqlDateSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/SqlDateSerde.java
@@ -70,11 +70,21 @@ final class SqlDateSerde implements SerdeRegistrar<Date> {
                 encoderContext, argument
         );
         if (specific != localDateSerde) {
-            return (encoder, context, t, value) -> specific.serialize(
-                    encoder,
-                    context,
-                    argument, value.toLocalDate()
-            );
+            return new Serializer<>() {
+                @Override
+                public void serialize(Encoder encoder, EncoderContext context, Argument<? extends Date> t, Date value) throws IOException {
+                    specific.serialize(
+                        encoder,
+                        context,
+                        argument, value.toLocalDate()
+                    );
+                }
+
+                @Override
+                public boolean isDefault(EncoderContext context, Date value) {
+                    return value.getTime() == 0L;
+                }
+            };
         }
         return this;
     }
@@ -100,6 +110,11 @@ final class SqlDateSerde implements SerdeRegistrar<Date> {
             return Date.valueOf(localDate);
         }
         return null;
+    }
+
+    @Override
+    public boolean isDefault(EncoderContext context, Date value) {
+        return value.getTime() == 0L;
     }
 
     @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/SqlTimestampSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/SqlTimestampSerde.java
@@ -45,11 +45,21 @@ final class SqlTimestampSerde implements SerdeRegistrar<Timestamp> {
                 encoderContext, argument
         );
         if (specific != instantSerde) {
-            return (encoder, context, t, value) -> specific.serialize(
-                    encoder,
-                    context,
-                    argument, value.toInstant()
-            );
+            return new Serializer<>() {
+                @Override
+                public void serialize(Encoder encoder, EncoderContext context, Argument<? extends Timestamp> t, Timestamp value) throws IOException {
+                    specific.serialize(
+                        encoder,
+                        context,
+                        argument, value.toInstant()
+                    );
+                }
+
+                @Override
+                public boolean isDefault(EncoderContext context, Timestamp value) {
+                    return value.getTime() == 0L;
+                }
+            };
         }
         return this;
     }
@@ -87,6 +97,11 @@ final class SqlTimestampSerde implements SerdeRegistrar<Timestamp> {
                 decoderContext,
                 INSTANT_ARGUMENT
         ));
+    }
+
+    @Override
+    public boolean isDefault(EncoderContext context, Timestamp value) {
+        return value.getTime() == 0L;
     }
 
     @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedObjectSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedObjectSerializer.java
@@ -17,6 +17,7 @@ package io.micronaut.serde.support.serializers;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
+import io.micronaut.json.JsonMapper;
 import io.micronaut.serde.Encoder;
 import io.micronaut.serde.ObjectSerializer;
 import io.micronaut.serde.Serializer;
@@ -36,7 +37,7 @@ import java.util.Map;
  * This class is used in multiple scenarios:
  * <ul>
  *     <li>When the user has an {@link Object} property in a serializable bean.</li>
- *     <li>When the user explicitly calls {@link io.micronaut.json.JsonMapper#writeValue}{@code (gen, }{@link Object}{@code
+ *     <li>When the user explicitly calls {@link JsonMapper#writeValue}{@code (gen, }{@link Object}{@code
  *     .class)}</li>
  * </ul>
  *
@@ -83,30 +84,16 @@ final class CustomizedObjectSerializer<T> implements ObjectSerializer<T> {
                         continue;
                     }
                 } else {
-                    switch (property.include) {
-                        case NON_NULL:
-                            if (propertyValue == null) {
-                                continue;
-                            }
-                            break;
-                        case NON_ABSENT:
-                            if (serializer.isAbsent(context, propertyValue)) {
-                                continue;
-                            }
-                            break;
-                        case NON_EMPTY:
-                            if (serializer.isEmpty(context, propertyValue)) {
-                                continue;
-                            }
-                        case NON_DEFAULT:
-                            if (serializer.isEmpty(context, propertyValue) || propertyValue != null && serializer.isDefault(context, propertyValue)) {
-                                continue;
-                            }
-                            break;
-                        case NEVER:
-                            continue;
-                        default:
-                            // fall through
+                    boolean skipped = switch (property.include) {
+                        case ALWAYS -> false;
+                        case NON_NULL -> propertyValue == null;
+                        case NON_ABSENT -> serializer.isAbsent(context, propertyValue);
+                        case NON_DEFAULT -> serializer.isEmpty(context, propertyValue) || propertyValue != null && serializer.isDefault(context, propertyValue);
+                        case NON_EMPTY -> serializer.isEmpty(context, propertyValue);
+                        case NEVER -> true;
+                    };
+                    if (skipped) {
+                        continue;
                     }
                 }
 

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedObjectSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedObjectSerializer.java
@@ -98,6 +98,10 @@ final class CustomizedObjectSerializer<T> implements ObjectSerializer<T> {
                             if (serializer.isEmpty(context, propertyValue)) {
                                 continue;
                             }
+                        case NON_DEFAULT:
+                            if (serializer.isEmpty(context, propertyValue) || propertyValue != null && serializer.isDefault(context, propertyValue)) {
+                                continue;
+                            }
                             break;
                         case NEVER:
                             continue;

--- a/test-suite-tck-jackson-databind/src/test/groovy/io/micronaut/serde/tck/jackson/databind/DatabindJsonIncludeSpec.groovy
+++ b/test-suite-tck-jackson-databind/src/test/groovy/io/micronaut/serde/tck/jackson/databind/DatabindJsonIncludeSpec.groovy
@@ -48,4 +48,42 @@ class Test {
             "OptionalLong"                 | [value: OptionalLong.empty()]   | '{"value":null}'
     }
 
+    @Unroll
+    void "test @JsonInclude(NON_DEFAULT) on class"() {
+        given:
+            def context = buildContext('test.Test', """
+package test;
+
+import java.util.*;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.*;
+
+@JsonInclude(NON_DEFAULT)
+class Test {
+    private String value = "abc";
+    public void setValue(String value) {
+        this.value = value;
+    }
+    public String getValue() {
+        return value;
+    }
+}
+""")
+        when:
+            def bean = newInstance(context, 'test.Test')
+            bean.value = value
+            String json = writeJson(jsonMapper, bean)
+        then:
+            json == result
+
+        cleanup:
+            context.close()
+
+        where:
+            value | result
+            null  | """{"value":null}"""
+            "abc"  | """{}"""
+            "xyz"  | """{"value":"xyz"}"""
+    }
+
 }


### PR DESCRIPTION
Except this scenario:

> When used for a POJO, definition is that only values that differ from the default values of POJO properties are included. This is done by creating an instance of POJO using zero-argument constructor, and accessing property values: value is used as the default value by using equals() method, except for the case where property has `null` value in which case straight null check is used.