### PR TITLE
Support `@JsonPropertyOrder(alphabetic=true) + global`

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/config/DefaultSerializationConfiguration.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/DefaultSerializationConfiguration.java
@@ -33,12 +33,15 @@ final class DefaultSerializationConfiguration implements SerializationConfigurat
 
     private final SerdeConfig.SerInclude inclusion;
     private final boolean alwaysSerializeErrorsAsList;
+    private final boolean sortPropertiesAlphabetically;
 
     @ConfigurationInject
     DefaultSerializationConfiguration(@Bindable(defaultValue = "NON_EMPTY") SerdeConfig.SerInclude inclusion,
-                                      @Bindable(defaultValue = StringUtils.TRUE) boolean alwaysSerializeErrorsAsList) {
+                                      @Bindable(defaultValue = StringUtils.TRUE) boolean alwaysSerializeErrorsAsList,
+                                      @Bindable(defaultValue = StringUtils.FALSE) boolean sortPropertiesAlphabetically) {
         this.inclusion = inclusion;
         this.alwaysSerializeErrorsAsList = alwaysSerializeErrorsAsList;
+        this.sortPropertiesAlphabetically = sortPropertiesAlphabetically;
     }
 
     @Override
@@ -49,6 +52,11 @@ final class DefaultSerializationConfiguration implements SerializationConfigurat
     @Override
     public boolean isAlwaysSerializeErrorsAsList() {
         return alwaysSerializeErrorsAsList;
+    }
+
+    @Override
+    public boolean sortPropertiesAlphabetically() {
+        return sortPropertiesAlphabetically;
     }
 
 }

--- a/serde-api/src/main/java/io/micronaut/serde/config/SerializationConfiguration.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/SerializationConfiguration.java
@@ -39,4 +39,15 @@ public interface SerializationConfiguration {
      */
     @Bindable(defaultValue = StringUtils.TRUE)
     boolean isAlwaysSerializeErrorsAsList();
+
+    /**
+     * Determines whether properties should be serialized in alphabetical order.
+     *
+     * @return true if properties should be sorted alphabetically, false otherwise
+     * @since 2.14
+     */
+    @Bindable(defaultValue = StringUtils.FALSE)
+    default boolean sortPropertiesAlphabetically() {
+        return false;
+    }
 }

--- a/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonPropertyOrderSpec.groovy
+++ b/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonPropertyOrderSpec.groovy
@@ -64,6 +64,248 @@ class Test {
             ['c', 'a', 'b'] | '{"c":3,"a":1,"b":2}'
     }
 
+    void "test @JsonPropertyOrder on type where order is alphabetic"() {
+        given:
+            buildContext('jsonorder.Test', """
+package jsonorder;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+@JsonPropertyOrder(alphabetic = true)
+class Test {
+    private int c = 3;
+    private int b = 2;
+    private int a = 1;
+    public void setB(int b) {
+        this.b = b;
+    }
+    public void setA(int a) {
+        this.a = a;
+    }
+    public void setC(int c) {
+        this.c = c;
+    }
+    public int getB() {
+        return b;
+    }
+    public int getA() {
+        return a;
+    }
+    public int getC() {
+        return c;
+    }
+}
+""", [:])
+        expect:
+            writeJson(jsonMapper, beanUnderTest) == '{"a":1,"b":2,"c":3}'
+    }
+
+    void "test @JsonPropertyOrder on type where order is alphabetic - PERAPP"() {
+        given:
+            buildContext('jsonorder.Test', """
+package jsonorder;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+class Test {
+    private int c = 3;
+    private int b = 2;
+    private int a = 1;
+    public void setB(int b) {
+        this.b = b;
+    }
+    public void setA(int a) {
+        this.a = a;
+    }
+    public void setC(int c) {
+        this.c = c;
+    }
+    public int getB() {
+        return b;
+    }
+    public int getA() {
+        return a;
+    }
+    public int getC() {
+        return c;
+    }
+}
+""", [:], [
+                    "micronaut.serde.serialization.sort-properties-alphabetically": true,
+                    "jackson.mapper.sort-properties-alphabetically"               : true
+            ]
+            )
+        expect:
+            writeJson(jsonMapper, beanUnderTest) == '{"a":1,"b":2,"c":3}'
+    }
+
+    void "test @JsonPropertyOrder on type where order is alphabetic and @JsonProperty"() {
+        given:
+            buildContext('jsonorder.Test', """
+package jsonorder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+@JsonPropertyOrder(alphabetic = true)
+class Test {
+    private int c = 3;
+    @JsonProperty("d")
+    private int b = 2;
+    private int a = 1;
+    public void setB(int b) {
+        this.b = b;
+    }
+    public void setA(int a) {
+        this.a = a;
+    }
+    public void setC(int c) {
+        this.c = c;
+    }
+    public int getB() {
+        return b;
+    }
+    public int getA() {
+        return a;
+    }
+    public int getC() {
+        return c;
+    }
+}
+""", [:])
+        expect:
+            writeJson(jsonMapper, beanUnderTest) == '{"a":1,"c":3,"d":2}'
+    }
+
+    void "test @JsonPropertyOrder on type where order is alphabetic and @JsonProperty - PERAPP"() {
+        given:
+            buildContext('jsonorder.Test', """
+package jsonorder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+class Test {
+    private int c = 3;
+    @JsonProperty("d")
+    private int b = 2;
+    private int a = 1;
+    public void setB(int b) {
+        this.b = b;
+    }
+    public void setA(int a) {
+        this.a = a;
+    }
+    public void setC(int c) {
+        this.c = c;
+    }
+    public int getB() {
+        return b;
+    }
+    public int getA() {
+        return a;
+    }
+    public int getC() {
+        return c;
+    }
+}
+""", [:], [
+                    "micronaut.serde.serialization.sort-properties-alphabetically": true,
+                    "jackson.mapper.sort-properties-alphabetically"               : true
+            ]
+            )
+        expect:
+            writeJson(jsonMapper, beanUnderTest) == '{"a":1,"c":3,"d":2}'
+    }
+
+    void "test @JsonPropertyOrder on type where order is alphabetic and @JsonProperty getter"() {
+        given:
+            buildContext('jsonorder.Test', """
+package jsonorder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+@JsonPropertyOrder(alphabetic = true)
+class Test {
+    private int c = 3;
+    private int b = 2;
+    private int a = 1;
+    public void setB(int b) {
+        this.b = b;
+    }
+    public void setA(int a) {
+        this.a = a;
+    }
+    public void setC(int c) {
+        this.c = c;
+    }
+
+    @JsonProperty("d")
+    public int getB() {
+        return b;
+    }
+    public int getA() {
+        return a;
+    }
+    public int getC() {
+        return c;
+    }
+}
+""", [:])
+        expect:
+            writeJson(jsonMapper, beanUnderTest) == '{"a":1,"c":3,"d":2}'
+    }
+
+    void "test @JsonPropertyOrder on type where order is alphabetic and @JsonGetter getter"() {
+        given:
+            buildContext('jsonorder.Test', """
+package jsonorder;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+@JsonPropertyOrder(alphabetic = true)
+class Test {
+    private int c = 3;
+    private int b = 2;
+    private int a = 1;
+    public void setB(int b) {
+        this.b = b;
+    }
+    public void setA(int a) {
+        this.a = a;
+    }
+    public void setC(int c) {
+        this.c = c;
+    }
+
+    @JsonGetter("d")
+    public int getB() {
+        return b;
+    }
+    public int getA() {
+        return a;
+    }
+    public int getC() {
+        return c;
+    }
+}
+""", [:])
+        expect:
+            writeJson(jsonMapper, beanUnderTest) == '{"a":1,"c":3,"d":2}'
+    }
+
     @Unroll
     void "test @JsonPropertyOrder with renamed property on type where order is #order"() {
         given:

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/SerdeAnnotationVisitor.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/SerdeAnnotationVisitor.java
@@ -57,7 +57,6 @@ import java.text.DecimalFormat;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.Temporal;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -765,7 +764,17 @@ public class SerdeAnnotationVisitor implements TypeElementVisitor<SerdeConfig, S
 
     private void visitProperties(ClassElement classElement, VisitorContext context) {
         final List<PropertyElement> beanProperties = classElement.getBeanProperties();
-        final List<String> order = Arrays.asList(classElement.stringValues(SerdeConfig.META_ANNOTATION_PROPERTY_ORDER));
+        final List<String> order;
+        if (classElement.booleanValue(SerdeConfig.META_ANNOTATION_PROPERTY_ORDER, "alphabetic").orElse(false)) {
+            List<String> newOrder = beanProperties.stream()
+                .map(p -> p.stringValue(SerdeConfig.class, SerdeConfig.PROPERTY).orElseGet(p::getName))
+                .sorted()
+                .toList();
+            classElement.annotate(SerdeConfig.META_ANNOTATION_PROPERTY_ORDER, b -> b.values(newOrder.toArray(new String[0])));
+            order = new ArrayList<>(newOrder);
+        } else {
+            order = new ArrayList<>(List.of(classElement.stringValues(SerdeConfig.META_ANNOTATION_PROPERTY_ORDER)));
+        }
         Collections.reverse(order);
         final Set<Introspected.AccessKind> access = CollectionUtils.setOf(classElement.enumValues(Introspected.class,
                                                                                              "accessKind",

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/jackson/JsonPropertyOrderMapper.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/jackson/JsonPropertyOrderMapper.java
@@ -15,33 +15,27 @@
  */
 package io.micronaut.serde.processor.jackson;
 
-import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.annotation.AnnotationValueBuilder;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.serde.config.annotation.SerdeConfig;
 
 import java.lang.annotation.Annotation;
-import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Support for @JsonPropertyOrder.
  */
-public class JsonPropertyOrderMapper extends ValidatingAnnotationMapper {
-    @Override
-    protected Set<String> getSupportedMemberNames() {
-        return Collections.singleton(AnnotationMetadata.VALUE_MEMBER);
-    }
+public class JsonPropertyOrderMapper implements NamedAnnotationMapper {
 
     @Override
-    protected List<AnnotationValue<?>> mapValid(AnnotationValue<Annotation> annotation,
-                                                      VisitorContext visitorContext) {
-        return Collections.singletonList(
-                AnnotationValue.builder(SerdeConfig.META_ANNOTATION_PROPERTY_ORDER)
-                        .values(annotation.stringValues())
-                        .build()
-        );
+    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation,
+                                        VisitorContext visitorContext) {
+        AnnotationValueBuilder<Annotation> builder = AnnotationValue.builder(SerdeConfig.META_ANNOTATION_PROPERTY_ORDER)
+            .values(annotation.stringValues());
+        annotation.booleanValue("alphabetic").ifPresent(v -> builder.member("alphabetic", v));
+        return List.of(builder.build());
     }
 
     @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBean.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBean.java
@@ -329,12 +329,15 @@ final class SerBean<T> {
                         Optional<SerProperty<T, Object>> prop = orderProps.stream()
                             .filter(p -> p.name.equals(propName) || p.originalName.equals(propName))
                             .findFirst();
-                        // Make sure we reference the property only oncemas
+                        // Make sure we reference the property only once
                         prop.ifPresent(orderProps::remove);
                         return prop.stream();
                     })
                 .toList();
             writeProperties.sort(Comparator.comparingInt(order::indexOf));
+        }
+        if (!writeProperties.isEmpty() && serializationConfiguration.sortPropertiesAlphabetically()) {
+            writeProperties.sort(Comparator.comparing(p -> p.name));
         }
 
         this.arrayWrapperProperty = introspection.stringValue(SerdeConfig.class, SerdeConfig.ARRAY_WRAPPER_PROPERTY).orElse(null);

--- a/test-suite-tck-jackson-databind/src/test/groovy/io/micronaut/serde/tck/jackson/databind/DatabindJsonPropertyOrderSpec.groovy
+++ b/test-suite-tck-jackson-databind/src/test/groovy/io/micronaut/serde/tck/jackson/databind/DatabindJsonPropertyOrderSpec.groovy
@@ -1,6 +1,716 @@
 package io.micronaut.serde.tck.jackson.databind
 
 import io.micronaut.serde.jackson.JsonPropertyOrderSpec
+import spock.lang.PendingFeature
+import spock.lang.Unroll
 
 class DatabindJsonPropertyOrderSpec extends JsonPropertyOrderSpec {
+
+    void "test basic order inherit 1"() {
+        given:
+            def context = buildContext('jsonorder.Test', """
+package jsonorder;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+class Test extends SuperTest {
+    private int c = 3;
+    private int b = 2;
+    private int a = 1;
+    private final int d;
+
+    public Test(int z, int d) {
+        super(z);
+        this.d = d;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+    public void setB(int b) {
+        this.b = b;
+    }
+    public void setC(int c) {
+        this.c = c;
+    }
+
+    public int getD() {
+        return d;
+    }
+
+    public int getA() {
+        return a;
+    }
+    public int getB() {
+        return b;
+    }
+    public int getC() {
+        return c;
+    }
+}
+
+@Serdeable
+class SuperTest {
+    private int x = 3;
+    private int y = 2;
+    private final int z;
+    public SuperTest(int z) {
+        this.z = z;
+    }
+
+    public void setX(int x) {
+        this.x = x;
+    }
+
+    public void setY(int y) {
+        this.y = y;
+    }
+
+    public int getX() {
+        return x;
+    }
+
+    public int getZ() {
+        return z;
+    }
+
+    public int getY() {
+        return y;
+    }
+}
+""")
+        when:
+            def t = context.classLoader.loadClass('jsonorder.Test')
+            beanUnderTest = t.newInstance(4, 5)
+        then:
+            writeJson(jsonMapper, beanUnderTest) == '{"x":3,"y":2,"z":4,"c":3,"b":2,"a":1,"d":5}'
+    }
+
+    void "test basic order with a constructor 1"() {
+        given:
+            def context = buildContext('jsonorder.Test', """
+package jsonorder;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+class Test {
+    private int c = 3;
+    private int b = 2;
+    private int a = 1;
+    private final int d;
+
+    public Test(int d) {
+        this.d = d;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+    public void setB(int b) {
+        this.b = b;
+    }
+    public void setC(int c) {
+        this.c = c;
+    }
+
+    public int getD() {
+        return d;
+    }
+
+    public int getA() {
+        return a;
+    }
+    public int getB() {
+        return b;
+    }
+    public int getC() {
+        return c;
+    }
+}
+""")
+        when:
+            def t = context.classLoader.loadClass('jsonorder.Test')
+            beanUnderTest = t.newInstance(4)
+        then:
+            writeJson(jsonMapper, beanUnderTest) == '{"c":3,"b":2,"a":1,"d":4}'
+    }
+
+    void "test basic order with a constructor 2"() {
+        given:
+            def context = buildContext('jsonorder.Test', """
+package jsonorder;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+class Test {
+    private final int d;
+    private int c = 3;
+    private int b = 2;
+    private int a = 1;
+
+    public Test(int d) {
+        this.d = d;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+    public void setB(int b) {
+        this.b = b;
+    }
+    public void setC(int c) {
+        this.c = c;
+    }
+
+    public int getA() {
+        return a;
+    }
+    public int getB() {
+        return b;
+    }
+    public int getC() {
+        return c;
+    }
+
+    public int getD() {
+        return d;
+    }
+}
+""")
+        when:
+            def t = context.classLoader.loadClass('jsonorder.Test')
+            beanUnderTest = t.newInstance(4)
+        then:
+            writeJson(jsonMapper, beanUnderTest) == '{"d":4,"c":3,"b":2,"a":1}'
+    }
+
+    void "test basic order with a constructor 2x"() {
+        given:
+            def context = buildContext('jsonorder.Test', """
+package jsonorder;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+class Test {
+    private int c = 3;
+    private int b = 2;
+    private int a = 1;
+    private final int d;
+
+    public Test(int d) {
+        this.d = d;
+    }
+
+    public void setA(int a) {
+        this.a = a;
+    }
+    public void setB(int b) {
+        this.b = b;
+    }
+    public void setC(int c) {
+        this.c = c;
+    }
+
+    public int getA() {
+        return a;
+    }
+    public int getB() {
+        return b;
+    }
+    public int getC() {
+        return c;
+    }
+
+    public int getD() {
+        return d;
+    }
+}
+""")
+        when:
+            def t = context.classLoader.loadClass('jsonorder.Test')
+            beanUnderTest = t.newInstance(4)
+        then:
+            writeJson(jsonMapper, beanUnderTest) == '{"c":3,"b":2,"a":1,"d":4}'
+    }
+
+    void "test order is default"() {
+        given:
+            buildContext('jsonorder.Test', """
+package jsonorder;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+class Test {
+    private int c = 3;
+    private int b = 2;
+    private int a = 1;
+    public void setA(int a) {
+        this.a = a;
+    }
+    public void setB(int b) {
+        this.b = b;
+    }
+    public void setC(int c) {
+        this.c = c;
+    }
+    public int getA() {
+        return a;
+    }
+    public int getB() {
+        return b;
+    }
+    public int getC() {
+        return c;
+    }
+}
+""", [:])
+        expect:
+            writeJson(jsonMapper, beanUnderTest) == '{"c":3,"b":2,"a":1}'
+    }
+
+    void "test renamed property on type where order default"() {
+        given:
+            buildContext('jsonorder.Test', """
+package jsonorder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+class Test {
+    private int c = 3;
+    @JsonProperty("d")
+    private int b = 2;
+    private int a = 1;
+    public void setA(int a) {
+        this.a = a;
+    }
+    public void setB(int b) {
+        this.b = b;
+    }
+    public void setC(int c) {
+        this.c = c;
+    }
+    public int getA() {
+        return a;
+    }
+    public int getB() {
+        return b;
+    }
+    public int getC() {
+        return c;
+    }
+}
+""", [:])
+        expect:
+            writeJson(jsonMapper, beanUnderTest) == '{"c":3,"a":1,"d":2}'
+    }
+
+    void "test renamed property to existing one on type where order is default"() {
+        given:
+            buildContext('jsonorder.Test', """
+package jsonorder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+class Test {
+    private int c = 3;
+    @JsonProperty("d")
+    private int b = 2;
+    @JsonProperty("b")
+    private int a = 1;
+    public void setA(int a) {
+        this.a = a;
+    }
+    public void setB(int b) {
+        this.b = b;
+    }
+    public void setC(int c) {
+        this.c = c;
+    }
+    public int getA() {
+        return a;
+    }
+    public int getB() {
+        return b;
+    }
+    public int getC() {
+        return c;
+    }
+}
+""", [:])
+        expect:
+            writeJson(jsonMapper, beanUnderTest) == '{"c":3,"d":2,"b":1}'
+    }
+
+    void "test renamed getter property to existing one on type where order is default"() {
+        given:
+            buildContext('jsonorder.Test', """
+package jsonorder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+class Test {
+    private int c = 3;
+    private int b = 2;
+    private int a = 1;
+    public void setA(int a) {
+        this.a = a;
+    }
+    public void setB(int b) {
+        this.b = b;
+    }
+    public void setC(int c) {
+        this.c = c;
+    }
+
+    @JsonProperty("b")
+    public int getA() {
+        return a;
+    }
+
+    @JsonProperty("d")
+    public int getB() {
+        return b;
+    }
+    public int getC() {
+        return c;
+    }
+}
+""", [:])
+        expect:
+            writeJson(jsonMapper, beanUnderTest) == '{"c":3,"d":2,"b":1}'
+    }
+
+    void "test renamed getter property to existing one on type where order is default X"() {
+        given:
+            buildContext('jsonorder.Test', """
+package jsonorder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+class Test {
+    private int c = 3;
+    private int b = 2;
+    private int a = 1;
+    public void setA(int a) {
+        this.a = a;
+    }
+    public void setB(int b) {
+        this.b = b;
+    }
+    public void setC(int c) {
+        this.c = c;
+    }
+
+    public int getA() {
+        return a;
+    }
+
+    @JsonProperty("d")
+    public int getB() {
+        return b;
+    }
+    public int getC() {
+        return c;
+    }
+}
+""", [:])
+        expect:
+            writeJson(jsonMapper, beanUnderTest) == '{"c":3,"a":1,"d":2}'
+    }
+
+    void "test renamed JsonGetter property to existing one on type where order is default"() {
+        given:
+            buildContext('jsonorder.Test', """
+package jsonorder;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+class Test {
+    private int c = 3;
+    private int b = 2;
+    private int a = 1;
+    public void setA(int a) {
+        this.a = a;
+    }
+    public void setB(int b) {
+        this.b = b;
+    }
+    public void setC(int c) {
+        this.c = c;
+    }
+
+    @JsonGetter("b")
+    public int getA() {
+        return a;
+    }
+
+    @JsonGetter("d")
+    public int getB() {
+        return b;
+    }
+    public int getC() {
+        return c;
+    }
+}
+""", [:])
+        expect:
+            writeJson(jsonMapper, beanUnderTest) == '{"c":3,"d":2,"b":1}'
+    }
+
+    void "test property order with renamed JsonGetter property order"() {
+        given:
+            buildContext('jsonorder.Test', """
+package jsonorder;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+class Test {
+    private int c = 3;
+    private int b = 2;
+    private int a = 1;
+    public void setA(int a) {
+        this.a = a;
+    }
+    public void setB(int b) {
+        this.b = b;
+    }
+    public void setC(int c) {
+        this.c = c;
+    }
+
+    public int getA() {
+        return a;
+    }
+
+    @JsonGetter("d")
+    public int getB() {
+        return b;
+    }
+    public int getC() {
+        return c;
+    }
+}
+""", [:])
+        expect:
+            writeJson(jsonMapper, beanUnderTest) ==  '{"c":3,"a":1,"d":2}'
+
+    }
+
+    void "test property order with bean and JsonProperty 1"() {
+        given:
+            buildContext('jsonorder.Test', """
+package jsonorder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.serde.annotation.Serdeable;
+
+import java.util.Objects;
+
+@Serdeable
+final class Test {
+    @JsonProperty("d")
+    private final int a;
+    private final int b;
+
+    Test(@JsonProperty("d") int a, int b) {
+        this.a = a;
+        this.b = b;
+    }
+
+    public int getA() {
+        return a;
+    }
+
+    public int getB() {
+        return b;
+    }
+}
+""")
+        when:
+            def bean = typeUnderTest.getType().newInstance(1, 2)
+        then:
+            writeJson(jsonMapper, bean) ==  '{"d":1,"b":2}'
+    }
+
+    void "test property order with bean and JsonProperty 1X"() {
+        given:
+            buildContext('jsonorder.Test', """
+package jsonorder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.serde.annotation.Serdeable;
+
+import java.util.Objects;
+
+@Serdeable
+final class Test {
+    @JsonProperty("d")
+    private final int a;
+    private final int b;
+
+    Test(int a, int b) {
+        this.a = a;
+        this.b = b;
+    }
+
+    public int getA() {
+        return a;
+    }
+
+    public int getB() {
+        return b;
+    }
+}
+""")
+        when:
+            def bean = typeUnderTest.getType().newInstance(1, 2)
+        then:
+            writeJson(jsonMapper, bean) ==  '{"b":2,"d":1}'
+    }
+
+    void "test property order with bean and JsonProperty 2"() {
+        given:
+            buildContext('jsonorder.Test', """
+package jsonorder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.serde.annotation.Serdeable;
+
+import java.util.Objects;
+
+@Serdeable
+final class Test {
+    private final int a;
+    @JsonProperty("d")
+    private final int b;
+    private final int c;
+
+    Test(int a, int b, int c) {
+        this.a = a;
+        this.b = b;
+        this.c = c;
+    }
+
+    public int getA() {
+        return a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public int getC() {
+        return c;
+    }
+}
+""")
+        when:
+            def bean = typeUnderTest.getType().newInstance(1, 2, 3)
+        then:
+            writeJson(jsonMapper, bean) ==  '{"a":1,"c":3,"d":2}'
+    }
+
+    void "test property order with record and JsonProperty 1"() {
+        given:
+            buildContext('jsonorder.Test', """
+package jsonorder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+record Test(@JsonProperty("d") int a, int b) {
+}
+""")
+        when:
+            def bean = typeUnderTest.getType().newInstance(1, 2)
+        then:
+            writeJson(jsonMapper, bean) ==  '{"d":1,"b":2}'
+    }
+
+    @PendingFeature(reason = "Not supported by Jackson Databind")
+    @Unroll
+    void "test @JsonPropertyOrder on property where order is #order"() {
+        given:
+            def context = buildContext("""
+package jsonorder;
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+class Other {
+    @JsonPropertyOrder(${formatOrder(order)})
+    private Test test;
+    public void setTest(jsonorder.Test test) {
+        this.test = test;
+    }
+    public jsonorder.Test getTest() {
+        return test;
+    }
+}
+@Serdeable
+class Test {
+    private int c = 3;
+    private int b = 2;
+    private int a = 1;
+    public void setA(int a) {
+        this.a = a;
+    }
+    public void setB(int b) {
+        this.b = b;
+    }
+    public void setC(int c) {
+        this.c = c;
+    }
+    public int getA() {
+        return a;
+    }
+    public int getB() {
+        return b;
+    }
+    public int getC() {
+        return c;
+    }
+}
+""")
+            def o = newInstance(context, 'jsonorder.Other')
+            def t = newInstance(context, 'jsonorder.Test')
+            o.test = t
+
+        expect:
+            writeJson(jsonMapper, o) == result
+
+        cleanup:
+            context.close()
+
+        where:
+            order           | result
+            ['a', 'b', 'c'] | '{"test":{"a":1,"b":2,"c":3}}'
+            ['c', 'a', 'b'] | '{"test":{"c":3,"a":1,"b":2}}'
+    }
+
+
 }


### PR DESCRIPTION
Fixes https://github.com/micronaut-projects/micronaut-serialization/issues/546

+ Added some tests to define the properties order for Databind