### PR TITLE
Fix: make getValueSerializer thread safe

### DIFF
--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedMapSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedMapSerializer.java
@@ -203,7 +203,7 @@ final class CustomizedMapSerializer<K, V> implements CustomizableSerializer<Map<
                     return internalKeySerializer;
                 }
 
-                private Serializer<? super V> getValueSerializer(EncoderContext context, V v) throws SerdeException {
+                private synchronized Serializer<? super V> getValueSerializer(EncoderContext context, V v) throws SerdeException {
                     if (valueGeneric == null || !valueGeneric.getType().equals(v.getClass())) {
                         valueGeneric = (Argument<V>) Argument.of(v.getClass());
                         internalValSerializer = context.findSerializer(valueGeneric).createSpecific(context, valueGeneric);


### PR DESCRIPTION
This pull request introduces a thread-safety improvement to the `CustomizedMapSerializer` class by making the `getValueSerializer` method synchronized. This change ensures that concurrent access to this method is handled safely, preventing potential race conditions when multiple threads are serializing map values.

**Thread-safety enhancement:**

* Made the `getValueSerializer` method in `CustomizedMapSerializer.java` synchronized to ensure safe concurrent access when updating `valueGeneric` and `internalValSerializer`.

**Below Error Observed in Race Condition**
Error getting property [Map<String K, Object V> specification] of type [class io.micronaut.configuration.graphql.GraphQLResponseBody]: Cannot invoke \"io.micronaut.serde.Serializer.serialize(io.micronaut.serde.Encoder, io.micronaut.serde.Serializer$EncoderContext, io.micronaut.core.type.Argument, Object)\" because \"valSerializer\" is null"}]}