### PR TITLE
Fix: make getValueSerializer thread safe in v2.15.1

### DIFF
--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedMapSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/CustomizedMapSerializer.java
@@ -203,7 +203,7 @@ final class CustomizedMapSerializer<K, V> implements CustomizableSerializer<Map<
                     return internalKeySerializer;
                 }
 
-                private Serializer<? super V> getValueSerializer(EncoderContext context, V v) throws SerdeException {
+                private synchronized Serializer<? super V> getValueSerializer(EncoderContext context, V v) throws SerdeException {
                     if (valueGeneric == null || !valueGeneric.getType().equals(v.getClass())) {
                         valueGeneric = (Argument<V>) Argument.of(v.getClass());
                         internalValSerializer = context.findSerializer(valueGeneric).createSpecific(context, valueGeneric);


### PR DESCRIPTION
This PR introduces a thread-safety improvement to the `CustomizedMapSerializer` class by synchronizing access to the value serializer. This change ensures that concurrent calls to the `getValueSerializer` method do not result in race conditions or inconsistent state.

Thread-safety enhancement:

* Made the `getValueSerializer` method in `CustomizedMapSerializer.java` `synchronized`, preventing concurrent access issues when retrieving or creating the value serializer.

Issue Noticed:
Under race conditions we see below error:
Error getting property [Map<String K, Object V> specification] of type [class io.micronaut.configuration.graphql.GraphQLResponseBody]: Cannot invoke \"io.micronaut.serde.Serializer.serialize(io.micronaut.serde.Encoder, io.micronaut.serde.Serializer$EncoderContext, io.micronaut.core.type.Argument, Object)\" because \"valSerializer\" is null"}]}

**Note**
This bug exists in v2.15.1 where getValueSerializer is not thread-safe.
It has been refactored away in 2.15.x, so this PR only applies to users pinned to v2.15.1.