### PR TITLE
Fix subtypes being set to null for empty JSON

### DIFF
--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/JacksonBasicSerdeSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/JacksonBasicSerdeSpec.groovy
@@ -35,8 +35,9 @@ class JacksonBasicSerdeSpec extends AbstractBasicSerdeSpec {
         obj = new MyBeanWithNestedObject("id2", null)
         json = jsonMapper.writeValueAsString(obj)
         result = jsonMapper.readValue(json, MyBeanWithNestedObject)
-        then:
-        obj == result
+        then: "The result is different, as always has added the type"
+        def expected = new MyBeanWithNestedObject("id2", new MyBeanWithNestedObject.MyNestedBean(null, null))
+        expected == result
         json == """{"id":"id2"}"""
     }
 

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/JacksonBasicSerdeSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/JacksonBasicSerdeSpec.groovy
@@ -35,9 +35,8 @@ class JacksonBasicSerdeSpec extends AbstractBasicSerdeSpec {
         obj = new MyBeanWithNestedObject("id2", null)
         json = jsonMapper.writeValueAsString(obj)
         result = jsonMapper.readValue(json, MyBeanWithNestedObject)
-        then: "The result is different, as always has added the type"
-        def expected = new MyBeanWithNestedObject("id2", new MyBeanWithNestedObject.MyNestedBean(null, null))
-        expected == result
+        then:
+        obj == result
         json == """{"id":"id2"}"""
     }
 

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeJsonSubtypesSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeJsonSubtypesSpec.groovy
@@ -4,6 +4,56 @@ import io.micronaut.serde.jackson.JsonSubtypesSpec
 
 class SerdeJsonSubtypesSpec extends JsonSubtypesSpec {
 
+  void 'test nested subtypes deserialization'() {
+      given:
+      def compiled = buildContext('example.Wrapper', '''
+package example;
+
+import com.fasterxml.jackson.annotation.*;
+import io.micronaut.serde.annotation.Serdeable;
+import jakarta.annotation.Nullable;
+
+@Serdeable
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = ChildA.class, name = "subtype-a"),
+    @JsonSubTypes.Type(value = ChildB.class, name = "subtype-b")
+})
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "subtype")
+sealed interface Parent permits ChildA, ChildB {
+}
+
+@Serdeable
+record Wrapper(
+    @Nullable Parent inner
+) {
+}
+
+@Serdeable
+final class ChildA implements Parent {
+    private String propA;
+    public ChildA(String propA) { this.propA = propA; }
+    public String getPropA() { return propA; }
+}
+
+@Serdeable
+final class ChildB implements Parent {
+    public ChildB() {}
+}
+''', true)
+      def wrapper = compiled.classLoader.loadClass('example.Wrapper')
+      def cl = Thread.currentThread().getContextClassLoader()
+      Thread.currentThread().setContextClassLoader(compiled.classLoader)
+
+      expect:
+      deserializeFromString(jsonMapper, wrapper, '{"inner":{"subtype":"subtype-a", "propA": "a"}}').inner.class.simpleName == 'ChildA'
+      deserializeFromString(jsonMapper, wrapper, '{"inner":{"subtype":"subtype-a"}}').inner.class.simpleName == 'ChildA'
+      deserializeFromString(jsonMapper, wrapper, '{"inner":{"subtype":"subtype-b"}}').inner.class.simpleName == 'ChildB'
+
+      cleanup:
+      Thread.currentThread().setContextClassLoader(cl)
+      compiled.close()
+  }
+
   void 'test @JsonIgnoreProperties unknown property handling on subtypes'() {
         given: // TODO: disable global ignore unknown
         def compiled = buildContext('example.Base', '''

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SpecificObjectDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SpecificObjectDeserializer.java
@@ -905,9 +905,6 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
                 if (conf.preInstantiateCallback != null) {
                     conf.preInstantiateCallback.preInstantiate(introspection, values);
                 }
-                if (objectArgument.isNullable() && allNull(values) && propertiesConsumer == null && anyValuesDeserializer == null) {
-                    return null;
-                }
                 instance = introspection.instantiate(conf.strictNullable, values);
             } catch (InstantiationException e) {
                 throw new SerdeException(PREFIX_UNABLE_TO_DESERIALIZE_TYPE + introspection.getBeanType() + "]: " + e.getMessage(), e);
@@ -919,15 +916,6 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
                 anyValuesDeserializer.bind(instance);
             }
             return instance;
-        }
-
-        private boolean allNull(Object[] values) {
-            for (Object value : values) {
-                if (value != null) {
-                    return false;
-                }
-            }
-            return true;
         }
     }
 

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SpecificObjectDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SpecificObjectDeserializer.java
@@ -116,13 +116,13 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
                 handleUnexpectedProperty(objectDecoder, propertyName, deserBean);
             }
             if (beanDeserializer.isAllConsumed()) {
-                instance = beanDeserializer.provideInstance(type, decoderContext);
+                instance = beanDeserializer.provideInstance(type, decoderContext, false);
                 break;
             }
         }
 
         if (instance == null) {
-            instance = beanDeserializer.provideInstance(type, decoderContext);
+            instance = beanDeserializer.provideInstance(type, decoderContext, false);
         }
         if (deserBean.ignoreUnknown) {
             objectDecoder.finishStructure(true);
@@ -200,13 +200,13 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
                     handleUnexpectedProperty(objectDecoder, propertyName, deserBean);
                 }
                 if (beanDeserializer.isAllConsumed()) {
-                    instance = beanDeserializer.provideInstance(type, decoderContext);
+                    instance = beanDeserializer.provideInstance(type, decoderContext, false);
                     break;
                 }
             }
 
             if (instance == null) {
-                instance = beanDeserializer.provideInstance(type, decoderContext);
+                instance = beanDeserializer.provideInstance(type, decoderContext, false);
             }
             if (deserBean.ignoreUnknown) {
                 rootObjectDecoder.finishStructure(true);
@@ -490,7 +490,7 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
                     wrappedProperty.set(
                         decoderContext,
                         instance,
-                        unwrappedProperty.beanDeserializer.provideInstance(objectArgument, decoderContext)
+                        unwrappedProperty.beanDeserializer.provideInstance(objectArgument, decoderContext, true)
                     );
                 }
             }
@@ -588,7 +588,7 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
                             wrappedProperty.set(
                                 decoderContext,
                                 instance,
-                                up.beanDeserializer.provideInstance(objectArgument, decoderContext)
+                                up.beanDeserializer.provideInstance(objectArgument, decoderContext, true)
                             );
                         }
                         return true;
@@ -611,7 +611,7 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
                     wrappedProperty.set(
                         decoderContext,
                         instance,
-                        unwrappedProperty.beanDeserializer.provideInstance(objectArgument, decoderContext)
+                        unwrappedProperty.beanDeserializer.provideInstance(objectArgument, decoderContext, true)
                     );
                 }
             }
@@ -768,7 +768,7 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
             if (unwrappedProperties != null) {
                 for (UnwrappedPropertyDeserializer unwrappedProperty : unwrappedProperties) {
                     DeserBean.DerProperty<Object, Object> wrappedProperty = unwrappedProperty.wrappedProperty;
-                    Object value = unwrappedProperty.beanDeserializer.provideInstance(wrappedProperty.argument, decoderContext);
+                    Object value = unwrappedProperty.beanDeserializer.provideInstance(wrappedProperty.argument, decoderContext, true);
                     if (wrappedProperty.views != null && !decoderContext.hasView(wrappedProperty.views)) {
                         continue;
                     }
@@ -895,7 +895,7 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
         }
 
         @Override
-        public Object provideInstance(Argument<? super Object> objectArgument, DecoderContext decoderContext) throws IOException {
+        public Object provideInstance(Argument<? super Object> objectArgument, DecoderContext decoderContext, boolean isWrapped) throws IOException {
             Object instance;
             try {
                 Object[] values = constructorValuesDeserializer.getValues(decoderContext);
@@ -904,6 +904,9 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
                 }
                 if (conf.preInstantiateCallback != null) {
                     conf.preInstantiateCallback.preInstantiate(introspection, values);
+                }
+                if (isWrapped && objectArgument.isNullable() && allNull(values) && propertiesConsumer == null && anyValuesDeserializer == null) {
+                    return null;
                 }
                 instance = introspection.instantiate(conf.strictNullable, values);
             } catch (InstantiationException e) {
@@ -916,6 +919,15 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
                 anyValuesDeserializer.bind(instance);
             }
             return instance;
+        }
+
+        private boolean allNull(Object[] values) {
+            for (Object value : values) {
+                if (value != null) {
+                    return false;
+                }
+            }
+            return true;
         }
     }
 
@@ -981,7 +993,7 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
         }
 
         @Override
-        public Object provideInstance(Argument<? super Object> objectArgument, DecoderContext decoderContext) throws IOException {
+        public Object provideInstance(Argument<? super Object> objectArgument, DecoderContext decoderContext, boolean isWrapped) throws IOException {
             if (propertiesConsumer != null) {
                 propertiesConsumer.finalizeProperties(decoderContext, objectArgument, instance);
             }
@@ -1076,11 +1088,11 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
         }
 
         @Override
-        public Object provideInstance(Argument<? super Object> objectArgument, DecoderContext decoderContext) throws IOException {
+        public Object provideInstance(Argument<? super Object> objectArgument, DecoderContext decoderContext, boolean isWrapped) throws IOException {
             if (beanDeserializer == null) {
                 return null;
             }
-            return beanDeserializer.provideInstance(objectArgument, decoderContext);
+            return beanDeserializer.provideInstance(objectArgument, decoderContext, isWrapped);
         }
     }
 
@@ -1169,14 +1181,14 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
         }
 
         @Override
-        public Object provideInstance(Argument<? super Object> objectArgument, DecoderContext decoderContext) throws IOException {
+        public Object provideInstance(Argument<? super Object> objectArgument, DecoderContext decoderContext, boolean isWrapped) throws IOException {
             if (beanDeserializer == null) {
                 if (buffer != null) {
                     throw new SerdeException("Cannot deduct the subtype for bean " + objectArgument.getType().getName());
                 }
                 return null;
             }
-            return beanDeserializer.provideInstance(objectArgument, decoderContext);
+            return beanDeserializer.provideInstance(objectArgument, decoderContext, false);
         }
     }
 
@@ -1234,7 +1246,7 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
         }
 
         @Override
-        public Object provideInstance(Argument<? super Object> objectArgument, DecoderContext decoderContext) {
+        public Object provideInstance(Argument<? super Object> objectArgument, DecoderContext decoderContext, boolean isWrapped) {
             return instance;
         }
     }
@@ -1285,7 +1297,7 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
         }
 
         @Override
-        public Object provideInstance(Argument<? super Object> objectArgument, DecoderContext decoderContext) throws IOException {
+        public Object provideInstance(Argument<? super Object> objectArgument, DecoderContext decoderContext, boolean isWrapped) throws IOException {
             try {
                 return builder.build();
             } catch (InstantiationException e) {
@@ -1314,7 +1326,7 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
         abstract void init(DecoderContext decoderContext) throws SerdeException;
 
         @Nullable
-        abstract Object provideInstance(Argument<? super Object> objectArgument, DecoderContext decoderContext) throws IOException;
+        abstract Object provideInstance(Argument<? super Object> objectArgument, DecoderContext decoderContext, boolean isWrapped) throws IOException;
 
     }
 


### PR DESCRIPTION
Given the following classes:

```java
@Serdeable
@JsonSubTypes({
    @JsonSubTypes.Type(value = ChildA.class, name = "subtype-a"),
    @JsonSubTypes.Type(value = ChildB.class, name = "subtype-b")
})
@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "subtype")
sealed interface Parent permits ChildA, ChildB {
}

@Serdeable
final class ChildA implements Parent {
    private String propA;
    public ChildA(String propA) { this.propA = propA; }
    public String getPropA() { return propA; }
}
```

Deserialization would set the value to null when the JSON is of form `{"subtype":"subtype-a"}`. This is incorrect, as information is lost (the subtype information in this case).

@radovanradic Please take a look. It seems like this reverts some of the changes you made.