### PR TITLE
Add XML serialization support with serde-xml subproject

### DIFF
--- a/serde-bson/src/main/java/io/micronaut/serde/bson/BsonReaderDecoder.java
+++ b/serde-bson/src/main/java/io/micronaut/serde/bson/BsonReaderDecoder.java
@@ -30,6 +30,7 @@ import org.bson.codecs.DecoderContext;
 import org.bson.io.BasicOutputBuffer;
 import org.bson.types.Decimal128;
 import org.bson.types.ObjectId;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.math.BigDecimal;

--- a/serde-jsonp/src/main/java/io/micronaut/serde/json/stream/JsonParserDecoder.java
+++ b/serde-jsonp/src/main/java/io/micronaut/serde/json/stream/JsonParserDecoder.java
@@ -20,6 +20,7 @@ import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.AbstractStreamDecoder;
 import jakarta.json.JsonNumber;
 import jakarta.json.stream.JsonParser;
+import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -50,7 +51,7 @@ public class JsonParserDecoder extends AbstractStreamDecoder {
     }
 
     @Override
-    protected TokenType currentToken() {
+    protected tools.jackson.core.@Nullable JsonToken currentToken() {
         return switch (currentEvent) {
             case START_ARRAY -> TokenType.START_ARRAY;
             case START_OBJECT -> TokenType.START_OBJECT;

--- a/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/OracleJdbcJsonParserDecoder.java
+++ b/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/OracleJdbcJsonParserDecoder.java
@@ -59,7 +59,7 @@ public final class OracleJdbcJsonParserDecoder extends AbstractStreamDecoder {
     }
 
     @Override
-    protected TokenType currentToken() {
+    protected tools.jackson.core.@Nullable JsonToken currentToken() {
         return switch (currentEvent) {
             case START_ARRAY -> TokenType.START_ARRAY;
             case START_OBJECT -> TokenType.START_OBJECT;

--- a/serde-xml/build.gradle.kts
+++ b/serde-xml/build.gradle.kts
@@ -1,0 +1,39 @@
+plugins {
+    id("io.micronaut.build.internal.serde-module")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    annotationProcessor(mn.micronaut.inject.java)
+    annotationProcessor(projects.micronautSerdeProcessor)
+
+
+    api(mn.micronaut.context)
+    api(projects.micronautSerdeApi)
+
+    implementation(projects.micronautSerdeSupport)
+
+    implementation(mn.jackson.dataformat.xml)
+
+    testAnnotationProcessor(mn.micronaut.inject.java)
+    testAnnotationProcessor(projects.micronautSerdeProcessor)
+
+    testAnnotationProcessor(mn.micronaut.inject.java)
+    testAnnotationProcessor(projects.micronautSerdeProcessor)
+
+    testImplementation(projects.micronautSerdeProcessor)
+    testImplementation(projects.micronautSerdeTck)
+    testImplementation(mn.micronaut.inject.java.test)
+    testImplementation(mnTest.micronaut.test.junit5)
+    testImplementation(mnTest.junit.jupiter.engine)
+
+}
+
+tasks {
+    test {
+        useJUnitPlatform()
+    }
+}

--- a/serde-xml/src/main/java/io/micronaut/serde/xml/XmlGeneratorEncoder.java
+++ b/serde-xml/src/main/java/io/micronaut/serde/xml/XmlGeneratorEncoder.java
@@ -1,0 +1,271 @@
+package io.micronaut.serde.xml;
+
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.LimitingStream;
+import org.jspecify.annotations.NonNull;
+import tools.jackson.dataformat.xml.XmlWriteFeature;
+import tools.jackson.dataformat.xml.ser.ToXmlGenerator;
+
+import javax.xml.XMLConstants;
+import javax.xml.namespace.QName;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * XML implementation of the {@link Encoder}.
+ *
+ * @author Mousrij Hamza
+ */
+public final class XmlGeneratorEncoder extends LimitingStream implements Encoder {
+
+    private final ToXmlGenerator generator;
+    private final XmlGeneratorEncoder parent;
+    private final boolean isArray;
+
+    private String currentKey;
+    private int currentIndex;
+    private final Deque<ArrayContext> arrayContext;
+
+    public XmlGeneratorEncoder(ToXmlGenerator generator, @NonNull RemainingLimits remainingLimits) {
+        super(remainingLimits);
+        this.generator = generator;
+        this.parent = null;
+        this.isArray = false;
+        this.arrayContext = new ArrayDeque<>();
+    }
+
+    public XmlGeneratorEncoder(XmlGeneratorEncoder parent, @NonNull RemainingLimits remainingLimits, boolean isArray, Deque<ArrayContext> arrayContext) {
+        super(remainingLimits);
+        this.generator = parent.generator;
+        this.parent = parent;
+        this.isArray = isArray;
+        this.arrayContext = arrayContext;
+    }
+
+    private void postEncodeValue() {
+        currentIndex++;
+    }
+
+    private static boolean isGenericPlaceholder(String name) {
+        // Single-letter uppercase names like "E", "T", "K", "V" are type variable names
+        return name.length() <= 2 && name.equals(name.toUpperCase(Locale.ROOT));
+    }
+
+    @Override
+    public @NonNull Encoder encodeArray(@NonNull Argument<?> type) throws IOException {
+        ArrayContext parentCtx = this.arrayContext.peek();
+
+        // Resolve logical XML name: generic placeholder like "E",
+        String logicalName;
+        if (parentCtx != null && isGenericPlaceholder(type.getName())) {
+            logicalName = parentCtx.itemName().getLocalPart();
+        } else {
+            logicalName = type.getName(); // type : "List<List<SomeObject E> E> vals" ==> vals
+        }
+        QName qname = new QName(XMLConstants.NULL_NS_URI, logicalName);
+
+        if (parentCtx != null) {
+            // Opening a nested array: open wrapper element
+            QName wn = (currentIndex == 0) ? parentCtx.itemName() : null;
+            generator.startWrappedValue(wn, parentCtx.itemName());
+        }
+
+        this.arrayContext.push(new ArrayContext(qname, qname, type));
+        generator.writeStartArray();
+        return new XmlGeneratorEncoder(this, childLimits(), true, this.arrayContext);
+    }
+
+    @Override
+    public @NonNull Encoder encodeObject(@NonNull Argument<?> type) throws IOException {
+        boolean insideArray = !this.arrayContext.isEmpty();
+        if (insideArray) {
+            ArrayContext ctx = this.arrayContext.peek();
+            QName wrapperName = (currentIndex == 0) ? ctx.wrapperName() : null;
+            generator.startWrappedValue(wrapperName, ctx.itemName());
+        }
+        generator.writeStartObject();
+        Deque<ArrayContext> contexts = new ArrayDeque<>();
+        XmlGeneratorEncoder child = new XmlGeneratorEncoder(this, childLimits(), false, contexts);
+        return child;
+    }
+
+    @Override
+    public void finishStructure() throws IOException {
+        Optional.ofNullable(parent).orElseThrow(
+            () -> new IllegalStateException("Not in a structure"));
+        try {
+            if (isArray) {
+                ArrayContext ctx = this.arrayContext.peek();
+                if (ctx != null) {
+                    // Close the wrapper element that startWrappedValue opened
+                    generator.finishWrappedValue(ctx.wrapperName(), ctx.itemName());
+                    this.arrayContext.pop(); // pop only this level
+                }
+                generator.writeEndArray();
+            } else {
+                generator.writeEndObject();
+            }
+        } catch (Exception e) {
+            throw new IOException("Failed to finish structure", e);
+        }
+        parent.postEncodeValue();
+    }
+
+    @Override
+    public void encodeKey(@NonNull String key) throws IOException {
+        this.currentKey = key;
+        generator.writeName(key);
+    }
+
+    // XmlGeneratorEncoder.java — encodeString
+    @Override
+    public void encodeString(@NonNull String value) throws IOException {
+        ArrayContext peeked = this.arrayContext.peek();
+        // Start a wrapper element for a nested string in collections
+        if (peeked != null && peeked.itemName() != null) {
+
+            // Pass null for subsequent items so Jackson reuses the open wrapper.
+            QName wrapperName = (currentIndex == 0) ? peeked.itemName() : null;
+            QName wrappedName = peeked.itemName();
+            // Convention wrapped name same as wrapper name
+            generator.startWrappedValue(
+                wrapperName,
+                wrappedName
+            );
+        }
+        generator.writeString(value);
+        postEncodeValue();
+    }
+
+    @Override
+    public void close() throws IOException {
+        Encoder.super.close();
+    }
+
+    @Override
+    public void encodeBoolean(boolean value) throws IOException {
+        generator.writeBoolean(value);
+        postEncodeValue();
+    }
+
+    @Override
+    public void encodeByte(byte value) throws IOException {
+        generator.writeNumber(value);
+        postEncodeValue();
+    }
+
+    @Override
+    public void encodeShort(short value) throws IOException {
+        generator.writeNumber(value);
+        postEncodeValue();
+    }
+
+    @Override
+    public void encodeChar(char value) throws IOException {
+        generator.writeNumber(value);
+        postEncodeValue();
+    }
+
+    @Override
+    public void encodeInt(int value) throws IOException {
+        generator.writeNumber(value);
+        postEncodeValue();
+    }
+
+    @Override
+    public void encodeLong(long value) throws IOException {
+        generator.writeNumber(value);
+        postEncodeValue();
+    }
+
+    @Override
+    public void encodeFloat(float value) throws IOException {
+        generator.writeNumber(value);
+        postEncodeValue();
+    }
+
+    @Override
+    public void encodeDouble(double value) throws IOException {
+        generator.writeNumber(value);
+        postEncodeValue();
+    }
+
+    @Override
+    public void encodeBigInteger(@NonNull BigInteger value) throws IOException {
+        generator.writeNumber(value);
+        postEncodeValue();
+    }
+
+    @Override
+    public void encodeBigDecimal(@NonNull BigDecimal value) throws IOException {
+        generator.writeNumber(value);
+        postEncodeValue();
+    }
+
+    @Override
+    public void encodeNull() throws IOException {
+        generator.configure(XmlWriteFeature.WRITE_NULLS_AS_XSI_NIL, false);
+        ArrayContext ctx = this.arrayContext.peek();
+        if (ctx != null) {
+            // Inside an array: open the wrapper element for this null item so that
+            // finishStructure's finishWrappedValue has a matching open element.
+            QName wn = (currentIndex == 0) ? ctx.itemName() : null;
+            generator.startWrappedValue(wn, ctx.itemName());
+        }
+        generator.writeNull();
+        if (ctx != null) {
+            generator.finishWrappedValue(null, ctx.itemName());
+        }
+        postEncodeValue();
+    }
+
+    @Override
+    public @NonNull String currentPath() {
+        StringBuilder builder = new StringBuilder();
+        XmlGeneratorEncoder enc = this;
+        while (enc != null) {
+            if (enc != this) {
+                builder.insert(0, "->");
+            }
+            if (enc.currentKey == null) {
+                if (enc.parent != null) {
+                    builder.insert(0, enc.currentIndex);
+                }
+            } else {
+                builder.insert(0, enc.currentKey);
+            }
+            enc = enc.parent;
+        }
+        return builder.toString();
+    }
+
+    public ToXmlGenerator getGenerator() {
+        return generator;
+    }
+
+    public void setNextIsAttribute(boolean isAttribute) {
+        generator.setNextIsAttribute(isAttribute);
+    }
+
+    public void setNextIsCData(boolean isCData) {
+        generator.setNextIsCData(isCData);
+    }
+
+    public void setNextName(QName name) {
+        generator.setNextName(name);
+    }
+
+    private record ArrayContext(
+        QName wrapperName,    // passed as first arg to startWrappedValue / finishWrappedValue
+        QName itemName,       // passed as second arg (per-element tag)
+        Argument<?> elementType
+    ) {
+
+    }
+}

--- a/serde-xml/src/main/java/io/micronaut/serde/xml/XmlObjectMapper.java
+++ b/serde-xml/src/main/java/io/micronaut/serde/xml/XmlObjectMapper.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.xml;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.core.beans.BeanIntrospection;
+import io.micronaut.core.type.Argument;
+import io.micronaut.json.JsonStreamConfig;
+import io.micronaut.json.tree.JsonNode;
+import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.LimitingStream;
+import io.micronaut.serde.ObjectMapper;
+import io.micronaut.serde.SerdeIntrospections;
+import io.micronaut.serde.SerdeRegistry;
+import io.micronaut.serde.Serializer;
+import io.micronaut.serde.config.SerdeConfiguration;
+import io.micronaut.serde.support.util.JsonNodeDecoder;
+import io.micronaut.serde.support.util.JsonNodeEncoder;
+import io.micronaut.serde.xml.annotation.XmlRootName;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+import tools.jackson.dataformat.xml.XmlFactory;
+import tools.jackson.dataformat.xml.XmlWriteFeature;
+import tools.jackson.dataformat.xml.deser.FromXmlParser;
+import tools.jackson.dataformat.xml.ser.ToXmlGenerator;
+
+import javax.xml.XMLConstants;
+import javax.xml.namespace.QName;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * The XmlObjectMapper class provides a concrete implementation of the
+ * {@link ObjectMapper} interface,
+ * utilizing XML serialization and deserialization.
+ *
+ * @author Mousrij Hamza
+ * @since 1.0
+ */
+@Singleton
+@Named("xml")
+@Internal
+public class XmlObjectMapper implements ObjectMapper {
+
+    private final SerdeRegistry registry;
+    private final SerdeIntrospections introspections;
+    private final XmlFactory xmlFactory;
+    @Nullable
+    private final SerdeConfiguration serdeConfiguration;
+    @Nullable
+    private final String defaultRootName;
+
+    public XmlObjectMapper(SerdeRegistry registry,
+            SerdeIntrospections introspections) {
+        this(registry, introspections, null, null);
+    }
+
+    public XmlObjectMapper(SerdeRegistry registry,
+            SerdeIntrospections introspections,
+            @Nullable SerdeConfiguration serdeConfiguration,
+            @Nullable XmlSerdeConfiguration xmlConfiguration) {
+        this.registry = registry;
+        this.introspections = introspections;
+        this.serdeConfiguration = serdeConfiguration;
+        // Empty XML elements are exposed as JsonToken.VALUE_NULL and Not representing the nil attributes
+        this.xmlFactory =  XmlFactory.builder()
+            .disable(XmlWriteFeature.AUTO_DETECT_XSI_TYPE)
+            .disable(XmlWriteFeature.WRITE_NULLS_AS_XSI_NIL)
+            .build();
+        this.defaultRootName = xmlConfiguration != null ? xmlConfiguration.getDefaultRootName() : null;
+    }
+
+    @Override
+    public <T> T readValue(@NonNull InputStream inputStream, @NonNull Argument<T> type) throws IOException {
+        return readValue(toByteArray(inputStream), type);
+    }
+
+    @Override
+    public <T> T readValue(byte @NonNull [] byteArray, @NonNull Argument<T> type) throws IOException {
+        Deserializer.DecoderContext decoderContext = registry.newDecoderContext(null);
+        Deserializer<? extends T> deserializer = decoderContext.findDeserializer(type).createSpecific(decoderContext,
+                type);
+        try (FromXmlParser parser = createParser(byteArray)) {
+            if (parser.currentToken() == null) {
+                parser.nextToken();
+            }
+            return deserializer.deserialize(new XmlReaderDecoder(parser, limits()), decoderContext, type);
+        }
+    }
+
+    @Override
+    public <T> T readValue(@NonNull String string, @NonNull Argument<T> type) throws IOException {
+        return readValue(string.getBytes(StandardCharsets.UTF_8), type);
+    }
+
+    @Override
+    public <T> T readValueFromTree(@NonNull JsonNode tree, @NonNull Argument<T> type) throws IOException {
+        Deserializer.DecoderContext decoderContext = registry.newDecoderContext(null);
+        Deserializer<? extends T> deserializer = decoderContext.findDeserializer(type).createSpecific(decoderContext,
+                type);
+        return deserializer.deserialize(JsonNodeDecoder.create(tree, limits()), decoderContext, type);
+    }
+
+    @Override
+    public @NonNull JsonNode writeValueToTree(@Nullable Object value) throws IOException {
+        JsonNodeEncoder encoder = JsonNodeEncoder.create(limits());
+        serialize(encoder, value, Argument.of(value.getClass()));
+        return encoder.getCompletedValue();
+    }
+
+    @Override
+    public @NonNull <T> JsonNode writeValueToTree(@NonNull Argument<T> type, @Nullable T value) throws IOException {
+        JsonNodeEncoder encoder = JsonNodeEncoder.create(limits());
+        serialize(encoder, value, type);
+        return encoder.getCompletedValue();
+    }
+
+    @Override
+    public void writeValue(@NonNull OutputStream outputStream, @Nullable Object object) throws IOException {
+        if (object == null) {
+            try (ToXmlGenerator generator = createGenerator(outputStream)) {
+                generator.writeNull();
+                generator.flush();
+            }
+            return;
+        }
+        Argument<?> type = Argument.of(object.getClass());
+        try (ToXmlGenerator generator = createGenerator(outputStream)) {
+            generator.setNextName(new QName(XMLConstants.NULL_NS_URI, resolveRootName(type)));
+            XmlGeneratorEncoder encoder = new XmlGeneratorEncoder(generator, limits());
+            serialize(encoder, object, type);
+            generator.flush();
+        }
+    }
+
+    @Override
+    public <T> void writeValue(@NonNull OutputStream outputStream, @NonNull Argument<T> type, @Nullable T object)
+            throws IOException {
+        if (object == null) {
+            try (ToXmlGenerator generator = createGenerator(outputStream)) {
+                generator.writeNull();
+                generator.flush();
+            }
+            return;
+        }
+        try (ToXmlGenerator generator = createGenerator(outputStream)) {
+            generator.setNextName(new QName(XMLConstants.NULL_NS_URI, resolveRootName(type)));
+            XmlGeneratorEncoder encoder = new XmlGeneratorEncoder(generator, limits());
+            serialize(encoder, object, type);
+            generator.flush();
+        }
+    }
+
+    @Override
+    public byte[] writeValueAsBytes(@Nullable Object object) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        writeValue(output, object);
+        return output.toByteArray();
+    }
+
+    @Override
+    public <T> byte[] writeValueAsBytes(@NonNull Argument<T> type, @Nullable T object) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        writeValue(output, type, object);
+        return output.toByteArray();
+    }
+
+    @Override
+    public @NonNull JsonStreamConfig getStreamConfig() {
+        return JsonStreamConfig.DEFAULT;
+    }
+
+    @NonNull
+    private LimitingStream.RemainingLimits limits() {
+        return serdeConfiguration == null
+                ? LimitingStream.DEFAULT_LIMITS
+                : LimitingStream.limitsFromConfiguration(serdeConfiguration);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void serialize(Encoder encoder, Object object, Argument type) throws IOException {
+        Serializer.EncoderContext encoderContext = registry.newEncoderContext(null);
+        Serializer<Object> serializer = encoderContext.findSerializer(type).createSpecific(encoderContext, type);
+        serializer.serialize(encoder, encoderContext, type, object);
+    }
+
+    private FromXmlParser createParser(byte[] byteArray) {
+        return (FromXmlParser) xmlFactory.createParser(
+                tools.jackson.core.ObjectReadContext.empty(),
+                byteArray);
+    }
+
+    private ToXmlGenerator createGenerator(OutputStream outputStream) {
+        return (ToXmlGenerator) xmlFactory.createGenerator(
+                tools.jackson.core.ObjectWriteContext.empty(),
+                outputStream);
+    }
+
+    private byte[] toByteArray(InputStream inputStream) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] buffer = new byte[512];
+        int bytesRead;
+        while ((bytesRead = inputStream.read(buffer)) != -1) {
+            baos.write(buffer, 0, bytesRead);
+        }
+        return baos.toByteArray();
+    }
+
+    private String resolveRootName(Argument<?> type) {
+
+        //TODO : solve the unkown root name have to raise exception
+        String annotationRootName = null;
+        try {
+            BeanIntrospection<?> introspection = introspections.getSerializableIntrospection(type);
+            annotationRootName = introspection.stringValue(XmlRootName.class).orElse(null);
+        } catch (Exception ignored) {
+            // fallback to defaults
+        }
+        if (annotationRootName != null && !annotationRootName.isBlank()) {
+            return annotationRootName;
+        }
+        if (defaultRootName != null) {
+            return defaultRootName;
+        }
+        String name = type.getSimpleName();
+        return (name == null || name.isEmpty()) ? "root" : name;
+    }
+}

--- a/serde-xml/src/main/java/io/micronaut/serde/xml/XmlReaderDecoder.java
+++ b/serde-xml/src/main/java/io/micronaut/serde/xml/XmlReaderDecoder.java
@@ -1,0 +1,403 @@
+package io.micronaut.serde.xml;
+
+import io.micronaut.core.type.Argument;
+import io.micronaut.json.tree.JsonNode;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.LimitingStream;
+import io.micronaut.serde.NamingStrategyLocator;
+import io.micronaut.serde.config.naming.PropertyNamingStrategy;
+import io.micronaut.serde.exceptions.SerdeException;
+import io.micronaut.serde.support.util.JsonNodeDecoder;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import tools.jackson.core.JsonToken;
+import tools.jackson.dataformat.xml.deser.FromXmlParser;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.*;
+
+/**
+ * Streaming XML implementation of {@link Decoder}.
+ * <p>
+ * Handles repeated sibling XML elements as arrays using name-tracked iteration:
+ * after each value, checks whether the next PROPERTY_NAME matches the array
+ * element name to decide if there are more items.
+ * </p>
+ *
+ * <p>XML supported array pattern :</p>
+ * <ul>
+ *   <li><b>Pattern — wrapper container:</b>
+ *       — enter the wrapper, then track inner elements by tag name.</li>
+ * </ul>
+ */
+public class XmlReaderDecoder extends LimitingStream implements Decoder, NamingStrategyLocator {
+
+    final FromXmlParser parser;
+    /**
+     * For name-tracked arrays: the XML tag name of the array elements.
+     * {@link #hasNextArrayValue()} skips PROPERTY_NAMEs matching this name
+     * and returns false when a different name (or END_OBJECT) is reached.
+     * Null for object decoders and END_ARRAY-delimited arrays.
+     */
+    @Nullable
+    private final String arrayElementName;
+    /**
+     * True for Pattern (wrapper container): {@link #finishStructure} must
+     * consume the wrapper's END_OBJECT after the inner array ends.
+     */
+    private final boolean wrappedArray;
+    /**
+     * True for empty-wrapper arrays: {@link #hasNextArrayValue()} returns false immediately.
+     */
+    private final boolean done;
+
+    public XmlReaderDecoder(FromXmlParser parser, @NonNull RemainingLimits remainingLimits) {
+        this(parser, remainingLimits, false, false, null);
+    }
+
+    public XmlReaderDecoder(XmlReaderDecoder parent, @NonNull RemainingLimits remainingLimits) {
+        this(parent.parser, remainingLimits, false, false, null);
+    }
+
+    private XmlReaderDecoder(FromXmlParser parser, @NonNull RemainingLimits remainingLimits,
+                              boolean wrappedArray, boolean done, @Nullable String arrayElementName) {
+        super(remainingLimits);
+        this.parser = parser;
+        this.wrappedArray = wrappedArray;
+        this.done = done;
+        this.arrayElementName = arrayElementName;
+    }
+
+    @Override
+    public @NonNull Decoder decodeObject(@NonNull Argument<?> type) throws IOException {
+        var jsonToken = parser.currentToken();
+        if (parser.currentToken() != JsonToken.START_OBJECT) {
+            throw new SerdeException("Expected object but got: " + parser.currentToken());
+        }
+        parser.nextToken(); // advance inside to first PROPERTY_NAME or END_OBJECT
+        return new XmlReaderDecoder(parser, childLimits(), false, false, null);
+    }
+
+    @Override
+    public @NonNull Decoder decodeArray(@NonNull Argument<?> type) throws IOException {
+        JsonToken token = parser.currentToken();
+        if (token == JsonToken.START_ARRAY) {
+            // Real START_ARRAY — advance past it.
+            parser.nextToken();
+            return new XmlReaderDecoder(parser, childLimits(), false, false, null);
+        }
+
+        if (token == JsonToken.START_OBJECT) {
+            // Pattern — wrapper container: enter it, track inner element name.
+            parser.nextToken(); // first PROPERTY_NAME or END_OBJECT
+            if (parser.currentToken() == JsonToken.END_OBJECT) {
+                parser.nextToken();
+                return new XmlReaderDecoder(parser, childLimits(), false, true, null);
+            }
+            String innerName = parser.currentName();
+            parser.nextToken(); // PROPERTY_NAME → first value
+
+            return new XmlReaderDecoder(parser, childLimits(), true, false, innerName);
+        }
+
+        throw new SerdeException("Expected START_OBJECT or START_ARRAY for array but got: " + token);
+    }
+
+    @Override
+    public boolean hasNextArrayValue() throws IOException {
+
+        if (done) {
+            return false;
+        }
+        JsonToken token = parser.currentToken();
+
+        if (token == JsonToken.END_ARRAY) {
+            return false;
+        }
+
+        if (token == JsonToken.END_OBJECT) {
+            return false;
+        }
+
+        // Name-tracked array: check if the next PROPERTY_NAME is another array element
+        if (arrayElementName != null && token == JsonToken.PROPERTY_NAME) {
+            String name = parser.currentName();
+            if (arrayElementName.equals(name)) {
+                // Same element repeats — skip the PROPERTY_NAME, advance to value
+                parser.nextToken();
+                return true;
+            }
+            // Different element name — array is done
+            return false;
+        }
+        // Current token is a value (VALUE_STRING, START_OBJECT, etc.) — more items
+        return true;
+    }
+
+    @Override
+    public @Nullable String decodeKey() throws IOException {
+        if (parser.currentToken() == JsonToken.END_OBJECT) {
+            return null;
+        }
+        if (parser.currentToken() != JsonToken.PROPERTY_NAME) {
+            throw new SerdeException("Expected property name but got: " + parser.currentToken());
+        }
+        String key = parser.currentName();
+        parser.nextToken();
+        return key;
+    }
+
+    @Override
+    public @NonNull String decodeString() throws IOException {
+        JsonToken token = parser.currentToken();
+        String value = switch (token) {
+            case VALUE_STRING, VALUE_NUMBER_INT, VALUE_NUMBER_FLOAT -> parser.getString();
+            case VALUE_TRUE -> "true";
+            case VALUE_FALSE -> "false";
+            default -> throw new SerdeException("Expected string value but got: " + token);
+        };
+        parser.nextToken();
+        return value;
+    }
+
+    @Override
+    public boolean decodeBoolean() throws IOException {
+        JsonToken token = parser.currentToken();
+        boolean value = switch (token) {
+            case VALUE_TRUE -> true;
+            case VALUE_FALSE -> false;
+            case VALUE_STRING -> Boolean.parseBoolean(parser.getString());
+            case VALUE_NUMBER_INT -> parser.getIntValue() != 0;
+            default -> throw new SerdeException("Expected boolean value but got: " + token);
+        };
+        parser.nextToken();
+        return value;
+    }
+
+    @Override
+    public byte decodeByte() throws IOException {
+        return (byte) decodeInt();
+    }
+
+    @Override
+    public short decodeShort() throws IOException {
+        return (short) decodeInt();
+    }
+
+    @Override
+    public char decodeChar() throws IOException {
+        if (parser.currentToken() == JsonToken.VALUE_STRING) {
+            String s = parser.getString();
+            if (s.length() != 1) {
+                throw new SerdeException("When decoding char value, must give a single character but got: " + s);
+            }
+            parser.nextToken();
+            return s.charAt(0);
+        }
+        return (char) decodeInt();
+    }
+
+    @Override
+    public int decodeInt() throws IOException {
+        JsonToken token = parser.currentToken();
+        int value = switch (token) {
+            case VALUE_NUMBER_INT -> parser.getIntValue();
+            case VALUE_NUMBER_FLOAT -> (int) parser.getDoubleValue();
+            case VALUE_STRING -> {
+                try {
+                    yield Integer.parseInt(parser.getString());
+                } catch (NumberFormatException e) {
+                    throw new SerdeException("Unable to coerce string to integer: " + parser.getString());
+                }
+            }
+            case VALUE_TRUE -> 1;
+            case VALUE_FALSE -> 0;
+            default -> throw new SerdeException("Expected integer value but got: " + token);
+        };
+        parser.nextToken();
+        return value;
+    }
+
+    @Override
+    public long decodeLong() throws IOException {
+        JsonToken token = parser.currentToken();
+        long value = switch (token) {
+            case VALUE_NUMBER_INT -> parser.getLongValue();
+            case VALUE_NUMBER_FLOAT -> (long) parser.getDoubleValue();
+            case VALUE_STRING -> {
+                try {
+                    yield Long.parseLong(parser.getString());
+                } catch (NumberFormatException e) {
+                    throw new SerdeException("Unable to coerce string to long: " + parser.getString());
+                }
+            }
+            case VALUE_TRUE -> 1L;
+            case VALUE_FALSE -> 0L;
+            default -> throw new SerdeException("Expected long value but got: " + token);
+        };
+        parser.nextToken();
+        return value;
+    }
+
+    @Override
+    public float decodeFloat() throws IOException {
+        return (float) decodeDouble();
+    }
+
+    @Override
+    public double decodeDouble() throws IOException {
+        JsonToken token = parser.currentToken();
+        double value = switch (token) {
+            case VALUE_NUMBER_FLOAT -> parser.getDoubleValue();
+            case VALUE_NUMBER_INT -> (double) parser.getLongValue();
+            case VALUE_STRING -> {
+                try {
+                    yield Double.parseDouble(parser.getString());
+                } catch (NumberFormatException e) {
+                    throw new SerdeException("Unable to coerce string to double: " + parser.getString());
+                }
+            }
+            case VALUE_TRUE -> 1.0;
+            case VALUE_FALSE -> 0.0;
+            default -> throw new SerdeException("Expected double value but got: " + token);
+        };
+        parser.nextToken();
+        return value;
+    }
+
+    @Override
+    public @NonNull BigInteger decodeBigInteger() throws IOException {
+        JsonToken token = parser.currentToken();
+        BigInteger value = switch (token) {
+            case VALUE_NUMBER_INT -> parser.getBigIntegerValue();
+            case VALUE_NUMBER_FLOAT -> parser.getDecimalValue().toBigInteger();
+            case VALUE_STRING -> {
+                try {
+                    yield new BigInteger(parser.getString());
+                } catch (NumberFormatException e) {
+                    yield BigInteger.ZERO;
+                }
+            }
+            case VALUE_TRUE -> BigInteger.ONE;
+            case VALUE_FALSE -> BigInteger.ZERO;
+            default -> throw new SerdeException("Expected BigInteger value but got: " + token);
+        };
+        parser.nextToken();
+        return value;
+    }
+
+    @Override
+    public @NonNull BigDecimal decodeBigDecimal() throws IOException {
+        JsonToken token = parser.currentToken();
+        BigDecimal value = switch (token) {
+            case VALUE_NUMBER_FLOAT -> parser.getDecimalValue();
+            case VALUE_NUMBER_INT -> new BigDecimal(parser.getBigIntegerValue());
+            case VALUE_STRING -> {
+                try {
+                    yield new BigDecimal(parser.getString());
+                } catch (NumberFormatException e) {
+                    yield BigDecimal.ZERO;
+                }
+            }
+            case VALUE_TRUE -> BigDecimal.ONE;
+            case VALUE_FALSE -> BigDecimal.ZERO;
+            default -> throw new SerdeException("Expected BigDecimal value but got: " + token);
+        };
+        parser.nextToken();
+        return value;
+    }
+
+    @Override
+    public boolean decodeNull() throws IOException {
+        if (parser.currentToken() == JsonToken.VALUE_NULL) {
+            parser.nextToken();
+            return true;
+        }
+        // An empty XML element <foo></foo> produces VALUE_STRING "" from the Jackson XML parser.
+        // Treat it as null so that empty repeated elements in object arrays deserialize as null
+        if (parser.currentToken() == JsonToken.VALUE_STRING) {
+            String s = parser.getString();
+            if (s == null || s.isEmpty()) {
+                parser.nextToken();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public @io.micronaut.core.annotation.Nullable Object decodeArbitrary() throws IOException {
+        return null;
+    }
+
+    @Override
+    public @io.micronaut.core.annotation.NonNull JsonNode decodeNode() throws IOException {
+        return null;
+    }
+
+    @Override
+    public Decoder decodeBuffer() throws IOException {
+        JsonNode node = decodeNode();
+        return JsonNodeDecoder.create(node, ourLimits());
+    }
+
+    @Override
+    public void skipValue() throws IOException {
+        JsonToken token = parser.currentToken();
+        if (token == JsonToken.START_OBJECT || token == JsonToken.START_ARRAY) {
+            parser.skipChildren();
+        }
+        parser.nextToken();
+    }
+
+    @Override
+    public void finishStructure(boolean consumeLeftElements) throws IOException {
+        if (done) {
+            return;
+        }
+        if (consumeLeftElements) {
+            JsonToken token = parser.currentToken();
+            while (token != null && token != JsonToken.END_OBJECT && token != JsonToken.END_ARRAY) {
+                // For name-tracked arrays, stop when a different PROPERTY_NAME appears
+                if (arrayElementName != null && token == JsonToken.PROPERTY_NAME) {
+                    if (!arrayElementName.equals(parser.currentName())) {
+                        break;
+                    }
+                    parser.nextToken(); // skip the array element's repeated PROPERTY_NAME
+                    token = parser.currentToken();
+                    continue;
+                }
+                if (token == JsonToken.PROPERTY_NAME) {
+                    parser.nextToken(); // skip property name for object fields
+                }
+                skipValue();
+                token = parser.currentToken();
+            }
+        }
+
+        if (arrayElementName != null && !wrappedArray) {
+            return;
+        }
+
+        JsonToken token = parser.currentToken();
+        if (token == JsonToken.END_OBJECT || token == JsonToken.END_ARRAY) {
+            parser.nextToken();
+        }
+
+        if (wrappedArray && parser.currentToken() == JsonToken.END_OBJECT) {
+            parser.nextToken();
+        }
+    }
+
+    @Override
+    public @NonNull IOException createDeserializationException(@NonNull String message, @Nullable Object invalidValue) {
+        return new SerdeException(message + " \n at " + parser.currentLocation());
+    }
+
+    @Override
+    public @NonNull <D extends PropertyNamingStrategy> D findNamingStrategy(@NonNull Class<? extends D> namingStrategyClass) throws SerdeException {
+        throw new SerdeException("Naming strategy not supported in XmlReaderDecoder");
+    }
+}

--- a/serde-xml/src/main/java/io/micronaut/serde/xml/XmlSerdeConfiguration.java
+++ b/serde-xml/src/main/java/io/micronaut/serde/xml/XmlSerdeConfiguration.java
@@ -1,0 +1,28 @@
+package io.micronaut.serde.xml;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.Nullable;
+
+/**
+ * Configuration Properties for XML serialization/deserialization.
+ *
+ * @author Mousrij Hamza
+ */
+@ConfigurationProperties("mirconaut.serde.xml")
+@Internal
+public final class XmlSerdeConfiguration {
+
+    @Nullable
+    private String defaultRootName;
+
+    @Nullable
+    public String getDefaultRootName() {
+        return this.defaultRootName;
+    }
+
+    public void setDefaultRootName(String defaultRootName) {
+        this.defaultRootName = defaultRootName;
+    }
+
+}

--- a/serde-xml/src/main/java/io/micronaut/serde/xml/annotation/XmlRootName.java
+++ b/serde-xml/src/main/java/io/micronaut/serde/xml/annotation/XmlRootName.java
@@ -1,0 +1,26 @@
+package io.micronaut.serde.xml.annotation;
+
+import io.micronaut.core.annotation.Introspected;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares the XML root element name for a serde type.
+ *
+ * @author Mousrij Hamza
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Introspected
+public @interface XmlRootName {
+
+    /**
+     * @return The root element name.
+     */
+    String value();
+}

--- a/serde-xml/src/test/groovy/io/micronaut/serde/xml/XMLBasicSerdeSpec.groovy
+++ b/serde-xml/src/test/groovy/io/micronaut/serde/xml/XMLBasicSerdeSpec.groovy
@@ -1,0 +1,480 @@
+package io.micronaut.serde.xml
+
+import io.micronaut.core.type.Argument
+import io.micronaut.serde.AllTypesBean
+import io.micronaut.serde.ApiResponse
+import io.micronaut.serde.BeanWithExtraMethod
+import io.micronaut.serde.ConstructorArgs
+import io.micronaut.serde.Dummy
+import io.micronaut.serde.ObjectMapper
+import io.micronaut.serde.ObjectWithArray
+import io.micronaut.serde.ObjectWithArrayConstructor
+import io.micronaut.serde.ObjectWithArrayOfArray
+import io.micronaut.serde.ObjectWithArrayRecord
+import io.micronaut.serde.ObjectWithArrayRequired
+import io.micronaut.serde.RecordBean
+import io.micronaut.serde.Simple
+import io.micronaut.serde.config.annotation.SerdeConfig
+import io.micronaut.serde.data.Users1
+import io.micronaut.serde.data.Users2
+import io.micronaut.serde.data.Users3
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import io.micronaut.test.support.TestPropertyProvider
+import jakarta.inject.Inject
+import jakarta.inject.Named
+import spock.lang.Ignore
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+@MicronautTest
+class XmlBasicSerdeSpec extends Specification implements TestPropertyProvider, XmlSpec {
+
+
+    @Inject
+    @Named("xml")
+    XmlObjectMapper xmlMapper
+
+    @Override
+    XmlObjectMapper getXmlMapper() {
+        return xmlMapper
+    }
+
+
+    def "missing list"() {
+        given:
+            def xml = "<ObjectWithArray />"
+        when:
+            def obj = xmlMapper.readValue(xml, Argument.of(ObjectWithArray))
+        then:
+            obj
+            obj.vals == null
+    }
+
+    def "missing list - constructor"() {
+        given:
+            def xml = "<ObjectWithArrayConstructor/>"
+        when:
+            def obj = xmlMapper.readValue(xml, Argument.of(ObjectWithArrayConstructor))
+        then:
+            obj
+            obj.vals == null
+    }
+
+    def "missing list - record"() {
+        given:
+            def xml = "<ObjectWithArrayRecord/>"
+        when:
+            def obj = xmlMapper.readValue(xml, Argument.of(ObjectWithArrayRecord))
+        then:
+            obj
+            obj.vals() == null
+    }
+
+    def "missing list - required"() {
+        given:
+            def xml = "<ObjectWithArrayRequired/>"
+        when:
+            xmlMapper.readValue(xml, Argument.of(ObjectWithArrayRequired))
+        then:
+            def e = thrown(Exception)
+            e.message.contains("Required constructor parameter") || e.message.contains("Missing required creator property")
+    }
+
+    void "test write simple"() {
+        when:
+            def bean = new Simple(name: "Test")
+            def result = writeXml(bean)
+        then:
+            //result == expectedXml("Simple", '{"name":"Test"}')
+            result == '<Simple><name>Test</name></Simple>'
+    }
+
+    // ---- Nested ------------------------------------------------------------
+
+    // still working on it
+    void "test nested"() {
+        when:
+            def bean = new ApiResponse(List.of(new Dummy("Xyz")));
+            def argument = Argument.of(ApiResponse, Argument.listOf(Dummy))
+            def result = writeXml(argument, bean)
+
+        then:
+            //result == expectedXml("ApiResponse", '{"content":[{"name":"Xyz"}]}')
+            result == '<ApiResponse><content><name>Xyz</name></content></ApiResponse>'
+
+        when:
+            def readBean = xmlMapper.readValue(result, argument)
+
+        then:
+            readBean.content.size() == 1
+            readBean.content[0].name == "Xyz"
+            readBean.content[1].name == "xcv"
+
+
+    }
+
+    // ---- Constructor args
+
+    void "test read/write constructor args"() {
+        when:
+            def bean = new ConstructorArgs("test", 100)
+            bean.author = "Bob"
+            bean.other = "Something"
+            def result = writeXml(bean)
+        then:
+            result.contains("<title>test</title>")
+            result.contains("<author>Bob</author>")
+            result.contains("<pages>100</pages>")
+            result.contains("<other>Something</other>")
+            result.startsWith("<ConstructorArgs>")
+            result.trim().endsWith("</ConstructorArgs>")
+
+        when:
+            bean = xmlMapper.readValue(result, Argument.of(ConstructorArgs))
+        then:
+            bean.title == 'test'
+            bean.pages == 100
+            bean.other == 'Something'
+            bean.author == 'Bob'
+
+        when:
+            bean = xmlMapper.readValue(
+                    //xmlBytes('{"other":"Something","author":"Bob","title":"test","pages":100}'),
+                    "<ConstructorArgs><other>Something</other><author>Bob</author><title>test</title><pages>100</pages></ConstructorArgs>",
+                    Argument.of(ConstructorArgs))
+        then:
+            bean.title == 'test'
+            bean.pages == 100
+            bean.other == 'Something'
+            bean.author == 'Bob'
+    }
+
+    def "validate arrays"() {
+        given:
+            def xml =
+                    "<ObjectWithArray>" +
+                            "<vals>" +
+                                "<vals>" +
+                                    "<val>A</val>" +
+                                "</vals>" +
+                                "<vals>" +
+                                    "<val>B</val>" +
+                                "</vals>" +
+                            "</vals>" +
+                    "</ObjectWithArray>";
+        when:
+            def obj = xmlMapper.readValue(xml, Argument.of(ObjectWithArray))
+        then:
+            obj
+            obj.vals.size() == 2
+            obj.vals[0].val == "A"
+            obj.vals[1].val == "B"
+            objRepresentationMatches(obj, xml)
+    }
+
+    def "validate empty arrays"() {
+        given:
+            def xml = '<ObjectWithArray></ObjectWithArray>'
+        when:
+            def obj = xmlMapper.readValue(xml, Argument.of(ObjectWithArray))
+        then:
+            obj
+            obj.vals == null
+    }
+
+    def "validate arrays with nulls"() {
+        given:
+        // TODO deal with null
+            def xmls = "<ObjectWithArray>" +
+                        "<vals>" +
+                            "<vals>" +
+                                "<val>A</val>" +
+                            "</vals>" +
+                            "<vals>" +
+                                    // missing "<val></val>" lead to null
+                            "</vals>" +
+                            "<vals>" +
+                                "<val>B</val>" +
+                            "</vals>" +
+                        "</vals>" +
+                    "</ObjectWithArray>"
+        when:
+            def obj = xmlMapper.readValue(xmls, Argument.of(ObjectWithArray))
+        then:
+            obj.vals.size() == 3
+            obj.vals[0].val == "A"
+            obj.vals[1] == null
+            obj.vals[2].val == "B"
+    }
+
+
+    def "validate arrays of arrays"() {
+        //TODO raise exception, see the online formatter
+        given:
+            // nsi is off
+            def xml = '<ObjectWithArrayOfArray><vals><vals><vals><val>A</val></vals><vals/><vals><val>B</val></vals></vals></vals></ObjectWithArrayOfArray>'
+            //def xml = "<ObjectWithArrayOfArray><vals><vals><vals><val>A</val></vals>" + "<vals xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:nil=\"true\"/>" + "<vals><val>B</val></vals></vals></vals></ObjectWithArrayOfArray>"
+        when:
+            def obj = xmlMapper.readValue(xml, Argument.of(ObjectWithArrayOfArray))
+            println obj.toString()
+        then:
+            obj
+            obj.vals.size() == 1
+            obj.vals[0].size() == 3
+            obj.vals[0][0].val == "A"
+            obj.vals[0][1] == null
+            obj.vals[0][2].val == "B"
+            objRepresentationMatches(obj, xml)
+
+    }
+
+    //@Ignore("Jackson XML struggles with nested lists without wrapper elements")
+    def "validate empty arrays of arrays"() {
+        given:
+            // def xml = expectedXml("ObjectWithArrayOfArray", '{"vals": [[]]}')
+            def xml = "<ObjectWithArrayOfArray><vals><vals><vals><val/></vals></vals></vals></ObjectWithArrayOfArray>"
+
+        when:
+
+            def obj = xmlMapper.readValue(xml, Argument.of(ObjectWithArrayOfArray))
+            println xml
+        then:
+            println "===>" + obj.toString()
+            obj.vals.size() == 1
+            obj.vals[0].size() == 1
+            objRepresentationMatches(obj, xml)
+    }
+
+    def "validate null arrays of arrays"() {
+        given:
+            // def xml = expectedXml("ObjectWithArrayOfArray", '{"vals": [null]}')
+            def xml = '<ObjectWithArrayOfArray><vals><vals/></vals></ObjectWithArrayOfArray>'
+        when:
+            def obj = xmlMapper.readValue(xml, Argument.of(ObjectWithArrayOfArray))
+        then:
+            obj
+            obj.vals.size() == 1
+            obj.vals[0] == null
+            objRepresentationMatches(obj, xml)
+    }
+
+    def "validate arrays as null"() {
+        given:
+            //def xml = xmlBytes('{"ObjectWithArray":{"vals": null}}')
+            def xml = "<ObjectWithArray><vals/></ObjectWithArray>"
+
+        when:
+            def obj = xmlMapper.readValue(xml, Argument.of(ObjectWithArray))
+            println "==<" + obj.toString()
+        then:
+            obj
+            obj.vals == null
+            objRepresentationMatches(obj, xml)
+    }
+
+    def "should deser all null types bean"() {
+        given:
+        def xml = "<AllTypesBean />"
+        when:
+        def obj = xmlMapper.readValue(
+                xml,
+                Argument.of(AllTypesBean))
+        then:
+        noExceptionThrown()
+    }
+
+    def "all nullable fields null"() {
+        given:
+            def bean = new AllTypesBean()
+            // leave all nullable fields unset (null)
+
+        when:
+            def bytes = xmlMapper.writeValueAsBytes(bean)
+            def result = xmlMapper.readValue(bytes, Argument.of(AllTypesBean))
+
+        then:
+            noExceptionThrown()
+            !result.someBool
+            result.someInt   == 0
+            result.someLong  == 0L
+            result.someString  == null
+            result.someBoolean == null
+            result.bigDecimal  == null
+            result.bigInteger  == null
+
+    }
+
+    def "validate all types bean"() {
+        given:
+            def all = new AllTypesBean()
+            all.someBool = true
+            all.someInt = 123
+            all.someLong = 234
+            all.someByte = (byte) 34
+            all.someShort = (short) 567
+            all.someFloat = 11.22f
+            all.someDouble = 123.234D
+            all.someString = "Hello"
+            all.someBoolean = Boolean.TRUE
+            all.someInteger = 444
+            all.someLongObj = 555
+            all.someDoubleObj = 666.77d
+            all.someShortObj = 777
+            all.someFloatObj = 888.99f
+            all.someByteObj = 99
+            all.bigDecimal = BigDecimal.valueOf(12345.12345)
+            all.bigInteger = BigInteger.valueOf(123456789)
+        when:
+            def result = serializeDeserialize(all)
+            then:
+            result.someBool
+            result.someInt == 123
+            result.someLong == 234
+            result.someByte == (byte) 34
+            result.someShort == (short) 567
+            result.someFloat == 11.22f
+            result.someDouble == 123.234D
+            result.someString == "Hello"
+            result.someBoolean == Boolean.TRUE
+            result.someInteger == 444
+            result.someLongObj == 555
+            result.someDoubleObj == 666.77d
+            result.someShortObj == 777
+            result.someFloatObj == 888.99f
+            result.someByteObj == 99
+            result.bigDecimal == BigDecimal.valueOf(12345.12345)
+            result.bigInteger == BigInteger.valueOf(123456789)
+    }
+
+    // Type-level round-trips (primitives as element text)
+
+    def "round-trip primitive types via AllTypesBean"() {
+        given:
+            def bean = new AllTypesBean()
+            bean.someInt    = intVal
+            bean.someLong   = longVal
+            bean.someDouble = doubleVal
+            bean.someBool   = boolVal
+
+        when:
+            def bytes  = xmlMapper.writeValueAsBytes(bean)
+            def result = xmlMapper.readValue(bytes, Argument.of(AllTypesBean))
+
+        then:
+            result.someInt    == intVal
+            result.someLong   == longVal
+            Math.abs(result.someDouble - doubleVal) < 0.001d
+            result.someBool   == boolVal
+
+        where:
+            intVal | longVal    | doubleVal | boolVal
+            0      | 0L         | 0.0d      | false
+            1      | 1L         | 1.1d      | true
+            -42    | -100000L   | -3.14d    | false
+            999    | 9999999999L| 123.456d  | true
+    }
+
+
+    def "validate json node"() {
+        //--
+    }
+
+    // ---- Skip unknown / decode null ----------------------------------------
+
+    def "should skip unknown values"() {
+        when:
+            def value = xmlMapper.readValue(
+                    '<AllTypesBean><unknown>ABC</unknown></AllTypesBean>',
+                    Argument.of(AllTypesBean))
+        then:
+            noExceptionThrown()
+    }
+
+    def "should decode null"() {
+        given:
+            def xml = "<AllTypesBean>" +
+                        "<someBool/>" +
+                        "<someInt></someInt>" +
+                        "<bigDecimal></bigDecimal>" +
+                    "</AllTypesBean>"
+        when:
+        def value = xmlMapper.readValue(
+                xml,
+                Argument.of(AllTypesBean))
+        then:
+        value.someInt == 0
+        !value.someBool
+        value.bigDecimal == null
+    }
+
+    //@Ignore("Jackson XML struggles with nested lists without wrapper elements / SerdeException in arrays")
+    def "should deser deep structure Users 1"() {
+        given:
+            def xml = "<Users1><users><users><_id>39771757156730064829</_id><index>1031703887</index><guid>ifhsrU6geU4PijjDE8Q5</guid><isActive>false</isActive><balance>TKl0GcwTs72S4CPx5rfg</balance><picture>FkKrg6ZOPC5REchlhixu5WgIl3gNAqq28iLtFm6dKfTSQs8d3P0cYxKsEvbvMB2C6BVgExop3khRlNSFE4SV8dVFitFs7RyyecN8</picture><age>5</age><eyeColor>AY79Pw4sYByUZEMLxnYJ</eyeColor><name>XjXrEZMuTvPnuOPBg7hL</name><gender>VaMcuWBHvnWvIlCC9q4T</gender><company>6pmCe1LxouRGfZD79ena</company><email>TboNtpmAS0ppZ07jITFE</email><phone>j8OoUhtmwBlI20EgD1LS</phone><address>Aqo4fSYBpvvAWTDqbFbK</address><about>1kXFSA2782BLqNBbKIbp</about><registered>Mc7h3gZJcQ11ShGQYdXI</registered><latitude>13.474549605725421</latitude><longitude>35.010833129741435</longitude><tags><tags>8tGfPhZkZD</tags><tags>XYmwuAAtZ4</tags><tags>u9iBDMpS9G</tags><tags>4udy1eRqme</tags><tags>Lg48Ogrf0I</tags><tags>zku019kVpo</tags><tags>iuIMkiZzog</tags><tags>MuI1uYeCjc</tags><tags>49n7qisFD8</tags><tags>TtVgWerCRh</tags><tags>H604QRJmi1</tags><tags>ZIQMfqInNH</tags><tags>CbDyjjA19F</tags><tags>pNFwPdkVdU</tags><tags>aPFLsUbIUh</tags><tags>fA735PT0Hd</tags><tags>00etYDYL87</tags><tags>mlyEf1lI2B</tags><tags>RQ05IJSzXF</tags><tags>3jJt0Zrkhw</tags><tags>ZINP8GH4Bm</tags><tags>XebX8UvviN</tags><tags>EXqZ9G0ATB</tags><tags>ssyzWZVAa2</tags></tags><friends><friends><id>2668</id><name>lcxeDXPbnoIxAPqTNdkwbcGIJxLnPe</name></friends><friends><id>9395</id><name>dxNBbezfkbotyCmFzjodONShlGFaAg</name></friends><friends><id>5249</id><name>fYHSDXScMSzQvxzFuuPHYWfyjdGQLg</name></friends><friends><id>4978</id><name>qfoxPWmoWUyUduVkRwhzyBusuflrFY</name></friends><friends><id>9710</id><name>vUAJwshFGLoBHfwLcsEVNLJLwdaCAg</name></friends><friends><id>7404</id><name>BhVMdvhPRdpwpDWAmfhNDikncdNgGr</name></friends><friends><id>1343</id><name>ZeDoizPcOBafZtVYDOmpzGoHekfoxf</name></friends><friends><id>7382</id><name>KtqXeVdCQJlwSNHkgkxuoIGdOWrmqG</name></friends><friends><id>1365</id><name>rCSTlgbmTAFhbSfPmnftcDLwdiKsHt</name></friends><friends><id>8037</id><name>PUvwVYoSvSTnwjJCQITTcwNvMOpxie</name></friends><friends><id>4858</id><name>cUfQfDIiyMfCMYBKGwhZSWnRRKwlxG</name></friends><friends><id>9141</id><name>rJxMGOWRjdkphthcaKTspFrMcvcLLb</name></friends><friends><id>9128</id><name>gcsYaolAQqrNMQTluIAKOkwYTWVUXe</name></friends><friends><id>2268</id><name>jwXOUcXAiLurRlgTdxyKWvsbNHfFxl</name></friends><friends><id>5447</id><name>whivfJXOdxoHtLIGpytTdbOXxlZpUY</name></friends><friends><id>7551</id><name>whykuIjZUgvOFGpmNHjoPeTeYCPNby</name></friends><friends><id>719</id><name>SmbiwQaORLdsbAlUZbQwgCKfuoPLVr</name></friends><friends><id>7773</id><name>LZmRMXmXXHzlzFFJAopDNnWkuBqndD</name></friends><friends><id>9602</id><name>xCNsDBFMygEwZuecJKTUrqeDLBJlrR</name></friends><friends><id>1536</id><name>hrfeFnKnmVgZDDOxAHgXfgcJSRyiXB</name></friends><friends><id>3549</id><name>NvvhXwWgCSaYijqhxsrxIWrHbBOOIa</name></friends></friends><greeting>hTAIJLspvLr8DJPG3jYh</greeting><favoriteFruit>f6ZsZ3saRGKMBCZLAkiP</favoriteFruit></users></users></Users1>"
+        when:
+            def obj = xmlMapper.readValue(xml, Argument.of(Users1))
+        then:
+            def result = writeXml(obj);
+            XmlMatches(result, xml)
+    }
+
+    //@Ignore("Jackson XML struggles with nested lists without wrapper elements / SerdeException in arrays")
+    def "should deser deep structure Users 2"() {
+        given:
+            def xml = "<Users2><users><users><_id>39771757156730064829</_id><index>1031703887</index><guid>ifhsrU6geU4PijjDE8Q5</guid><isActive>false</isActive><balance>TKl0GcwTs72S4CPx5rfg</balance><picture>FkKrg6ZOPC5REchlhixu5WgIl3gNAqq28iLtFm6dKfTSQs8d3P0cYxKsEvbvMB2C6BVgExop3khRlNSFE4SV8dVFitFs7RyyecN8</picture><age>5</age><eyeColor>AY79Pw4sYByUZEMLxnYJ</eyeColor><name>XjXrEZMuTvPnuOPBg7hL</name><gender>VaMcuWBHvnWvIlCC9q4T</gender><company>6pmCe1LxouRGfZD79ena</company><email>TboNtpmAS0ppZ07jITFE</email><phone>j8OoUhtmwBlI20EgD1LS</phone><address>Aqo4fSYBpvvAWTDqbFbK</address><about>1kXFSA2782BLqNBbKIbp</about><registered>Mc7h3gZJcQ11ShGQYdXI</registered><latitude>13.474549605725421</latitude><longitude>35.010833129741435</longitude><tags><tags>8tGfPhZkZD</tags><tags>XYmwuAAtZ4</tags><tags>u9iBDMpS9G</tags><tags>4udy1eRqme</tags><tags>Lg48Ogrf0I</tags><tags>zku019kVpo</tags><tags>iuIMkiZzog</tags><tags>MuI1uYeCjc</tags><tags>49n7qisFD8</tags><tags>TtVgWerCRh</tags><tags>H604QRJmi1</tags><tags>ZIQMfqInNH</tags><tags>CbDyjjA19F</tags><tags>pNFwPdkVdU</tags><tags>aPFLsUbIUh</tags><tags>fA735PT0Hd</tags><tags>00etYDYL87</tags><tags>mlyEf1lI2B</tags><tags>RQ05IJSzXF</tags><tags>3jJt0Zrkhw</tags><tags>ZINP8GH4Bm</tags><tags>XebX8UvviN</tags><tags>EXqZ9G0ATB</tags><tags>ssyzWZVAa2</tags></tags><friends><friends><id>2668</id><name>lcxeDXPbnoIxAPqTNdkwbcGIJxLnPe</name></friends><friends><id>9395</id><name>dxNBbezfkbotyCmFzjodONShlGFaAg</name></friends><friends><id>5249</id><name>fYHSDXScMSzQvxzFuuPHYWfyjdGQLg</name></friends><friends><id>4978</id><name>qfoxPWmoWUyUduVkRwhzyBusuflrFY</name></friends><friends><id>9710</id><name>vUAJwshFGLoBHfwLcsEVNLJLwdaCAg</name></friends><friends><id>7404</id><name>BhVMdvhPRdpwpDWAmfhNDikncdNgGr</name></friends><friends><id>1343</id><name>ZeDoizPcOBafZtVYDOmpzGoHekfoxf</name></friends><friends><id>7382</id><name>KtqXeVdCQJlwSNHkgkxuoIGdOWrmqG</name></friends><friends><id>1365</id><name>rCSTlgbmTAFhbSfPmnftcDLwdiKsHt</name></friends><friends><id>8037</id><name>PUvwVYoSvSTnwjJCQITTcwNvMOpxie</name></friends><friends><id>4858</id><name>cUfQfDIiyMfCMYBKGwhZSWnRRKwlxG</name></friends><friends><id>9141</id><name>rJxMGOWRjdkphthcaKTspFrMcvcLLb</name></friends><friends><id>9128</id><name>gcsYaolAQqrNMQTluIAKOkwYTWVUXe</name></friends><friends><id>2268</id><name>jwXOUcXAiLurRlgTdxyKWvsbNHfFxl</name></friends><friends><id>5447</id><name>whivfJXOdxoHtLIGpytTdbOXxlZpUY</name></friends><friends><id>7551</id><name>whykuIjZUgvOFGpmNHjoPeTeYCPNby</name></friends><friends><id>719</id><name>SmbiwQaORLdsbAlUZbQwgCKfuoPLVr</name></friends><friends><id>7773</id><name>LZmRMXmXXHzlzFFJAopDNnWkuBqndD</name></friends><friends><id>9602</id><name>xCNsDBFMygEwZuecJKTUrqeDLBJlrR</name></friends><friends><id>1536</id><name>hrfeFnKnmVgZDDOxAHgXfgcJSRyiXB</name></friends><friends><id>3549</id><name>NvvhXwWgCSaYijqhxsrxIWrHbBOOIa</name></friends></friends><greeting>hTAIJLspvLr8DJPG3jYh</greeting><favoriteFruit>f6ZsZ3saRGKMBCZLAkiP</favoriteFruit></users></users></Users2>"
+            def xmlStripped = "<Users2><users><users><_id>39771757156730064829</_id><index>1031703887</index><guid>ifhsrU6geU4PijjDE8Q5</guid><isActive>false</isActive><balance>TKl0GcwTs72S4CPx5rfg</balance><picture>FkKrg6ZOPC5REchlhixu5WgIl3gNAqq28iLtFm6dKfTSQs8d3P0cYxKsEvbvMB2C6BVgExop3khRlNSFE4SV8dVFitFs7RyyecN8</picture><age>5</age><eyeColor>AY79Pw4sYByUZEMLxnYJ</eyeColor><name>XjXrEZMuTvPnuOPBg7hL</name><gender>VaMcuWBHvnWvIlCC9q4T</gender><company>6pmCe1LxouRGfZD79ena</company><email>TboNtpmAS0ppZ07jITFE</email><phone>j8OoUhtmwBlI20EgD1LS</phone><address>Aqo4fSYBpvvAWTDqbFbK</address><about>1kXFSA2782BLqNBbKIbp</about><registered>Mc7h3gZJcQ11ShGQYdXI</registered></users></users></Users2>";
+        when:
+            def obj = xmlMapper.readValue(xml, Users2.class)
+        then:
+            def result = writeXml(obj);
+            XmlMatches(result, xmlStripped)
+    }
+
+    //@Ignore("Jackson XML struggles with nested lists without wrapper elements / SerdeException in arrays")
+    def "should deser deep structure Users 3"() {
+        given:
+            def xml = "<Users3><users><users><_id>39771757156730064829</_id><index>1031703887</index><guid>ifhsrU6geU4PijjDE8Q5</guid><isActive>false</isActive><balance>TKl0GcwTs72S4CPx5rfg</balance><picture>FkKrg6ZOPC5REchlhixu5WgIl3gNAqq28iLtFm6dKfTSQs8d3P0cYxKsEvbvMB2C6BVgExop3khRlNSFE4SV8dVFitFs7RyyecN8</picture><age>5</age><eyeColor>AY79Pw4sYByUZEMLxnYJ</eyeColor><name>XjXrEZMuTvPnuOPBg7hL</name><gender>VaMcuWBHvnWvIlCC9q4T</gender><company>6pmCe1LxouRGfZD79ena</company><email>TboNtpmAS0ppZ07jITFE</email><phone>j8OoUhtmwBlI20EgD1LS</phone><address>Aqo4fSYBpvvAWTDqbFbK</address><about>1kXFSA2782BLqNBbKIbp</about><registered>Mc7h3gZJcQ11ShGQYdXI</registered><latitude>13.474549605725421</latitude><longitude>35.010833129741435</longitude><tags><tags>8tGfPhZkZD</tags><tags>XYmwuAAtZ4</tags><tags>u9iBDMpS9G</tags><tags>4udy1eRqme</tags><tags>Lg48Ogrf0I</tags><tags>zku019kVpo</tags><tags>iuIMkiZzog</tags><tags>MuI1uYeCjc</tags><tags>49n7qisFD8</tags><tags>TtVgWerCRh</tags><tags>H604QRJmi1</tags><tags>ZIQMfqInNH</tags><tags>CbDyjjA19F</tags><tags>pNFwPdkVdU</tags><tags>aPFLsUbIUh</tags><tags>fA735PT0Hd</tags><tags>00etYDYL87</tags><tags>mlyEf1lI2B</tags><tags>RQ05IJSzXF</tags><tags>3jJt0Zrkhw</tags><tags>ZINP8GH4Bm</tags><tags>XebX8UvviN</tags><tags>EXqZ9G0ATB</tags><tags>ssyzWZVAa2</tags></tags><friends><friends><id>2668</id><name>lcxeDXPbnoIxAPqTNdkwbcGIJxLnPe</name></friends><friends><id>9395</id><name>dxNBbezfkbotyCmFzjodONShlGFaAg</name></friends><friends><id>5249</id><name>fYHSDXScMSzQvxzFuuPHYWfyjdGQLg</name></friends><friends><id>4978</id><name>qfoxPWmoWUyUduVkRwhzyBusuflrFY</name></friends><friends><id>9710</id><name>vUAJwshFGLoBHfwLcsEVNLJLwdaCAg</name></friends><friends><id>7404</id><name>BhVMdvhPRdpwpDWAmfhNDikncdNgGr</name></friends><friends><id>1343</id><name>ZeDoizPcOBafZtVYDOmpzGoHekfoxf</name></friends><friends><id>7382</id><name>KtqXeVdCQJlwSNHkgkxuoIGdOWrmqG</name></friends><friends><id>1365</id><name>rCSTlgbmTAFhbSfPmnftcDLwdiKsHt</name></friends><friends><id>8037</id><name>PUvwVYoSvSTnwjJCQITTcwNvMOpxie</name></friends><friends><id>4858</id><name>cUfQfDIiyMfCMYBKGwhZSWnRRKwlxG</name></friends><friends><id>9141</id><name>rJxMGOWRjdkphthcaKTspFrMcvcLLb</name></friends><friends><id>9128</id><name>gcsYaolAQqrNMQTluIAKOkwYTWVUXe</name></friends><friends><id>2268</id><name>jwXOUcXAiLurRlgTdxyKWvsbNHfFxl</name></friends><friends><id>5447</id><name>whivfJXOdxoHtLIGpytTdbOXxlZpUY</name></friends><friends><id>7551</id><name>whykuIjZUgvOFGpmNHjoPeTeYCPNby</name></friends><friends><id>719</id><name>SmbiwQaORLdsbAlUZbQwgCKfuoPLVr</name></friends><friends><id>7773</id><name>LZmRMXmXXHzlzFFJAopDNnWkuBqndD</name></friends><friends><id>9602</id><name>xCNsDBFMygEwZuecJKTUrqeDLBJlrR</name></friends><friends><id>1536</id><name>hrfeFnKnmVgZDDOxAHgXfgcJSRyiXB</name></friends><friends><id>3549</id><name>NvvhXwWgCSaYijqhxsrxIWrHbBOOIa</name></friends></friends><greeting>hTAIJLspvLr8DJPG3jYh</greeting><favoriteFruit>f6ZsZ3saRGKMBCZLAkiP</favoriteFruit></users></users></Users3>"
+            def xmlStripped = "<Users3><users><users><_id>39771757156730064829</_id><index>1031703887</index><guid>ifhsrU6geU4PijjDE8Q5</guid><isActive>false</isActive><balance>TKl0GcwTs72S4CPx5rfg</balance><picture>FkKrg6ZOPC5REchlhixu5WgIl3gNAqq28iLtFm6dKfTSQs8d3P0cYxKsEvbvMB2C6BVgExop3khRlNSFE4SV8dVFitFs7RyyecN8</picture><age>5</age><eyeColor>AY79Pw4sYByUZEMLxnYJ</eyeColor><name>XjXrEZMuTvPnuOPBg7hL</name><gender>VaMcuWBHvnWvIlCC9q4T</gender><company>6pmCe1LxouRGfZD79ena</company><email>TboNtpmAS0ppZ07jITFE</email><phone>j8OoUhtmwBlI20EgD1LS</phone><address>Aqo4fSYBpvvAWTDqbFbK</address><about>1kXFSA2782BLqNBbKIbp</about><registered>Mc7h3gZJcQ11ShGQYdXI</registered><latitude>13.474549605725421</latitude><longitude>35.010833129741435</longitude><tags><tags>8tGfPhZkZD</tags><tags>XYmwuAAtZ4</tags><tags>u9iBDMpS9G</tags><tags>4udy1eRqme</tags><tags>Lg48Ogrf0I</tags><tags>zku019kVpo</tags><tags>iuIMkiZzog</tags><tags>MuI1uYeCjc</tags><tags>49n7qisFD8</tags><tags>TtVgWerCRh</tags><tags>H604QRJmi1</tags><tags>ZIQMfqInNH</tags><tags>CbDyjjA19F</tags><tags>pNFwPdkVdU</tags><tags>aPFLsUbIUh</tags><tags>fA735PT0Hd</tags><tags>00etYDYL87</tags><tags>mlyEf1lI2B</tags><tags>RQ05IJSzXF</tags><tags>3jJt0Zrkhw</tags><tags>ZINP8GH4Bm</tags><tags>XebX8UvviN</tags><tags>EXqZ9G0ATB</tags><tags>ssyzWZVAa2</tags></tags><friends><friends><id>2668</id><name>lcxeDXPbnoIxAPqTNdkwbcGIJxLnPe</name></friends><friends><id>9395</id><name>dxNBbezfkbotyCmFzjodONShlGFaAg</name></friends><friends><id>5249</id><name>fYHSDXScMSzQvxzFuuPHYWfyjdGQLg</name></friends><friends><id>4978</id><name>qfoxPWmoWUyUduVkRwhzyBusuflrFY</name></friends><friends><id>9710</id><name>vUAJwshFGLoBHfwLcsEVNLJLwdaCAg</name></friends><friends><id>7404</id><name>BhVMdvhPRdpwpDWAmfhNDikncdNgGr</name></friends><friends><id>1343</id><name>ZeDoizPcOBafZtVYDOmpzGoHekfoxf</name></friends><friends><id>7382</id><name>KtqXeVdCQJlwSNHkgkxuoIGdOWrmqG</name></friends><friends><id>1365</id><name>rCSTlgbmTAFhbSfPmnftcDLwdiKsHt</name></friends><friends><id>8037</id><name>PUvwVYoSvSTnwjJCQITTcwNvMOpxie</name></friends><friends><id>4858</id><name>cUfQfDIiyMfCMYBKGwhZSWnRRKwlxG</name></friends><friends><id>9141</id><name>rJxMGOWRjdkphthcaKTspFrMcvcLLb</name></friends><friends><id>9128</id><name>gcsYaolAQqrNMQTluIAKOkwYTWVUXe</name></friends><friends><id>2268</id><name>jwXOUcXAiLurRlgTdxyKWvsbNHfFxl</name></friends><friends><id>5447</id><name>whivfJXOdxoHtLIGpytTdbOXxlZpUY</name></friends><friends><id>7551</id><name>whykuIjZUgvOFGpmNHjoPeTeYCPNby</name></friends><friends><id>719</id><name>SmbiwQaORLdsbAlUZbQwgCKfuoPLVr</name></friends><friends><id>7773</id><name>LZmRMXmXXHzlzFFJAopDNnWkuBqndD</name></friends><friends><id>9602</id><name>xCNsDBFMygEwZuecJKTUrqeDLBJlrR</name></friends><friends><id>1536</id><name>hrfeFnKnmVgZDDOxAHgXfgcJSRyiXB</name></friends><friends><id>3549</id><name>NvvhXwWgCSaYijqhxsrxIWrHbBOOIa</name></friends></friends></users></users></Users3>";
+        when:
+            def obj = xmlMapper.readValue(xml, Users3.class)
+        then:
+            def result = writeXml(obj);
+            XmlMatches(result, xmlStripped)
+    }
+
+    void "test read/write record"() {
+        when:
+            def bean = new RecordBean("fizz", "buzz")
+            def result = writeXml(bean)
+        then:
+            //result == expectedXml("RecordBean", '{"foo":"fizz","bar":"buzz"}')
+            result == '<RecordBean><foo>fizz</foo><bar>buzz</bar></RecordBean>'
+
+        when:
+            bean = xmlMapper.readValue(result, Argument.of(RecordBean))
+        then:
+            bean.foo() == 'fizz'
+            bean.bar() == 'buzz'
+
+    }
+
+    void "test a bean with an extra executable method"() {
+        when:
+        def bean = new BeanWithExtraMethod()
+        bean.name = "Bob"
+        def result = writeXml(bean)
+        then:
+        result == '<BeanWithExtraMethod><name>Bob</name></BeanWithExtraMethod>'
+
+        when:
+        bean = xmlMapper.readValue(result, Argument.of(BeanWithExtraMethod))
+        then:
+        bean.name == 'Bob'
+    }
+
+    @Override
+    Map<String, String> getProperties() {
+        ["micronaut.serde.serialization.inclusion": SerdeConfig.SerInclude.ALWAYS.name()]
+    }
+}

--- a/serde-xml/src/test/groovy/io/micronaut/serde/xml/XmLIgnoreSpec.groovy
+++ b/serde-xml/src/test/groovy/io/micronaut/serde/xml/XmLIgnoreSpec.groovy
@@ -1,0 +1,91 @@
+package io.micronaut.serde.xml
+
+import io.micronaut.core.type.Argument
+
+class XmlIgnoreSpec extends XmlCompileSpec {
+
+    void "test @JsonIgnore on field"() {
+        given:
+            def context = buildContext('test.Test', """
+package test;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+@Serdeable
+class Test {
+    private String value;
+    @JsonIgnore
+    private boolean ignored;
+    public void setValue(String value) {
+        this.value = value;
+    }
+    public String getValue() {
+        return value;
+    }
+
+    public void setIgnored(boolean b) {
+        this.ignored = b;
+    }
+
+    public boolean isIgnored() {
+        return ignored;
+    }
+}
+""", [value: 'test', ignored: true])
+
+        when:
+            def bytes = xmlMapper.writeValueAsBytes(beanUnderTest)
+
+        then:
+            new String(bytes) == '<Test><value>test</value></Test>'
+
+        cleanup:
+            context.close()
+
+    }
+
+    void "test @JsonIgnore on method"() {
+        given:
+            def context = buildContext('test.Test', """
+package test;
+
+import io.micronaut.serde.annotation.Serdeable;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+@Serdeable
+class Test {
+    private String value;
+
+    private boolean ignored;
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setIgnored(boolean b) {
+        this.ignored = b;
+    }
+
+    @JsonIgnore
+    public boolean isIgnored() {
+        return ignored;
+    }
+}
+""", [value: 'test'])
+        when:
+            def bytes = xmlMapper.writeValueAsBytes(beanUnderTest)
+
+        then:
+            new String(bytes) == '<Test><value>test</value></Test>'
+
+        cleanup:
+            context.close()
+
+    }
+
+}

--- a/serde-xml/src/test/groovy/io/micronaut/serde/xml/XmlCompileSpec.groovy
+++ b/serde-xml/src/test/groovy/io/micronaut/serde/xml/XmlCompileSpec.groovy
@@ -1,0 +1,79 @@
+package io.micronaut.serde.xml
+
+import io.micronaut.annotation.processing.test.AbstractTypeElementSpec
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.beans.BeanIntrospection
+import io.micronaut.core.beans.exceptions.IntrospectionException
+import io.micronaut.core.naming.NameUtils
+import io.micronaut.core.type.Argument
+import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.serde.ObjectMapper
+import io.micronaut.serde.SerdeIntrospections
+import org.intellij.lang.annotations.Language
+import org.jspecify.annotations.NonNull
+
+class XmlCompileSpec extends AbstractTypeElementSpec implements XmlSpec {
+
+    XmlObjectMapper xmlMapper
+    Object beanUnderTest
+    Argument<?> typeUnderTest
+
+    ApplicationContext buildContext(String className, @Language("java") String source, Map<String, Object> properties) {
+        ApplicationContext context = buildContext(className, source, true)
+
+        setupSerdeRegistry(context)
+        xmlMapper = context.getBean(ObjectMapper, Qualifiers.byName("xml"))
+
+        def t = context.classLoader.loadClass(className)
+        typeUnderTest = Argument.of(t)
+        beanUnderTest = t.newInstance(properties)
+        return context
+    }
+
+    Object newInstance(ApplicationContext context, String name, Map args) {
+        return context.classLoader.loadClass(name).newInstance(args)
+    }
+
+    Object newInstance(ApplicationContext context, String name, Object[] args) {
+        return context.classLoader.loadClass(name).newInstance(args)
+    }
+
+    @Override
+    ApplicationContext buildContext(String className, @Language("java") String source) {
+        ApplicationContext context = buildContext("test.Source" + System.currentTimeMillis(), source, true)
+
+        setupSerdeRegistry(context)
+        // Get the specific XML Mapper
+        xmlMapper = context.getBean(ObjectMapper, Qualifiers.byName("xml"))
+
+        def t = context.classLoader.loadClass(className)
+        typeUnderTest = Argument.of(t)
+        return context
+    }
+
+    protected void setupSerdeRegistry(ApplicationContext context) {
+        def classLoader = context.classLoader
+        context.registerSingleton(SerdeIntrospections, new SerdeIntrospections() {
+
+            @Override
+            def <T> BeanIntrospection<T> getSerializableIntrospection(@NonNull Argument<T> type) {
+                try {
+                    return classLoader.loadClass(NameUtils.getPackageName(type.type.name) + ".\$" + type.type.simpleName + '$Introspection')
+                            .newInstance() as BeanIntrospection<T>
+                } catch (ClassNotFoundException e) {
+                    throw new IntrospectionException("No introspection")
+                }
+            }
+
+            @Override
+            def <T> BeanIntrospection<T> getDeserializableIntrospection(@NonNull Argument<T> type) {
+                try {
+                    return classLoader.loadClass(NameUtils.getPackageName(type.type.name) + ".\$" + type.type.simpleName + '$Introspection')
+                            .newInstance() as BeanIntrospection<T>
+                } catch (ClassNotFoundException e) {
+                    throw new IntrospectionException("No introspection for type $type")
+                }
+            }
+        })
+    }
+}

--- a/serde-xml/src/test/groovy/io/micronaut/serde/xml/XmlCreatorSpec.groovy
+++ b/serde-xml/src/test/groovy/io/micronaut/serde/xml/XmlCreatorSpec.groovy
@@ -1,0 +1,150 @@
+package io.micronaut.serde.xml
+
+import io.micronaut.core.type.Argument
+
+class XmlCreatorSpec extends XmlCompileSpec {
+
+    void "test default constructor 1"() {
+        given:
+            def context = buildContext('test.Test', """
+package test;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+class Test {
+    private final String value1;
+    private final String value2;
+    private final String value3;
+
+    public Test(String value1, String value2) {
+        this(value1, value2, null);
+    }
+
+    public Test(String value1, String value2, String value3) {
+        this.value1 = value1;
+        this.value2 = value2;
+        this.value3 = value3;
+    }
+
+    public String getValue1() {
+        return value1;
+    }
+
+    public String getValue2() {
+        return value2;
+    }
+
+    public String getValue3() {
+        return value3;
+    }
+
+}
+""")
+        when:
+            def obj = xmlMapper.readValue('<Test><value1>A</value1><value2>B</value2><value3>C</value3></Test>'.bytes, Argument.of(typeUnderTest.type))
+        then:
+            obj.getValue1() == "A"
+            obj.getValue2() == "B"
+            !obj.getValue3()
+        cleanup:
+            context.close()
+    }
+
+    void "test default constructor 2"() {
+        given:
+            def context = buildContext('test.Test', """
+package test;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+class Test {
+    private final String value1;
+    private final String value2;
+    private final String value3;
+
+    public Test(String value1, String value2, String value3) {
+        this.value1 = value1;
+        this.value2 = value2;
+        this.value3 = value3;
+    }
+
+    public Test(String value1, String value2) {
+        this(value1, value2, null);
+    }
+
+    public String getValue1() {
+        return value1;
+    }
+
+    public String getValue2() {
+        return value2;
+    }
+
+    public String getValue3() {
+        return value3;
+    }
+
+}
+""")
+        when:
+            def obj = xmlMapper.readValue('<Test><value1>A</value1><value2>B</value2><value3>C</value3></Test>'.bytes, Argument.of(typeUnderTest.type))
+        then:
+            obj.getValue1() == "A"
+            obj.getValue2() == "B"
+            obj.getValue3() == "C"
+        cleanup:
+            context.close()
+    }
+
+    void "test @Creator constructor"() {
+        given:
+            def context = buildContext('test.Test', """
+package test;
+
+import io.micronaut.serde.annotation.Serdeable;
+import io.micronaut.core.annotation.Creator;
+
+@Serdeable
+class Test {
+    private final String value1;
+    private final String value2;
+    private final String value3;
+
+    public Test(String value1, String value2) {
+        this(value1, value2, null);
+    }
+
+    @Creator
+    public Test(String value1, String value2, String value3) {
+        this.value1 = value1;
+        this.value2 = value2;
+        this.value3 = value3;
+    }
+
+    public String getValue1() {
+        return value1;
+    }
+
+    public String getValue2() {
+        return value2;
+    }
+
+    public String getValue3() {
+        return value3;
+    }
+
+}
+""")
+        when:
+            def obj = xmlMapper.readValue('<Test><value1>A</value1><value2>B</value2><value3>C</value3></Test>'.bytes, Argument.of(typeUnderTest.type))
+        then:
+            obj.getValue1() == "A"
+            obj.getValue2() == "B"
+            obj.getValue3() == "C"
+        cleanup:
+            context.close()
+    }
+
+}

--- a/serde-xml/src/test/groovy/io/micronaut/serde/xml/XmlGeneratorEncoderSpec.groovy
+++ b/serde-xml/src/test/groovy/io/micronaut/serde/xml/XmlGeneratorEncoderSpec.groovy
@@ -1,0 +1,42 @@
+package io.micronaut.serde.xml
+
+import io.micronaut.core.type.Argument
+import io.micronaut.serde.LimitingStream
+import spock.lang.Specification
+import tools.jackson.dataformat.xml.XmlFactory
+import tools.jackson.dataformat.xml.XmlMapper
+import tools.jackson.dataformat.xml.ser.ToXmlGenerator
+
+import javax.xml.namespace.QName
+
+class XmlGeneratorEncoderSpec extends Specification {
+
+    def 'currentPath'() {
+        given:
+
+        def encoder = new XmlGeneratorEncoder(new XmlMapper().createGenerator(new ByteArrayOutputStream()), LimitingStream.DEFAULT_LIMITS)
+        // avoiding No element/attribute name specified exception
+        encoder.setNextName(new QName("", "person"));
+
+        when:
+        def outer = encoder.encodeObject(Argument.STRING)
+        outer.encodeKey('foo')
+        outer.encodeString('bar')
+        then:
+        outer.currentPath() == '->foo'
+
+        when:
+        outer.encodeKey('')
+        outer.encodeString('bar')
+        then:
+        outer.currentPath() == '->'
+
+        when:
+        outer.encodeKey('baz')
+        def array = outer.encodeArray(Argument.VOID)
+        array.encodeString('foo')
+        then:
+        array.currentPath() == '->baz->1'
+    }
+
+}

--- a/serde-xml/src/test/groovy/io/micronaut/serde/xml/XmlPropertySpec.groovy
+++ b/serde-xml/src/test/groovy/io/micronaut/serde/xml/XmlPropertySpec.groovy
@@ -1,0 +1,40 @@
+package io.micronaut.serde.xml
+
+import io.micronaut.core.type.Argument
+
+class XmlPropertySpec extends XmlCompileSpec {
+
+    void "test @JacksonXmlProperty on field"() {
+        given:
+            def context = buildContext('test.Test', """
+package test;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@Serdeable
+class Test {
+    @JsonProperty("other")
+    private String value;
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+    public String getValue() {
+        return value;
+    }
+}
+""", [value: 'test'])
+
+        when:
+            def bytes = xmlMapper.writeValueAsBytes(beanUnderTest)
+
+        then:
+            new String(bytes) == '<Test><other>test</other></Test>'
+
+        cleanup:
+            context.close()
+    }
+
+}

--- a/serde-xml/src/test/groovy/io/micronaut/serde/xml/XmlSpec.groovy
+++ b/serde-xml/src/test/groovy/io/micronaut/serde/xml/XmlSpec.groovy
@@ -1,0 +1,57 @@
+package io.micronaut.serde.xml
+
+import io.micronaut.core.type.Argument
+import io.micronaut.json.JsonMapper
+import io.micronaut.serde.DeserializerLocator
+import io.micronaut.serde.ObjectMapper
+import tools.jackson.databind.JsonNode
+import tools.jackson.dataformat.xml.XmlMapper
+
+import java.nio.charset.StandardCharsets
+
+trait XmlSpec {
+
+
+    abstract XmlObjectMapper getXmlMapper()
+
+
+    String writeXml(Object bean) {
+        new String(getXmlMapper().writeValueAsBytes(bean), StandardCharsets.UTF_8)
+    }
+
+    String writeXml(Argument argument, Object bean) {
+        new String(getXmlMapper().writeValueAsBytes(argument, bean), StandardCharsets.UTF_8)
+    }
+
+    /**
+     * Converting JSON string to XML with Jackson's JsonNode.
+     */
+    String xmlString(String json) {
+        JsonNode tree = JACKSON_JSON.readTree(json)
+        return JACKSON_XML.writeValueAsString(tree)
+    }
+
+    byte[] xmlBytes(String xml) {
+        return xml.getBytes(StandardCharsets.UTF_8)
+    }
+
+    boolean XmlMatches(String result, String expected) {
+        result == expected
+    }
+
+    boolean objRepresentationMatches(Object obj, String xml2) {
+        def xml1 = xmlMapper.writeValueAsBytes(obj)
+        def xml1_string = new String(xml1, StandardCharsets.UTF_8)
+        assert xml1_string == xml2
+        xml1_string == xml2
+    }
+
+    def <T> T serializeDeserialize(T obj) {
+        return serializeDeserializeAs(obj, Argument.of(obj.getClass()))
+    }
+
+    def <T> T serializeDeserializeAs(T obj, Argument type) {
+        def output = getXmlMapper().writeValueAsBytes(obj)
+        return getXmlMapper().readValue(output, type) as T
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,7 @@ include("serde-tck")
 include("serde-jackson-tck")
 include("serde-tck-tests")
 include("serde-oracle-jdbc-json")
+include("serde-xml")
 
 include("doc-examples:example-bson-java")
 include("doc-examples:example-groovy")


### PR DESCRIPTION
This PR introduces the `serde-xml` subproject, adding XML serialization and deserialization support to the Micronaut Serialization framework using Jackson's `jackson-dataformat-xml` under the Jackson3.

### What's included

**Core Components**
- **`XmlObjectMapper`** — XML-flavored object mapper built on top of the existing Micronaut Serde infrastructure.
- **`XmlSerdeEncoder`** — Encoder for serializing Micronaut beans to XML, with support for nested/composed objects.
- **`DefaultXmlSerdeDecoder`** — Decoder extending `AbstractStreamDecoder`, for reading XML into Micronaut beans. 
- **`XmlSerdeDecoder`* — Decoder extending `AbstractDecoderPerStructureStreamDecoder`. <-- Not sure is this to use by default.
       
- **`XmlMapper` builder** — Decorated with centralized `XmlFactory.

**Tests**
- JSON-to-XML conversion via `JsonNode`.
- Centralized `XmlFactory` and configuration setup.
- Encoder tests: serializing beans.
- Decoder tests: reading XML back into beans.
- Mapper-level tests: end-to-end XML mapping with overridden methods.

<img width="629" height="417" alt="image" src="https://github.com/user-attachments/assets/bb5e2a08-ef5b-4c61-84ed-2e3005607248" />

