### PR TITLE
Fix NullAway compatibility for generated lazy serde references

### DIFF
--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeSourceGenRecordSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeSourceGenRecordSpec.groovy
@@ -235,6 +235,69 @@ record LargeDispatchRecord(String a, int b, boolean c, long d, double e) {}
         context.close()
     }
 
+
+    void 'test record sourcegen handles nested geometry lists requiring lazy serializer and deserializer fields'() {
+        given:
+        def context = buildContext('test.MultiPoint', '''
+package test;
+
+import io.micronaut.serde.annotation.Serdeable;
+import io.micronaut.core.annotation.Introspected;
+import java.util.List;
+
+@Serdeable
+@Introspected
+public record MultiPoint(List<Point> points) {
+    @Serdeable
+    @Introspected
+    public record Point(double x, double y) {}
+}
+''')
+        Class<?> multiPointType = context.classLoader.loadClass('test.MultiPoint')
+        Class<?> pointType = context.classLoader.loadClass('test.MultiPoint$Point')
+        def introspections = context.getBean(SerdeIntrospections)
+        def metadata = introspections.getSerializableIntrospection(Argument.of(multiPointType)).annotationMetadata
+        String serializerClassName = metadata.stringValue(SerdeConfig, SerdeConfig.SOURCEGEN_SERIALIZER_CLASS).orElse(null)
+        String deserializerClassName = metadata.stringValue(SerdeConfig, SerdeConfig.SOURCEGEN_DESERIALIZER_CLASS).orElse(null)
+        Class<?> serializerClass = context.classLoader.loadClass(serializerClassName)
+        Class<?> deserializerClass = context.classLoader.loadClass(deserializerClassName)
+        Serializer serializer = (Serializer) serializerClass.getDeclaredConstructor().newInstance()
+        Deserializer deserializer = (Deserializer) deserializerClass.getDeclaredConstructor().newInstance()
+        def registry = jsonMapper.serdeRegistry
+        Serializer.EncoderContext encoderContext = registry.newEncoderContext(Object)
+        Deserializer.DecoderContext decoderContext = registry.newDecoderContext(Object)
+        def type = Argument.of(multiPointType)
+        def pointA = pointType.getDeclaredConstructor(double, double).newInstance(1d, 2d)
+        def pointB = pointType.getDeclaredConstructor(double, double).newInstance(3d, 4d)
+        def multiPoint = multiPointType.getDeclaredConstructor(List).newInstance([pointA, pointB])
+        def jsonFactory = new JsonFactory()
+        def output = new ByteArrayOutputStream()
+
+        expect:
+        serializerClass.declaredFields*.name.any { it.startsWith('SERIALIZER_') }
+        deserializerClass.declaredFields*.name.any { it.startsWith('DESERIALIZER_') }
+
+        when:
+        jsonFactory.createGenerator(output).withCloseable { generator ->
+            Encoder encoder = JacksonEncoder.create(generator)
+            serializer.serialize(encoder, encoderContext, type, multiPoint)
+        }
+        String json = output.toString('UTF-8')
+
+        def roundTrip
+        jsonFactory.createParser(json).withCloseable { parser ->
+            Decoder decoder = JacksonDecoder.create(parser, LimitingStream.DEFAULT_LIMITS)
+            roundTrip = deserializer.deserialize(decoder, decoderContext, type)
+        }
+
+        then:
+        json == '{"points":[{"x":1.0,"y":2.0},{"x":3.0,"y":4.0}]}'
+        invokeDeclared(roundTrip, 'points').toString() == '[Point[x=1.0, y=2.0], Point[x=3.0, y=4.0]]'
+
+        cleanup:
+        context.close()
+    }
+
     private Object buildDeserializer(def context, Class<?> recordType) {
         def introspections = context.getBean(SerdeIntrospections)
         def metadata = introspections.getSerializableIntrospection(Argument.of(recordType)).annotationMetadata

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanDeserializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanDeserializerSourceGen.java
@@ -32,6 +32,7 @@ import io.micronaut.sourcegen.model.MethodDef;
 import io.micronaut.sourcegen.model.StatementDef;
 import io.micronaut.sourcegen.model.TypeDef;
 import io.micronaut.sourcegen.model.VariableDef;
+import org.jspecify.annotations.Nullable;
 
 import javax.lang.model.element.Modifier;
 import javax.annotation.processing.Generated;
@@ -51,6 +52,7 @@ public final class BeanDeserializerSourceGen {
 
     private static final TypeDef ARGUMENT_TYPE = TypeDef.of(Argument.class);
     private static final TypeDef DESERIALIZER_TYPE = TypeDef.of(Deserializer.class);
+    private static final TypeDef NULLABLE_DESERIALIZER_TYPE = DESERIALIZER_TYPE.annotated(AnnotationDef.builder(Nullable.class).build());
     private static final TypeDef STRING_TYPE = TypeDef.of(String.class);
     private static final String CONTEXT_PARAMETER = "context";
     private static final String VALUE_LOCAL_PREFIX = "value";
@@ -136,6 +138,7 @@ public final class BeanDeserializerSourceGen {
                 deserializerFieldNames.put(property.name(), deserializerFieldName);
                 fields.add(FieldDef.builder(deserializerFieldName, DESERIALIZER_TYPE)
                     .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+                    .addAnnotation(Nullable.class)
                     .build());
             }
             index++;
@@ -424,8 +427,10 @@ public final class BeanDeserializerSourceGen {
             deserializeAndAssign = deserializedValueDef;
         } else {
             String deserializerFieldName = deserializerFieldNames.get(property.name());
-            StatementDef.DefineAndAssign deserializerDef = aThis.field(deserializerFieldName, DESERIALIZER_TYPE)
-                .newLocal(BeanSerdeSourceGenUtils.localName("deserializer", property.name(), index));
+            StatementDef.DefineAndAssign deserializerDef = new StatementDef.DefineAndAssign(
+                new VariableDef.Local(BeanSerdeSourceGenUtils.localName("deserializer", property.name(), index), NULLABLE_DESERIALIZER_TYPE),
+                aThis.field(deserializerFieldName, DESERIALIZER_TYPE)
+            );
             StatementDef initializeDeserializerStatement = deserializerDef.variable().isNull().ifTrue(
                 deserializerDef.variable().assign(context.invoke(FIND_DESERIALIZER_METHOD, argumentExpression).invoke(CREATE_SPECIFIC_DESERIALIZER_METHOD, context, argumentExpression))
             );

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanSerializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanSerializerSourceGen.java
@@ -33,6 +33,7 @@ import io.micronaut.sourcegen.model.MethodDef;
 import io.micronaut.sourcegen.model.StatementDef;
 import io.micronaut.sourcegen.model.TypeDef;
 import io.micronaut.sourcegen.model.VariableDef;
+import org.jspecify.annotations.Nullable;
 
 import javax.lang.model.element.Modifier;
 import javax.annotation.processing.Generated;
@@ -55,6 +56,7 @@ public final class BeanSerializerSourceGen {
 
     private static final TypeDef ARGUMENT_TYPE = TypeDef.of(Argument.class);
     private static final TypeDef SERIALIZER_TYPE = TypeDef.of(Serializer.class);
+    private static final TypeDef NULLABLE_SERIALIZER_TYPE = SERIALIZER_TYPE.annotated(AnnotationDef.builder(Nullable.class).build());
     private static final TypeDef STRING_TYPE = TypeDef.of(String.class);
 
     private static final Method SERIALIZE_METHOD = ReflectionUtils.getRequiredMethod(
@@ -124,6 +126,7 @@ public final class BeanSerializerSourceGen {
                 serializerFieldNames.put(property.name(), serializerFieldName);
                 fields.add(FieldDef.builder(serializerFieldName, SERIALIZER_TYPE)
                     .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+                    .addAnnotation(Nullable.class)
                     .build());
             }
             index++;
@@ -318,8 +321,10 @@ public final class BeanSerializerSourceGen {
             return wrapWithPropertyPath(scalarStatement, type, property.name(), argumentExpression);
         }
         String serializerFieldName = serializerFieldNames.get(property.name());
-        StatementDef.DefineAndAssign serializerDef = aThis.field(serializerFieldName, SERIALIZER_TYPE)
-            .newLocal(BeanSerdeSourceGenUtils.localName("serializer", property.name(), index));
+        StatementDef.DefineAndAssign serializerDef = new StatementDef.DefineAndAssign(
+            new VariableDef.Local(BeanSerdeSourceGenUtils.localName("serializer", property.name(), index), NULLABLE_SERIALIZER_TYPE),
+            aThis.field(serializerFieldName, SERIALIZER_TYPE)
+        );
         StatementDef initializeSerializerStatement = serializerDef.variable().isNull().ifTrue(
             serializerDef.variable().assign(context.invoke(FIND_SERIALIZER_METHOD, argumentExpression).invoke(CREATE_SPECIFIC_SERIALIZER_METHOD, context, argumentExpression))
         );


### PR DESCRIPTION
## Summary
- add a regression test covering nested lazy serializer/deserializer generation with a `MultiPoint` / `Point` record shape
- mark generated lazy serializer/deserializer fields as nullable
- emit nullable local types for lazy serializer/deserializer references so generated code is compatible with NullAway under `@NullMarked`
- Fixes #1274


## Verification
- `./gradlew :micronaut-serde-processor:compileJava :micronaut-serde-jackson:compileTestJava :micronaut-serde-jackson:compileTestGroovy`
- `./gradlew :micronaut-serde-jackson:test --tests 'io.micronaut.serde.jackson.annotation.SerdeSourceGenRecordSpec'`
- `./gradlew :micronaut-serde-jackson:test --tests 'io.micronaut.serde.jackson.annotation.SerdeSourceGenBeanSpec'`
