### PR TITLE
fix: prevent Serializer<List<Foo>> from matching unrelated collection types

### DIFF
--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeJsonSerializeDeserializeSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeJsonSerializeDeserializeSpec.groovy
@@ -168,4 +168,70 @@ class ListSomethingDeserializer implements Deserializer<List<Something>> {
         cleanup:
             context.close()
     }
+
+    // Test for https://github.com/micronaut-projects/micronaut-serialization/issues/1187
+    void 'test json serialize a custom container'() {
+        given:
+            def context = buildContext('test.SomeModel', """
+package test;
+
+import java.io.IOException;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.Serializer;
+import io.micronaut.serde.annotation.Serdeable;
+import jakarta.inject.Singleton;
+import java.util.List;
+import java.util.stream.Collectors;
+
+record Something(String s) {}
+
+@Serdeable
+record SomeModel(List<Something> specificList, List<String> genericList) {}
+
+@Singleton
+class ListSomethingDeserializer implements Deserializer<List<Something>> {
+    @Override
+    public @Nullable List<Something> deserialize(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super List<Something>> type) throws IOException {
+        var stringValue = decoder.decodeString();
+        return java.util.Arrays.stream(stringValue.split("\\\\|"))
+            .map(Something::new)
+            .toList();
+    }
+}
+
+@Singleton
+class ListSomethingSerializer implements Serializer<List<Something>> {
+    @Override
+    public void serialize(@NonNull Encoder encoder, @NonNull EncoderContext context, @NonNull Argument<? extends List<Something>> type, @NonNull List<Something> value) throws IOException {
+        encoder.encodeString(value.stream().map(Something::s).collect(Collectors.joining("|")));
+    }
+}
+""")
+
+        when:
+            def json = '{"specificList":"a|b|c","genericList":["a","b","c"]}'
+            def SomeModel = context.getClassLoader().loadClass("test.SomeModel")
+            def result = jsonMapper.readValue(json, SomeModel)
+        then:
+            result != null
+
+        when:
+            def serialized = writeJson(jsonMapper, result)
+        then:
+            serialized == json
+
+        when:
+            // Serialize a plain List<String> - must NOT use ListSomethingSerializer
+            def strings = jsonMapper.writeValueAsString(List.of("a", "b", "c"))
+        then:
+            strings == '["a","b","c"]'
+
+        cleanup:
+            context.close()
+    }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeRegistry.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeRegistry.java
@@ -365,7 +365,49 @@ public class DefaultSerdeRegistry implements SerdeRegistry {
         Argument<?> type,
         Collection<BeanDefinition<Serializer>> candidates) throws SerdeException {
 
+        // When multiple serializers match, prefer the one whose type argument most closely matches.
+        // If the type has no type parameters (raw collection), prefer candidates with type-variable
+        // type arguments (more generic) over candidates with concrete type arguments.
+        // This prevents a user-defined Serializer<List<Foo>> from being used for raw/unparameterized
+        // collection types like the result of List.of(...).
+        // See https://github.com/micronaut-projects/micronaut-serialization/issues/1187
+        if (type.getTypeParameters().length == 0) {
+            List<BeanDefinition<Serializer>> genericCandidates = candidates.stream()
+                .filter(candidate -> {
+                    List<Argument<?>> typeArgs = candidate.getTypeArguments(Serializer.class);
+                    if (typeArgs.isEmpty()) {
+                        return false;
+                    }
+                    Argument<?> candidateArg = typeArgs.get(0);
+                    // A candidate is "generic" if its type argument has no concrete type parameters
+                    // (i.e. all type parameters are type variables or the candidate has no type params)
+                    return hasOnlyTypeVariableParameters(candidateArg);
+                })
+                .toList();
+            if (!genericCandidates.isEmpty() && genericCandidates.size() < candidates.size()) {
+                candidates = genericCandidates;
+            }
+        }
+
         return lastChanceResolve(type, candidates, "serializers");
+    }
+
+    /**
+     * Returns true if the given argument has only type-variable parameters (no concrete types in its type parameters).
+     * This is used to detect "generic" serializers like {@code Serializer<List<E>>} vs specific ones like
+     * {@code Serializer<List<String>>}.
+     */
+    private static boolean hasOnlyTypeVariableParameters(Argument<?> argument) {
+        Argument<?>[] typeParameters = argument.getTypeParameters();
+        if (typeParameters.length == 0) {
+            return true;
+        }
+        for (Argument<?> typeParameter : typeParameters) {
+            if (!typeParameter.isTypeVariable()) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private BeanDefinition<Deserializer> lastChanceResolveDeserializer(

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/CoreSerializers.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/CoreSerializers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,13 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.serde.config.SerializationConfiguration;
 import io.micronaut.serde.support.SerializerRegistrar;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.TreeSet;
 import java.util.function.Consumer;
 
 /**
@@ -33,6 +40,18 @@ public final class CoreSerializers {
         consumer.accept(new OptionalMultiValuesSerializer<>(serializationConfiguration));
         consumer.accept(new OptionalValuesSerializer<>());
         consumer.accept(new StreamSerializer<>());
+
+        // Register specific collection serializers so that a user-defined
+        // Serializer<List<Foo>> does not accidentally match List<Bar> or other unrelated
+        // collection types (e.g. raw/unparameterized list types).
+        // See https://github.com/micronaut-projects/micronaut-serialization/issues/1187
+        consumer.accept(new SpecificOnlyCollectionSerializer<Object, ArrayList<Object>>(ArrayList.class) { });
+        consumer.accept(new SpecificOnlyCollectionSerializer<Object, LinkedList<Object>>(LinkedList.class) { });
+        consumer.accept(new SpecificOnlyCollectionSerializer<Object, HashSet<Object>>(HashSet.class) { });
+        consumer.accept(new SpecificOnlyCollectionSerializer<Object, LinkedHashSet<Object>>(LinkedHashSet.class) { });
+        consumer.accept(new SpecificOnlyCollectionSerializer<Object, TreeSet<Object>>(TreeSet.class) { });
+        consumer.accept(new SpecificOnlyCollectionSerializer<Object, List<Object>>(List.class) { });
+        consumer.accept(new SpecificOnlyCollectionSerializer<Object, Collection<Object>>(Collection.class) { });
     }
 
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/SpecificOnlyCollectionSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/SpecificOnlyCollectionSerializer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serializers;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Serializer;
+import io.micronaut.serde.exceptions.SerdeException;
+import io.micronaut.serde.support.SerializerRegistrar;
+import io.micronaut.serde.util.CustomizableSerializer;
+
+import java.util.Collection;
+
+import static io.micronaut.serde.support.util.SerdeArgumentConf.reconstructGenericWithParentMetadata;
+
+/**
+ * A base class for specific collection serializers that register with a type-variable argument.
+ * This ensures that user-defined {@code Serializer<List<SomeSpecificType>>} beans do not
+ * accidentally match when serializing other generic lists (e.g. {@code List<String>}).
+ *
+ * @param <E> The element type
+ * @param <C> The collection type
+ * @see <a href="https://github.com/micronaut-projects/micronaut-serialization/issues/1187">Issue #1187</a>
+ */
+@Internal
+abstract class SpecificOnlyCollectionSerializer<E, C extends Collection<E>>
+        implements CustomizableSerializer<C>, SerializerRegistrar<C> {
+
+    private final Class<? extends Collection> type;
+
+    SpecificOnlyCollectionSerializer(Class<? extends Collection> type) {
+        this.type = type;
+    }
+
+    @Override
+    public Serializer<C> createSpecific(EncoderContext context, Argument<? extends C> type) throws SerdeException {
+        final Argument<?>[] generics = type.getTypeParameters();
+        if (generics.length > 0) {
+            @SuppressWarnings("unchecked") final Argument<E> generic = reconstructGenericWithParentMetadata(type, (Argument<E>) generics[0]);
+            if (generic.getType() == String.class) {
+                return (Serializer) StringIterableSerializer.INSTANCE;
+            }
+            Serializer<? super E> componentSerializer = context.findSerializer(generic).createSpecific(context, generic);
+            return (Serializer) new CustomizedIterableSerializer<>(generic, componentSerializer);
+        }
+        return (Serializer) new RuntimeValueIterableSerializer<>();
+    }
+
+    @Override
+    public Argument<C> getType() {
+        return (Argument) Argument.of(type, Argument.ofTypeVariable(Object.class, "E"));
+    }
+}


### PR DESCRIPTION
## What
- add `SpecificOnlyCollectionSerializer` for generic collection serializer registration
- register specific collection serializers in `CoreSerializers`
- prefer generic serializer candidates for raw/unparameterized collection types in `DefaultSerdeRegistry`
- add regression coverage for issue #1187

## Why
A user-defined `Serializer<List<Something>>` could be incorrectly selected when serializing unrelated raw collection instances, such as the result of `List.of(...)`, causing a `ClassCastException`.

## Verification
- added failing regression test first, then fixed implementation
- `./gradlew :micronaut-serde-jackson:test --tests "io.micronaut.serde.jackson.annotation.SerdeJsonSerializeDeserializeSpec.test json serialize a custom container" -q`
- `./gradlew check -x japiCmp -x checkVersionCatalogCompatibility`
- `./gradlew spotlessCheck`

Fixes #1187
