### PR TITLE
Fix missing deserializer NPE on retry

### DIFF
--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBean.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBean.java
@@ -467,9 +467,12 @@ final class DeserBean<T> {
             try {
                 if (!initialized && !initializing) {
                     initializing = true;
-                    initializeInternal(decoderContext);
-                    initialized = true;
-                    initializing = false;
+                    try {
+                        initializeInternal(decoderContext);
+                        initialized = true;
+                    } finally {
+                        initializing = false;
+                    }
                 }
             } finally {
                 lock.unlock();

--- a/serde-support/src/test/java/io/micronaut/serde/support/MissingCustomDeserializerRetryTest.java
+++ b/serde-support/src/test/java/io/micronaut/serde/support/MissingCustomDeserializerRetryTest.java
@@ -1,0 +1,58 @@
+package io.micronaut.serde.support;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.ObjectMapper;
+import io.micronaut.serde.annotation.Serdeable;
+import io.micronaut.serde.exceptions.SerdeException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class MissingCustomDeserializerRetryTest {
+
+    @Test
+    void repeatedAttemptsShouldNotCauseNpeAfterInitializationFailure() {
+        try (ApplicationContext ctx = ApplicationContext.run()) {
+            ObjectMapper objectMapper = ctx.getBean(ObjectMapper.class);
+
+            SerdeException first = Assertions.assertThrows(SerdeException.class,
+                () -> objectMapper.readValue("{\"value\":\"test\"}", BeanWithMissingDeserializer.class));
+            Assertions.assertTrue(first.getMessage().contains("Cannot find deserializer"));
+            Assertions.assertFalse(containsNullPointerException(first));
+
+            SerdeException second = Assertions.assertThrows(SerdeException.class,
+                () -> objectMapper.readValue("{\"value\":\"test\"}", BeanWithMissingDeserializer.class));
+            Assertions.assertTrue(second.getMessage().contains("Cannot find deserializer"));
+            Assertions.assertFalse(containsNullPointerException(second));
+        }
+    }
+
+    private static boolean containsNullPointerException(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof NullPointerException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    @Serdeable
+    @Introspected
+    static class BeanWithMissingDeserializer {
+        @Serdeable.Deserializable(using = MissingStringDeserializer.class)
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    abstract static class MissingStringDeserializer implements io.micronaut.serde.Deserializer<String> {
+    }
+}

--- a/serde-support/src/test/java/io/micronaut/serde/support/MissingCustomDeserializerTest.java
+++ b/serde-support/src/test/java/io/micronaut/serde/support/MissingCustomDeserializerTest.java
@@ -1,0 +1,54 @@
+package io.micronaut.serde.support;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.ObjectMapper;
+import io.micronaut.serde.annotation.Serdeable;
+import io.micronaut.serde.exceptions.SerdeException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class MissingCustomDeserializerTest {
+
+    @Test
+    void missingCustomDeserializerShouldNotCauseNpe() {
+        try (ApplicationContext ctx = ApplicationContext.run()) {
+            ObjectMapper objectMapper = ctx.getBean(ObjectMapper.class);
+
+            SerdeException exception = Assertions.assertThrows(SerdeException.class,
+                () -> objectMapper.readValue("{\"value\":\"test\"}", BeanWithMissingDeserializer.class));
+
+            Assertions.assertTrue(exception.getMessage().contains("Cannot find deserializer"));
+            Assertions.assertFalse(containsNullPointerException(exception));
+        }
+    }
+
+    private static boolean containsNullPointerException(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof NullPointerException) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    @Serdeable
+    @Introspected
+    static class BeanWithMissingDeserializer {
+        @Serdeable.Deserializable(using = MissingStringDeserializer.class)
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    abstract static class MissingStringDeserializer implements io.micronaut.serde.Deserializer<String> {
+    }
+}


### PR DESCRIPTION
## Summary
- reset `DeserBean` initialization state when property deserializer lookup fails
- preserve the original missing deserializer error across repeated deserialization attempts
- add regression tests for both the initial failure and retry path

## Verification
- `./gradlew :micronaut-serde-support:test --tests 'io.micronaut.serde.support.MissingCustomDeserializerTest' --tests 'io.micronaut.serde.support.MissingCustomDeserializerRetryTest'`

Resolves #989
