### PR TITLE
Handle empty form values as null for nullable temporal and enum properties

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ jmh = "1.37"
 lombok = "1.18.44"
 
 micronaut-platform = "4.10.10"
-micronaut = "5.0.0-M17"
+micronaut = "5.0.0-M20"
 micronaut-discovery = "5.0.0-M1"
 micronaut-oracle-cloud = "6.0.0-M1"
 micronaut-reactor = "4.0.0-M1"

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeEmptyStringNullableSerdeSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeEmptyStringNullableSerdeSpec.groovy
@@ -1,0 +1,78 @@
+package io.micronaut.serde.jackson.annotation
+
+class SerdeEmptyStringNullableSerdeSpec extends SerdeJsonEnumSpec {
+
+    void 'test nullable temporal empty string deserializes to null'() {
+        given:
+            def context = buildContext('''
+package test;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
+import java.time.LocalDateTime;
+
+@Serdeable
+class NullableTemporalHolder {
+    @Nullable
+    LocalDateTime publishedAt;
+}
+''')
+
+        when:
+            def nullableResult = jsonMapper.readValue('{"publishedAt":""}', argumentOf(context, 'test.NullableTemporalHolder'))
+
+        then:
+            nullableResult.publishedAt == null
+
+        cleanup:
+            context.close()
+    }
+
+    void 'test nullable enum creator empty string deserializes to null'() {
+        given:
+            def context = buildContext('''
+package test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.Arrays;
+import java.util.Objects;
+
+@Serdeable
+class Test {
+    @Nullable
+    MyEnum value;
+}
+
+@Serdeable
+enum MyEnum {
+    VALUE1("value_1"),
+    VALUE2("value_2");
+
+    private final String value;
+
+    MyEnum(String value) {
+        this.value = value;
+    }
+
+    @JsonCreator
+    public static MyEnum create(String value) {
+        return Arrays.stream(values())
+            .filter(val -> Objects.equals(val.value, value))
+            .findFirst()
+            .orElse(null);
+    }
+}
+''')
+
+        when:
+            def result = jsonMapper.readValue('{"value":""}', argumentOf(context, 'test.Test'))
+
+        then:
+            result.value == null
+
+        cleanup:
+            context.close()
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/DefaultFormattedTemporalSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/DefaultFormattedTemporalSerde.java
@@ -98,6 +98,9 @@ public abstract class DefaultFormattedTemporalSerde<T extends TemporalAccessor> 
     @Override
     public final T deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super T> type) throws IOException {
         String text = decoder.decodeString();
+        if (text.isEmpty() && type.isNullable()) {
+            return null;
+        }
         try {
             return stringFormatter.parse(text, query());
         } catch (DateTimeException e) {

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/EnumSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/EnumSerde.java
@@ -264,6 +264,9 @@ final class EnumCreatorDeserializer<E extends Enum<E>> implements Deserializer<E
         if (!allowNull && v == null) {
             return null;
         }
+        if (v instanceof String s && s.isEmpty() && allowNull) {
+            return null;
+        }
         return transform(v);
     }
 }
@@ -315,10 +318,10 @@ final class EnumValueDeserializer<E extends Enum<E>> implements Deserializer<E> 
     @Override
     public E deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super E> type) throws IOException {
         Object v = valueDeserializer.deserializeNullable(decoder, context, valueType);
-        if (v instanceof String s && s.isEmpty() && type.isNullable()) {
+        if (!allowNull && v == null) {
             return null;
         }
-        if (!allowNull && v == null) {
+        if (v instanceof String s && s.isEmpty() && type.isNullable() && !cache.containsKey("")) {
             return null;
         }
         return transform(decoder, v);
@@ -354,10 +357,13 @@ final class EnumPropertyDeserializer<E extends Enum<E>> implements Deserializer<
     @Override
     public E deserialize(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super E> type) throws IOException {
         String value = decoder.decodeString();
+        E result = cache.get(value);
+        if (result != null) {
+            return result;
+        }
         if (value.isEmpty() && nullable) {
             return null;
         }
-        E result = cache.get(value);
         if (result != null) {
             return result;
         }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/EnumSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/EnumSerde.java
@@ -101,7 +101,8 @@ final class EnumSerde<E extends Enum<E>> implements CustomizableDeserializer<E>,
                 }
                 return new EnumPropertyDeserializer<>(
                     cache,
-                    acceptCaseInsensitive
+                    acceptCaseInsensitive,
+                    type.isNullable()
                 );
             }
             return createEnumCreatorDeserializer(context, deserializableIntrospection);
@@ -119,7 +120,8 @@ final class EnumSerde<E extends Enum<E>> implements CustomizableDeserializer<E>,
         }
         return new EnumPropertyDeserializer<>(
             cache,
-            acceptCaseInsensitive
+            acceptCaseInsensitive,
+            type.isNullable()
         );
     }
 
@@ -313,6 +315,9 @@ final class EnumValueDeserializer<E extends Enum<E>> implements Deserializer<E> 
     @Override
     public E deserializeNullable(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super E> type) throws IOException {
         Object v = valueDeserializer.deserializeNullable(decoder, context, valueType);
+        if (v instanceof String s && s.isEmpty() && type.isNullable()) {
+            return null;
+        }
         if (!allowNull && v == null) {
             return null;
         }
@@ -338,15 +343,20 @@ final class EnumPropertyDeserializer<E extends Enum<E>> implements Deserializer<
 
     private final Map<String, E> cache;
     private final boolean acceptCaseInsensitive;
+    private final boolean nullable;
 
-    EnumPropertyDeserializer(Map<String, E> cache, boolean acceptCaseInsensitive) {
+    EnumPropertyDeserializer(Map<String, E> cache, boolean acceptCaseInsensitive, boolean nullable) {
         this.cache = cache;
         this.acceptCaseInsensitive = acceptCaseInsensitive;
+        this.nullable = nullable;
     }
 
     @Override
     public E deserialize(@NonNull Decoder decoder, @NonNull DecoderContext context, @NonNull Argument<? super E> type) throws IOException {
         String value = decoder.decodeString();
+        if (value.isEmpty() && nullable) {
+            return null;
+        }
         E result = cache.get(value);
         if (result != null) {
             return result;


### PR DESCRIPTION
## What changed

This change fixes HTTP server TCK failures caused by empty form-urlencoded values being deserialized incorrectly for nullable properties when running Micronaut core TCK tests against Micronaut Serialization.

### Fixes

- Treat empty strings as `null` for nullable temporal properties in `DefaultFormattedTemporalSerde`
- Treat empty strings as `null` for nullable enum properties in `EnumSerde`

## Why

`FormsJacksonAnnotationsTest` expects form submissions like these to bind successfully:

- `publishedAt=` where `publishedAt` is a nullable `LocalDateTime`
- `category=` where `category` is a nullable enum

Before this change:

- empty temporal values were parsed and failed with `DateTimeException`
- empty enum values were treated as invalid enum constants

After this change:

- nullable temporal and enum properties bind as `null` for empty form values
- the TCK expectation is restored

## Validation

- `:test-suite-http-server-tck-netty:test` passes when run against a locally published Micronaut core containing the upstream HEAD proxy fix
- `FormsJacksonAnnotationsTest` is resolved on the serialization side

## Notes

The remaining `FilterProxyTest` failure was traced to upstream `micronaut-core` HEAD response handling and is addressed separately in a core change. https://github.com/micronaut-projects/micronaut-core/pull/12607
