### PR TITLE
Fix @SerdeImport on test classes for @MappedEntity

### DIFF
--- a/doc-examples/example-java/build.gradle.kts
+++ b/doc-examples/example-java/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
 
     implementation(projects.micronautSerdeJackson)
     implementation(mn.micronaut.http.client)
+    implementation("io.micronaut.data:micronaut-data-model")
     implementation(libs.oci.aidocument)
 
     runtimeOnly(mnLogging.logback.classic)

--- a/doc-examples/example-java/src/main/java/example/ImportedMappedEntity.java
+++ b/doc-examples/example-java/src/main/java/example/ImportedMappedEntity.java
@@ -1,0 +1,22 @@
+package example;
+
+import io.micronaut.data.annotation.MappedEntity;
+
+@MappedEntity
+public class ImportedMappedEntity {
+    private final Long id;
+    private final String name;
+
+    public ImportedMappedEntity(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/doc-examples/example-java/src/main/java/example/ImportedPojo.java
+++ b/doc-examples/example-java/src/main/java/example/ImportedPojo.java
@@ -1,0 +1,19 @@
+package example;
+
+public class ImportedPojo {
+    private final Long id;
+    private final String name;
+
+    public ImportedPojo(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/doc-examples/example-java/src/test/java/example/MappedEntitySerdeImportTest.java
+++ b/doc-examples/example-java/src/test/java/example/MappedEntitySerdeImportTest.java
@@ -1,0 +1,40 @@
+package example;
+
+import io.micronaut.serde.ObjectMapper;
+import io.micronaut.serde.annotation.SerdeImport;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MicronautTest
+@SerdeImport(ImportedPojo.class)
+@SerdeImport(ImportedMappedEntity.class)
+class MappedEntitySerdeImportTest {
+
+    @Test
+    void testSerdeImportOnTestClassSupportsPlainPojo(ObjectMapper objectMapper) throws IOException {
+        String json = objectMapper.writeValueAsString(new ImportedPojo(1L, "plain"));
+        assertEquals(
+            "{\"id\":1,\"name\":\"plain\"}",
+            json
+        );
+        ImportedPojo read = objectMapper.readValue(json, ImportedPojo.class);
+        assertEquals(1L, read.getId());
+        assertEquals("plain", read.getName());
+    }
+
+    @Test
+    void testSerdeImportOnTestClassSupportsMappedEntity(ObjectMapper objectMapper) throws IOException {
+        String json = objectMapper.writeValueAsString(new ImportedMappedEntity(1L, "mapped"));
+        assertEquals(
+            "{\"id\":1,\"name\":\"mapped\"}",
+            json
+        );
+        ImportedMappedEntity read = objectMapper.readValue(json, ImportedMappedEntity.class);
+        assertEquals(1L, read.getId());
+        assertEquals("mapped", read.getName());
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeIntrospections.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/DefaultSerdeIntrospections.java
@@ -17,6 +17,7 @@ package io.micronaut.serde.support;
 
 import io.micronaut.context.annotation.BootstrapContextCompatible;
 import io.micronaut.context.annotation.DefaultImplementation;
+import io.micronaut.context.BeanDefinitionRegistry;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.AnnotationMetadataProvider;
 import io.micronaut.core.annotation.AnnotationValue;
@@ -56,15 +57,19 @@ import java.util.stream.Collectors;
 public class DefaultSerdeIntrospections implements SerdeIntrospections {
 
     private final Set<String> serdePackages;
+    private final BeanDefinitionRegistry beanDefinitionRegistry;
 
     @Inject
-    public DefaultSerdeIntrospections(SerdeConfiguration configuration) {
+    public DefaultSerdeIntrospections(SerdeConfiguration configuration,
+                                      BeanDefinitionRegistry beanDefinitionRegistry) {
         final List<String> introspectionPackages = configuration.getIncludedIntrospectionPackages();
         this.serdePackages = new HashSet<>(introspectionPackages);
+        this.beanDefinitionRegistry = beanDefinitionRegistry;
     }
 
     public DefaultSerdeIntrospections() {
         this.serdePackages = Collections.singleton("io.micronaut");
+        this.beanDefinitionRegistry = null;
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -104,6 +109,9 @@ public class DefaultSerdeIntrospections implements SerdeIntrospections {
                     result = (BeanIntrospection<T>) OrderUtil.sort(candidates.stream()).findFirst().orElse(null);
                 }
             }
+        }
+        if (result == null && introspection.isPresent() && isImportedForSerialization(type)) {
+            result = introspection.get();
         }
         if (result != null) {
             return resolveIntrospectionForSerialization(type, result);
@@ -168,7 +176,7 @@ public class DefaultSerdeIntrospections implements SerdeIntrospections {
      * @param <T> The generic type
      */
     protected @NonNull <T> BeanIntrospection<T> resolveIntrospectionForDeserialization(@NonNull Argument<T> type, @NonNull BeanIntrospection<T> introspection) {
-        if (isEnabledForDeserialization(introspection, type)) {
+        if (isEnabledForDeserialization(introspection, type) || isImportedForDeserialization(type)) {
             final AnnotationMetadata declaredMetadata = introspection.getDeclaredMetadata();
             final AnnotationValue<SerdeConfig> serdeConfig = declaredMetadata.getDeclaredAnnotation(SerdeConfig.class);
             Class<?> deserializeType = resolveDeserAsType(
@@ -239,6 +247,25 @@ public class DefaultSerdeIntrospections implements SerdeIntrospections {
     private <T extends Annotation> boolean isMixinEnabledForSerialization(List<AnnotationValue<T>> mixinsValues,
                                                                           Argument<?> type) {
         return isEnabledForMixin(mixinsValues, type, "serializable");
+    }
+
+    private boolean isImportedForDeserialization(Argument<?> type) {
+        return isImported(type, "deserializable");
+    }
+
+    private boolean isImportedForSerialization(Argument<?> type) {
+        return isImported(type, "serializable");
+    }
+
+    private boolean isImported(Argument<?> type, String member) {
+        if (beanDefinitionRegistry == null) {
+            return false;
+        }
+        return beanDefinitionRegistry.getBeanDefinitionReferences().stream().anyMatch(reference -> {
+            AnnotationMetadata annotationMetadata = reference.getAnnotationMetadata();
+            return annotationMetadata.hasAnnotation(SerdeImport.class) &&
+                isEnabledForMixin(annotationMetadata.getAnnotationValuesByType(SerdeImport.class), type, member);
+        });
     }
 
     private <T extends Annotation> Boolean isEnabledForMixin(List<AnnotationValue<T>> mixinsValues,


### PR DESCRIPTION
## Summary
- add a reproducer in the Java doc example showing that `@SerdeImport` on a `@MicronautTest` class works for a plain POJO but fails for an already-introspected `@MappedEntity`
- treat matching `@SerdeImport` bean definitions as enabling serde for existing bean introspections so test-scope imports work for `@MappedEntity`
- cover both serialization and deserialization in the new test

## Verification
- `~/.gradle/wrapper/dists/gradle-9.4.1-bin/arn2x92ynaizyzdaamcbpbhtj/gradle-9.4.1/bin/gradle :micronaut-doc-examples:micronaut-example-java:test --tests example.MappedEntitySerdeImportTest`
- `~/.gradle/wrapper/dists/gradle-9.4.1-bin/arn2x92ynaizyzdaamcbpbhtj/gradle-9.4.1/bin/gradle :micronaut-doc-examples:micronaut-example-java:test`

Resolves #980