### PR TITLE
Fix NullAway compatibility for generated lazy serde references (record serde)

### DIFF
--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordDeserializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordDeserializerSourceGen.java
@@ -43,6 +43,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import jakarta.inject.Singleton;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Generates optimized source deserializers for records.
@@ -135,6 +136,7 @@ public final class RecordDeserializerSourceGen {
                 deserializerFieldNames.put(component.name(), deserializerFieldName);
                 fields.add(FieldDef.builder(deserializerFieldName, DESERIALIZER_TYPE)
                     .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+                    .addAnnotation(Nullable.class)
                     .build());
             }
             index++;

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerializerSourceGen.java
@@ -43,6 +43,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import jakarta.inject.Singleton;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Generates optimized source serializers for records.
@@ -124,6 +125,7 @@ public final class RecordSerializerSourceGen {
                 serializerFieldNames.put(component.name(), serializerFieldName);
                 fields.add(FieldDef.builder(serializerFieldName, SERIALIZER_TYPE)
                     .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+                    .addAnnotation(Nullable.class)
                     .build());
             }
             index++;


### PR DESCRIPTION
The previous [PR](https://github.com/micronaut-projects/micronaut-serialization/pull/1275/files) fixed the issue in `BeanDeserializerSourceGen` and `BeanSerializerSourceGen` but not in `RecordDeserializerSourceGen` and `RecordSerializerSourceGen`