### PR TITLE
Improve and add more tests for compile-time serdes

### DIFF
--- a/benchmarks/src/jmh/java/io/micronaut/serde/SourceGenRoutingBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/serde/SourceGenRoutingBenchmark.java
@@ -6,6 +6,7 @@ import io.micronaut.core.annotation.Introspected;
 import io.micronaut.core.type.Argument;
 import io.micronaut.json.JsonMapper;
 import io.micronaut.serde.annotation.Serdeable;
+import io.micronaut.serde.annotation.SerdeableGenerated;
 import io.micronaut.serde.jackson.JacksonJsonMapper;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -77,7 +78,7 @@ public class SourceGenRoutingBenchmark {
         }
     }
 
-    @Serdeable
+    @SerdeableGenerated
     @Introspected
     public record GeneratedShape(String name, int count) {
     }

--- a/benchmarks/src/jmh/java/io/micronaut/serde/data/InputConstructor.java
+++ b/benchmarks/src/jmh/java/io/micronaut/serde/data/InputConstructor.java
@@ -1,9 +1,11 @@
 package io.micronaut.serde.data;
 
 import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.SerdeableGenerated;
 
 import java.util.List;
 
 @Introspected
+@SerdeableGenerated
 public record InputConstructor(List<String> haystack, String needle) {
 }

--- a/benchmarks/src/jmh/java/io/micronaut/serde/data/InputSetter.java
+++ b/benchmarks/src/jmh/java/io/micronaut/serde/data/InputSetter.java
@@ -1,10 +1,12 @@
 package io.micronaut.serde.data;
 
 import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.SerdeableGenerated;
 
 import java.util.List;
 
 @Introspected
+@SerdeableGenerated
 public class InputSetter {
 
     private List<String> haystack;

--- a/benchmarks/src/jmh/java/io/micronaut/serde/data/IntArrayConstructor.java
+++ b/benchmarks/src/jmh/java/io/micronaut/serde/data/IntArrayConstructor.java
@@ -1,7 +1,9 @@
 package io.micronaut.serde.data;
 
 import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.SerdeableGenerated;
 
 @Introspected
+@SerdeableGenerated
 public record IntArrayConstructor(int[] integers) {
 }

--- a/benchmarks/src/jmh/java/io/micronaut/serde/data/IntConstructor.java
+++ b/benchmarks/src/jmh/java/io/micronaut/serde/data/IntConstructor.java
@@ -1,7 +1,9 @@
 package io.micronaut.serde.data;
 
 import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.SerdeableGenerated;
 
 @Introspected
+@SerdeableGenerated
 public record IntConstructor(int integer) {
 }

--- a/benchmarks/src/jmh/java/io/micronaut/serde/data/IntegerConstructor.java
+++ b/benchmarks/src/jmh/java/io/micronaut/serde/data/IntegerConstructor.java
@@ -1,7 +1,9 @@
 package io.micronaut.serde.data;
 
 import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.SerdeableGenerated;
 
 @Introspected
+@SerdeableGenerated
 public record IntegerConstructor(Integer integer) {
 }

--- a/benchmarks/src/jmh/java/io/micronaut/serde/data/Name.java
+++ b/benchmarks/src/jmh/java/io/micronaut/serde/data/Name.java
@@ -1,7 +1,9 @@
 package io.micronaut.serde.data;
 
 import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.SerdeableGenerated;
 
 @Introspected
+@SerdeableGenerated
 public record Name(String firstName, String lastName) {
 }

--- a/benchmarks/src/jmh/java/io/micronaut/serde/data/SimpleBean.java
+++ b/benchmarks/src/jmh/java/io/micronaut/serde/data/SimpleBean.java
@@ -1,8 +1,8 @@
 package io.micronaut.serde.data;
 
-import io.micronaut.serde.annotation.Serdeable;
+import io.micronaut.serde.annotation.SerdeableGenerated;
 
-@Serdeable
+@SerdeableGenerated
 public class SimpleBean {
 
     private Long id;

--- a/benchmarks/src/jmh/java/io/micronaut/serde/data/StringArrayConstructor.java
+++ b/benchmarks/src/jmh/java/io/micronaut/serde/data/StringArrayConstructor.java
@@ -1,7 +1,9 @@
 package io.micronaut.serde.data;
 
 import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.SerdeableGenerated;
 
 @Introspected
+@SerdeableGenerated
 public record StringArrayConstructor(String[] strs) {
 }

--- a/benchmarks/src/jmh/java/io/micronaut/serde/data/StringConstructor.java
+++ b/benchmarks/src/jmh/java/io/micronaut/serde/data/StringConstructor.java
@@ -1,7 +1,9 @@
 package io.micronaut.serde.data;
 
 import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.SerdeableGenerated;
 
 @Introspected
+@SerdeableGenerated
 public record StringConstructor(String str) {
 }

--- a/serde-api/src/main/java/io/micronaut/serde/annotation/SerdeableGenerated.java
+++ b/serde-api/src/main/java/io/micronaut/serde/annotation/SerdeableGenerated.java
@@ -23,7 +23,22 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * A {@link Serdeable} type that opts into compile-time generated serializers and deserializers.
+ * Declares the compile-time generated serde contract for a {@link Serdeable} type.
+ *
+ * <p>Micronaut Serialization already attempts to generate compile-time serializers and
+ * deserializers for simple eligible {@link Serdeable} shapes without this annotation. A shape is
+ * currently eligible when it is a simple bean, record, or enum whose serialization model can be
+ * represented directly by source generation. Features that require runtime behavior, such as
+ * custom serde classes, custom naming or property mappings, unwrapped or subtyped properties,
+ * any getters/setters, unsupported Jackson annotations, and complex enum or creator handling,
+ * fall back to the runtime introspection serde.</p>
+ *
+ * <p>This annotation is used when the generated serde decision should be explicit. With the
+ * default settings, compilation fails if either the serializer or deserializer cannot be
+ * generated. Set {@link #required()} to {@code false} to allow normal runtime fallback while
+ * still using generated serdes where they are eligible. Use {@link #skip()} to disable both
+ * generated directions, or {@link #skipSerializer()} and {@link #skipDeserializer()} to opt out
+ * of only one direction.</p>
  *
  * @author Denis Stepanov
  * @since 3.0
@@ -35,22 +50,30 @@ import java.lang.annotation.Target;
 public @interface SerdeableGenerated {
 
     /**
-     * @return Whether compilation should fail when a non-skipped serializer or deserializer cannot be generated.
+     * Returns whether compilation should fail when a non-skipped serializer or deserializer cannot be generated.
+     *
+     * @return {@code true} if compilation should fail when generation is not possible
      */
     boolean required() default true;
 
     /**
-     * @return Whether both generated serializer and deserializer should be skipped.
+     * Returns whether both generated directions should be skipped.
+     *
+     * @return {@code true} if both generated serializer and deserializer should be skipped
      */
     boolean skip() default false;
 
     /**
-     * @return Whether the generated serializer should be skipped.
+     * Returns whether the generated serializer should be skipped.
+     *
+     * @return {@code true} if the generated serializer should be skipped
      */
     boolean skipSerializer() default false;
 
     /**
-     * @return Whether the generated deserializer should be skipped.
+     * Returns whether the generated deserializer should be skipped.
+     *
+     * @return {@code true} if the generated deserializer should be skipped
      */
     boolean skipDeserializer() default false;
 }

--- a/serde-api/src/main/java/io/micronaut/serde/annotation/SerdeableGenerated.java
+++ b/serde-api/src/main/java/io/micronaut/serde/annotation/SerdeableGenerated.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.annotation;
+
+import io.micronaut.core.annotation.Experimental;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A {@link Serdeable} type that opts into compile-time generated serializers and deserializers.
+ *
+ * @author Denis Stepanov
+ * @since 3.0
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Serdeable
+@Experimental
+public @interface SerdeableGenerated {
+
+    /**
+     * @return Whether compilation should fail when a non-skipped serializer or deserializer cannot be generated.
+     */
+    boolean required() default true;
+
+    /**
+     * @return Whether both generated serializer and deserializer should be skipped.
+     */
+    boolean skip() default false;
+
+    /**
+     * @return Whether the generated serializer should be skipped.
+     */
+    boolean skipSerializer() default false;
+
+    /**
+     * @return Whether the generated deserializer should be skipped.
+     */
+    boolean skipDeserializer() default false;
+}

--- a/serde-api/src/main/java/io/micronaut/serde/util/GeneratedSerdeExceptionUtil.java
+++ b/serde-api/src/main/java/io/micronaut/serde/util/GeneratedSerdeExceptionUtil.java
@@ -121,6 +121,33 @@ public final class GeneratedSerdeExceptionUtil {
     }
 
     /**
+     * Checks a constructor argument value against strict nullable deserialization.
+     *
+     * @param context The decoder context.
+     * @param value The constructor argument value.
+     * @param beanType The declaring bean argument.
+     * @param propertyName The property name.
+     * @param propertyArgument The property argument.
+     * @throws SerdeException If strict nullable deserialization rejects the value.
+     * @since 3.0
+     */
+    public static void checkStrictNullableConstructorParameter(Deserializer.DecoderContext context,
+                                                              @Nullable Object value,
+                                                              Argument<?> beanType,
+                                                              String propertyName,
+                                                              Argument<?> propertyArgument) throws SerdeException {
+        boolean strictNullable = context.getDeserializationConfiguration()
+            .map(DeserializationConfiguration::isStrictNullable)
+            .orElse(false);
+        if (strictNullable && value == null) {
+            SerdeException serdeException = new SerdeException("Unable to deserialize type [" + beanType.getType().getName() +
+                "]. Non-null constructor parameter [" + propertyArgument + "] is not present or is null in the supplied data");
+            serdeException.getPath().add(ReferencePath.ofProperty(beanType.getType(), propertyArgument.withName(propertyName)));
+            throw serdeException;
+        }
+    }
+
+    /**
      * Appends a property path segment to an existing {@link SerdeException}.
      *
      * @param exception The exception to enrich.

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/JsonCompileSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/JsonCompileSpec.groovy
@@ -97,6 +97,16 @@ class JsonCompileSpec extends AbstractTypeElementSpec implements JsonSpec {
         return new String(jsonMapper.cloneWithViewClass(view).writeValueAsBytes(value), StandardCharsets.UTF_8)
     }
 
+    static String generatedTestSource(String className) {
+        String sourcePath = className.replace('.', File.separator) + ".java"
+        def sourceFile = new File("build/generated/sources/annotationProcessor/java/test", sourcePath)
+        if (!sourceFile.exists()) {
+            sourceFile = new File("serde-jackson/build/generated/sources/annotationProcessor/java/test", sourcePath)
+        }
+        assert sourceFile.exists() : "Generated test source not found: ${sourcePath}"
+        return sourceFile.text
+    }
+
     static <T> T deserializeFromString(JsonMapper jsonMapper, Class<T> type, @Language("json") String json, Class<?> view = Object.class) {
         return jsonMapper.cloneWithViewClass(view).readValue(json, Argument.of(type))
     }

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeSourceGenBeanSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeSourceGenBeanSpec.groovy
@@ -180,18 +180,14 @@ public class ParityBean {
         beanType.getMethod('getTags').invoke(fromSpecificNull).toString() == '[a, b]'
 
         when:
-        def duplicateDefaultFailure = captureFailure {
-            deserializeValue(defaultDeserializer, decoderContext, type, '{"value":"a","value":"b","count":1}')
-        }
-        def duplicateSpecificFailure = captureFailure {
-            deserializeValue(specificDeserializer, decoderContext, type, '{"value":"a","value":"b","count":1}')
-        }
+        def duplicateDefault = deserializeValue(defaultDeserializer, decoderContext, type, '{"value":"a","value":"b","count":1}')
+        def duplicateSpecific = deserializeValue(specificDeserializer, decoderContext, type, '{"value":"a","value":"b","count":1}')
 
         then:
-        duplicateDefaultFailure != null
-        duplicateSpecificFailure != null
-        duplicateDefaultFailure.message?.contains('value')
-        duplicateSpecificFailure.message?.contains('value')
+        beanType.getMethod('getValue').invoke(duplicateDefault) == 'a'
+        beanType.getMethod('getValue').invoke(duplicateSpecific) == 'a'
+        beanType.getMethod('getCount').invoke(duplicateDefault) == 1
+        beanType.getMethod('getCount').invoke(duplicateSpecific) == 1
 
         when:
         def unknownDefaultFailure = captureFailure {
@@ -299,18 +295,18 @@ class LargeDispatchBean {
         invokeDeclared(large, 'getE') == 3.5d
 
         when:
-        def smallDuplicate = captureFailure {
-            deserializeValue(smallDeserializer, decoderContext, smallArgument, '{"a":"x","a":"y","b":7,"c":true}')
-        }
-        def largeDuplicate = captureFailure {
-            deserializeValue(largeDeserializer, decoderContext, largeArgument, '{"a":"x","b":7,"c":true,"d":9,"e":3.5,"e":1.0}')
-        }
+        def smallDuplicate = deserializeValue(smallDeserializer, decoderContext, smallArgument, '{"a":"x","a":"y","b":7,"c":true}')
+        def largeDuplicate = deserializeValue(largeDeserializer, decoderContext, largeArgument, '{"a":"x","b":7,"c":true,"d":9,"e":3.5,"e":1.0}')
 
         then:
-        smallDuplicate instanceof SerdeException
-        largeDuplicate instanceof SerdeException
-        smallDuplicate.message?.contains('a')
-        largeDuplicate.message?.contains('e')
+        invokeDeclared(smallDuplicate, 'getA') == 'x'
+        invokeDeclared(smallDuplicate, 'getB') == 7
+        invokeDeclared(smallDuplicate, 'isC')
+        invokeDeclared(largeDuplicate, 'getA') == 'x'
+        invokeDeclared(largeDuplicate, 'getB') == 7
+        invokeDeclared(largeDuplicate, 'isC')
+        invokeDeclared(largeDuplicate, 'getD') == 9L
+        invokeDeclared(largeDuplicate, 'getE') == 3.5d
 
         cleanup:
         context.close()

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeSourceGenRecordSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeSourceGenRecordSpec.groovy
@@ -127,18 +127,14 @@ public record ParityRecord(String value, int count, java.util.List<String> tags)
         fromSpecificMissing.tags().toString() == '[a, b]'
 
         when:
-        def duplicateDefaultFailure = captureFailure {
-            deserializeValue(defaultDeserializer, decoderContext, type, '{"value":"a","value":"b","count":1}')
-        }
-        def duplicateSpecificFailure = captureFailure {
-            deserializeValue(specificDeserializer, decoderContext, type, '{"value":"a","value":"b","count":1}')
-        }
+        def duplicateDefault = deserializeValue(defaultDeserializer, decoderContext, type, '{"value":"a","value":"b","count":1}')
+        def duplicateSpecific = deserializeValue(specificDeserializer, decoderContext, type, '{"value":"a","value":"b","count":1}')
 
         then:
-        duplicateDefaultFailure != null
-        duplicateSpecificFailure != null
-        duplicateDefaultFailure.message?.contains('value')
-        duplicateSpecificFailure.message?.contains('value')
+        duplicateDefault.value() == 'a'
+        duplicateSpecific.value() == 'a'
+        duplicateDefault.count() == 1
+        duplicateSpecific.count() == 1
 
         when:
         def unknownDefaultFailure = captureFailure {
@@ -218,18 +214,18 @@ record LargeDispatchRecord(String a, int b, boolean c, long d, double e) {}
         invokeDeclared(large, 'e') == 3.5d
 
         when:
-        def smallDuplicate = captureFailure {
-            deserializeValue(smallDeserializer, decoderContext, smallArgument, '{"a":"x","a":"y","b":7,"c":true}')
-        }
-        def largeDuplicate = captureFailure {
-            deserializeValue(largeDeserializer, decoderContext, largeArgument, '{"a":"x","b":7,"c":true,"d":9,"e":3.5,"e":1.0}')
-        }
+        def smallDuplicate = deserializeValue(smallDeserializer, decoderContext, smallArgument, '{"a":"x","a":"y","b":7,"c":true}')
+        def largeDuplicate = deserializeValue(largeDeserializer, decoderContext, largeArgument, '{"a":"x","b":7,"c":true,"d":9,"e":3.5,"e":1.0}')
 
         then:
-        smallDuplicate instanceof SerdeException
-        largeDuplicate instanceof SerdeException
-        smallDuplicate.message?.contains('a')
-        largeDuplicate.message?.contains('e')
+        invokeDeclared(smallDuplicate, 'a') == 'x'
+        invokeDeclared(smallDuplicate, 'b') == 7
+        invokeDeclared(smallDuplicate, 'c')
+        invokeDeclared(largeDuplicate, 'a') == 'x'
+        invokeDeclared(largeDuplicate, 'b') == 7
+        invokeDeclared(largeDuplicate, 'c')
+        invokeDeclared(largeDuplicate, 'd') == 9L
+        invokeDeclared(largeDuplicate, 'e') == 3.5d
 
         cleanup:
         context.close()

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeDeserializerBehaviorSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeDeserializerBehaviorSpec.groovy
@@ -9,12 +9,10 @@ import io.micronaut.serde.jackson.JsonCompileSpec
 
 class CompileTimeDeserializerBehaviorSpec extends JsonCompileSpec {
 
-    void 'test primitive boolean missing constructor properties and nullable values match runtime deserializer'() {
+    void 'test generated record deserializer source handles primitive booleans and missing constructor properties'() {
         given:
         def context = ApplicationContext.run()
-        jsonMapper = context.getBean(JsonMapper)
         Class<?> generatedType = SourceGenGeneratedConstructorDefaults
-        Class<?> runtimeType = SourceGenRuntimeConstructorDefaults
         def introspections = context.getBean(SerdeIntrospections)
         def generatedMetadata = introspections.getDeserializableIntrospection(Argument.of(generatedType)).annotationMetadata
         String deserializerClassName = generatedMetadata.stringValue(SerdeConfig, SerdeConfig.SOURCEGEN_DESERIALIZER_CLASS).orElse(null)
@@ -27,40 +25,173 @@ class CompileTimeDeserializerBehaviorSpec extends JsonCompileSpec {
         !deserializerSource.contains('component0')
         deserializerSource.indexOf('if (!seenProperty') > -1
         deserializerSource.indexOf('if (!seenProperty') < deserializerSource.indexOf('return new io.micronaut.serde.jackson.compiletime.SourceGenGeneratedConstructorDefaults')
-
-        when:
-        def generatedMissingName = jsonMapper.readValue('{"active":true}', Argument.of(generatedType))
-        def runtimeMissingName = jsonMapper.readValue('{"active":true}', Argument.of(runtimeType))
-        def generatedMissingPrimitiveValues = jsonMapper.readValue('{"name":"Ada"}', Argument.of(generatedType))
-        def runtimeMissingPrimitiveValues = jsonMapper.readValue('{"name":"Ada"}', Argument.of(runtimeType))
-        def generatedMissingNullableValues = jsonMapper.readValue('{"name":"Ada","active":true,"count":1}', Argument.of(generatedType))
-        def runtimeMissingNullableValues = jsonMapper.readValue('{"name":"Ada","active":true,"count":1}', Argument.of(runtimeType))
-        def generatedNullValues = jsonMapper.readValue('{"name":null,"active":null,"count":null,"nullableName":null,"nullableActive":null}', Argument.of(generatedType))
-        def runtimeNullValues = jsonMapper.readValue('{"name":null,"active":null,"count":null,"nullableName":null,"nullableActive":null}', Argument.of(runtimeType))
-        def generatedMissingAll = jsonMapper.readValue('{}', Argument.of(generatedType))
-        def runtimeMissingAll = jsonMapper.readValue('{}', Argument.of(runtimeType))
-
-        then:
-        assertPropertiesEqual(generatedMissingName, runtimeMissingName)
-        assertPropertiesEqual(generatedMissingPrimitiveValues, runtimeMissingPrimitiveValues)
-        assertPropertiesEqual(generatedMissingNullableValues, runtimeMissingNullableValues)
-        assertPropertiesEqual(generatedNullValues, runtimeNullValues)
-        assertPropertiesEqual(generatedMissingAll, runtimeMissingAll)
+        !deserializerSource.contains('duplicateProperty')
 
         cleanup:
         context.close()
     }
 
-    private static void assertPropertiesEqual(Object generated, Object runtime) {
-        assert invokeDeclared(generated, 'name') == invokeDeclared(runtime, 'name')
-        assert invokeDeclared(generated, 'active') == invokeDeclared(runtime, 'active')
-        assert invokeDeclared(generated, 'count') == invokeDeclared(runtime, 'count')
-        assert invokeDeclared(generated, 'nullableName') == invokeDeclared(runtime, 'nullableName')
-        assert invokeDeclared(generated, 'nullableActive') == invokeDeclared(runtime, 'nullableActive')
+    void 'test generated bean deserializer source handles primitive booleans without nullable decode'() {
+        given:
+        def context = ApplicationContext.run()
+        Class<?> generatedType = SourceGenGeneratedPropertyDefaults
+        def introspections = context.getBean(SerdeIntrospections)
+        def generatedMetadata = introspections.getDeserializableIntrospection(Argument.of(generatedType)).annotationMetadata
+        String deserializerClassName = generatedMetadata.stringValue(SerdeConfig, SerdeConfig.SOURCEGEN_DESERIALIZER_CLASS).orElse(null)
+        String deserializerSource = generatedTestSource(deserializerClassName)
+
+        expect:
+        deserializerSource.contains('boolean value1 = false;')
+        deserializerSource.contains('value1 = objectDecoder.decodeBoolean();')
+        !deserializerSource.contains('value1 = objectDecoder.decodeBooleanNullable();')
+        !deserializerSource.contains('duplicateProperty')
+
+        cleanup:
+        context.close()
     }
 
-    private static Object invokeDeclared(Object target, String methodName) {
-        def method = target.getClass().getDeclaredMethod(methodName)
+    void 'test generated record deserializer matches runtime for primitive nullable and missing properties'() {
+        given:
+        def context = ApplicationContext.run()
+        jsonMapper = context.getBean(JsonMapper)
+
+        expect:
+        assertReadMatches(jsonMapper, SourceGenGeneratedConstructorDefaults, SourceGenRuntimeConstructorDefaults, json)
+
+        cleanup:
+        context.close()
+
+        where:
+        scenario                    | json
+        'full input'                | '{"name":"Ada","active":true,"count":42,"nullableName":"Grace","nullableActive":false}'
+        'missing reference'         | '{"active":true,"count":42,"nullableName":"Grace","nullableActive":false}'
+        'missing primitives'        | '{"name":"Ada","nullableName":"Grace","nullableActive":false}'
+        'missing nullable values'   | '{"name":"Ada","active":true,"count":42}'
+        'explicit null values'      | '{"name":null,"active":null,"count":null,"nullableName":null,"nullableActive":null}'
+        'missing all values'        | '{}'
+    }
+
+    void 'test generated bean deserializer matches runtime for primitive nullable and missing properties'() {
+        given:
+        def context = ApplicationContext.run()
+        jsonMapper = context.getBean(JsonMapper)
+
+        expect:
+        assertReadMatches(jsonMapper, SourceGenGeneratedPropertyDefaults, SourceGenRuntimePropertyDefaults, json)
+
+        cleanup:
+        context.close()
+
+        where:
+        scenario                    | json
+        'full input'                | '{"name":"Ada","active":false,"count":42,"nullableName":"Grace","nullableActive":false}'
+        'missing reference'         | '{"active":false,"count":42,"nullableName":"Grace","nullableActive":false}'
+        'missing primitives'        | '{"name":"Ada","nullableName":"Grace","nullableActive":false}'
+        'missing nullable values'   | '{"name":"Ada","active":false,"count":42}'
+        'explicit null values'      | '{"name":null,"active":null,"count":null,"nullableName":null,"nullableActive":null}'
+        'missing all values'        | '{}'
+    }
+
+    void 'test generated record duplicate property handling matches runtime deserializer'() {
+        given:
+        def context = ApplicationContext.run()
+        jsonMapper = context.getBean(JsonMapper)
+
+        expect:
+        assertReadMatches(jsonMapper, SourceGenGeneratedConstructorDefaults, SourceGenRuntimeConstructorDefaults, json)
+
+        cleanup:
+        context.close()
+
+        where:
+        scenario                       | json
+        'duplicate reference'          | '{"name":"Ada","name":"Grace","active":true,"count":1}'
+        'reference null first'         | '{"name":null,"name":"Grace","active":true,"count":1}'
+        'duplicate primitive boolean'  | '{"name":"Ada","active":true,"active":false,"count":1}'
+        'primitive boolean null first' | '{"name":"Ada","active":null,"active":true,"count":1}'
+        'duplicate primitive int'      | '{"name":"Ada","active":true,"count":1,"count":2}'
+        'primitive int null first'     | '{"name":"Ada","active":true,"count":null,"count":1}'
+        'primitive boolean null last'  | '{"name":"Ada","active":true,"active":null,"count":1}'
+        'primitive int null last'      | '{"name":"Ada","active":true,"count":1,"count":null}'
+        'duplicate nullable reference' | '{"name":"Ada","active":true,"count":1,"nullableName":"Grace","nullableName":"Lovelace"}'
+        'nullable reference null first' | '{"name":"Ada","active":true,"count":1,"nullableName":null,"nullableName":"Grace"}'
+        'nullable reference null last' | '{"name":"Ada","active":true,"count":1,"nullableName":"Grace","nullableName":null}'
+        'duplicate nullable boolean'   | '{"name":"Ada","active":true,"count":1,"nullableActive":true,"nullableActive":false}'
+        'nullable boolean null first'  | '{"name":"Ada","active":true,"count":1,"nullableActive":null,"nullableActive":true}'
+        'nullable boolean null last'   | '{"name":"Ada","active":true,"count":1,"nullableActive":true,"nullableActive":null}'
+    }
+
+    void 'test generated bean duplicate property handling matches runtime deserializer'() {
+        given:
+        def context = ApplicationContext.run()
+        jsonMapper = context.getBean(JsonMapper)
+
+        expect:
+        assertReadMatches(jsonMapper, SourceGenGeneratedPropertyDefaults, SourceGenRuntimePropertyDefaults, json)
+
+        cleanup:
+        context.close()
+
+        where:
+        scenario                       | json
+        'duplicate reference'          | '{"name":"Ada","name":"Grace","active":true,"count":1}'
+        'reference null first'         | '{"name":null,"name":"Grace","active":true,"count":1}'
+        'duplicate primitive boolean'  | '{"name":"Ada","active":true,"active":false,"count":1}'
+        'primitive boolean null first' | '{"name":"Ada","active":null,"active":true,"count":1}'
+        'duplicate primitive int'      | '{"name":"Ada","active":true,"count":1,"count":2}'
+        'primitive int null first'     | '{"name":"Ada","active":true,"count":null,"count":1}'
+        'primitive boolean null last'  | '{"name":"Ada","active":true,"active":null,"count":1}'
+        'primitive int null last'      | '{"name":"Ada","active":true,"count":1,"count":null}'
+        'duplicate nullable reference' | '{"name":"Ada","active":true,"count":1,"nullableName":"Grace","nullableName":"Lovelace"}'
+        'nullable reference null first' | '{"name":"Ada","active":true,"count":1,"nullableName":null,"nullableName":"Grace"}'
+        'nullable reference null last' | '{"name":"Ada","active":true,"count":1,"nullableName":"Grace","nullableName":null}'
+        'duplicate nullable boolean'   | '{"name":"Ada","active":true,"count":1,"nullableActive":true,"nullableActive":false}'
+        'nullable boolean null first'  | '{"name":"Ada","active":true,"count":1,"nullableActive":null,"nullableActive":true}'
+        'nullable boolean null last'   | '{"name":"Ada","active":true,"count":1,"nullableActive":true,"nullableActive":null}'
+    }
+
+    private static void assertPropertiesEqual(Object generated, Object runtime) {
+        assert propertyValue(generated, 'name') == propertyValue(runtime, 'name')
+        assert propertyValue(generated, 'active') == propertyValue(runtime, 'active')
+        assert propertyValue(generated, 'count') == propertyValue(runtime, 'count')
+        assert propertyValue(generated, 'nullableName') == propertyValue(runtime, 'nullableName')
+        assert propertyValue(generated, 'nullableActive') == propertyValue(runtime, 'nullableActive')
+    }
+
+    private static void assertReadMatches(JsonMapper jsonMapper,
+                                          Class<?> generatedType,
+                                          Class<?> runtimeType,
+                                          String json) {
+        def generated = jsonMapper.readValue(json, Argument.of(generatedType))
+        def runtime = jsonMapper.readValue(json, Argument.of(runtimeType))
+        assertPropertiesEqual(generated, runtime)
+    }
+
+    private static Object propertyValue(Object target, String propertyName) {
+        def recordMethod = findDeclaredMethod(target, propertyName)
+        if (recordMethod != null) {
+            return invoke(recordMethod, target)
+        }
+        def getter = findDeclaredMethod(target, 'get' + propertyName.capitalize())
+        if (getter != null) {
+            return invoke(getter, target)
+        }
+        def booleanGetter = findDeclaredMethod(target, 'is' + propertyName.capitalize())
+        if (booleanGetter != null) {
+            return invoke(booleanGetter, target)
+        }
+        throw new IllegalArgumentException("No readable property '${propertyName}' on ${target.class.name}")
+    }
+
+    private static def findDeclaredMethod(Object target, String methodName) {
+        try {
+            return target.getClass().getDeclaredMethod(methodName)
+        } catch (NoSuchMethodException ignored) {
+            return null
+        }
+    }
+
+    private static Object invoke(def method, Object target) {
         method.setAccessible(true)
         method.invoke(target)
     }

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeDeserializerBehaviorSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeDeserializerBehaviorSpec.groovy
@@ -1,0 +1,67 @@
+package io.micronaut.serde.jackson.compiletime
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.type.Argument
+import io.micronaut.json.JsonMapper
+import io.micronaut.serde.SerdeIntrospections
+import io.micronaut.serde.config.annotation.SerdeConfig
+import io.micronaut.serde.jackson.JsonCompileSpec
+
+class CompileTimeDeserializerBehaviorSpec extends JsonCompileSpec {
+
+    void 'test primitive boolean missing constructor properties and nullable values match runtime deserializer'() {
+        given:
+        def context = ApplicationContext.run()
+        jsonMapper = context.getBean(JsonMapper)
+        Class<?> generatedType = SourceGenGeneratedConstructorDefaults
+        Class<?> runtimeType = SourceGenRuntimeConstructorDefaults
+        def introspections = context.getBean(SerdeIntrospections)
+        def generatedMetadata = introspections.getDeserializableIntrospection(Argument.of(generatedType)).annotationMetadata
+        String deserializerClassName = generatedMetadata.stringValue(SerdeConfig, SerdeConfig.SOURCEGEN_DESERIALIZER_CLASS).orElse(null)
+        String deserializerSource = generatedTestSource(deserializerClassName)
+
+        expect:
+        deserializerSource.contains('boolean propertyValue1 = false;')
+        deserializerSource.contains('propertyValue1 = objectDecoder.decodeBoolean();')
+        !deserializerSource.contains('propertyValue1 = objectDecoder.decodeBooleanNullable();')
+        !deserializerSource.contains('component0')
+        deserializerSource.indexOf('if (!seenProperty') > -1
+        deserializerSource.indexOf('if (!seenProperty') < deserializerSource.indexOf('return new io.micronaut.serde.jackson.compiletime.SourceGenGeneratedConstructorDefaults')
+
+        when:
+        def generatedMissingName = jsonMapper.readValue('{"active":true}', Argument.of(generatedType))
+        def runtimeMissingName = jsonMapper.readValue('{"active":true}', Argument.of(runtimeType))
+        def generatedMissingPrimitiveValues = jsonMapper.readValue('{"name":"Ada"}', Argument.of(generatedType))
+        def runtimeMissingPrimitiveValues = jsonMapper.readValue('{"name":"Ada"}', Argument.of(runtimeType))
+        def generatedMissingNullableValues = jsonMapper.readValue('{"name":"Ada","active":true,"count":1}', Argument.of(generatedType))
+        def runtimeMissingNullableValues = jsonMapper.readValue('{"name":"Ada","active":true,"count":1}', Argument.of(runtimeType))
+        def generatedNullValues = jsonMapper.readValue('{"name":null,"active":null,"count":null,"nullableName":null,"nullableActive":null}', Argument.of(generatedType))
+        def runtimeNullValues = jsonMapper.readValue('{"name":null,"active":null,"count":null,"nullableName":null,"nullableActive":null}', Argument.of(runtimeType))
+        def generatedMissingAll = jsonMapper.readValue('{}', Argument.of(generatedType))
+        def runtimeMissingAll = jsonMapper.readValue('{}', Argument.of(runtimeType))
+
+        then:
+        assertPropertiesEqual(generatedMissingName, runtimeMissingName)
+        assertPropertiesEqual(generatedMissingPrimitiveValues, runtimeMissingPrimitiveValues)
+        assertPropertiesEqual(generatedMissingNullableValues, runtimeMissingNullableValues)
+        assertPropertiesEqual(generatedNullValues, runtimeNullValues)
+        assertPropertiesEqual(generatedMissingAll, runtimeMissingAll)
+
+        cleanup:
+        context.close()
+    }
+
+    private static void assertPropertiesEqual(Object generated, Object runtime) {
+        assert invokeDeclared(generated, 'name') == invokeDeclared(runtime, 'name')
+        assert invokeDeclared(generated, 'active') == invokeDeclared(runtime, 'active')
+        assert invokeDeclared(generated, 'count') == invokeDeclared(runtime, 'count')
+        assert invokeDeclared(generated, 'nullableName') == invokeDeclared(runtime, 'nullableName')
+        assert invokeDeclared(generated, 'nullableActive') == invokeDeclared(runtime, 'nullableActive')
+    }
+
+    private static Object invokeDeclared(Object target, String methodName) {
+        def method = target.getClass().getDeclaredMethod(methodName)
+        method.setAccessible(true)
+        method.invoke(target)
+    }
+}

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeDeserializerBehaviorSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeDeserializerBehaviorSpec.groovy
@@ -23,8 +23,7 @@ class CompileTimeDeserializerBehaviorSpec extends JsonCompileSpec {
         deserializerSource.contains('propertyValue1 = objectDecoder.decodeBoolean();')
         !deserializerSource.contains('propertyValue1 = objectDecoder.decodeBooleanNullable();')
         !deserializerSource.contains('component0')
-        deserializerSource.indexOf('if (!seenProperty') > -1
-        deserializerSource.indexOf('if (!seenProperty') < deserializerSource.indexOf('return new io.micronaut.serde.jackson.compiletime.SourceGenGeneratedConstructorDefaults')
+        !deserializerSource.contains('if (!seenProperty')
         !deserializerSource.contains('duplicateProperty')
 
         cleanup:
@@ -41,8 +40,9 @@ class CompileTimeDeserializerBehaviorSpec extends JsonCompileSpec {
         String deserializerSource = generatedTestSource(deserializerClassName)
 
         expect:
-        deserializerSource.contains('boolean value1 = false;')
-        deserializerSource.contains('value1 = objectDecoder.decodeBoolean();')
+        !deserializerSource.contains('boolean value1 = false;')
+        !deserializerSource.contains('value1 = objectDecoder.decodeBoolean();')
+        deserializerSource.contains('bean.setActive(objectDecoder.decodeBoolean());')
         !deserializerSource.contains('value1 = objectDecoder.decodeBooleanNullable();')
         !deserializerSource.contains('duplicateProperty')
 

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeSourceGenSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeSourceGenSpec.groovy
@@ -1,0 +1,268 @@
+package io.micronaut.serde.jackson.compiletime
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.type.Argument
+import io.micronaut.json.JsonMapper
+import io.micronaut.serde.Decoder
+import io.micronaut.serde.Deserializer
+import io.micronaut.serde.LimitingStream
+import io.micronaut.serde.SerdeIntrospections
+import io.micronaut.serde.config.annotation.SerdeConfig
+import io.micronaut.serde.exceptions.SerdeException
+import io.micronaut.serde.jackson.JacksonDecoder
+import io.micronaut.serde.jackson.JsonCompileSpec
+import tools.jackson.core.json.JsonFactory
+
+class CompileTimeSourceGenSpec extends JsonCompileSpec {
+
+    void 'test generated serializers use object encoder and generated classes use indexed fields'() {
+        given:
+        def context = ApplicationContext.run()
+        Class<?> beanType = SourceGenIndexedShapeBean.class
+        Class<?> recordType = SourceGenIndexedShapeRecord.class
+        def introspections = context.getBean(SerdeIntrospections)
+
+        when:
+        def beanMetadata = introspections.getSerializableIntrospection(Argument.of(beanType)).annotationMetadata
+        def recordMetadata = introspections.getSerializableIntrospection(Argument.of(recordType)).annotationMetadata
+        String beanSerializerClassName = beanMetadata.stringValue(SerdeConfig, SerdeConfig.SOURCEGEN_SERIALIZER_CLASS).orElseThrow()
+        String beanDeserializerClassName = beanMetadata.stringValue(SerdeConfig, SerdeConfig.SOURCEGEN_DESERIALIZER_CLASS).orElseThrow()
+        String recordSerializerClassName = recordMetadata.stringValue(SerdeConfig, SerdeConfig.SOURCEGEN_SERIALIZER_CLASS).orElseThrow()
+        String recordDeserializerClassName = recordMetadata.stringValue(SerdeConfig, SerdeConfig.SOURCEGEN_DESERIALIZER_CLASS).orElseThrow()
+        Class<?> beanSerializerClass = context.classLoader.loadClass(beanSerializerClassName)
+        Class<?> beanDeserializerClass = context.classLoader.loadClass(beanDeserializerClassName)
+        Class<?> recordSerializerClass = context.classLoader.loadClass(recordSerializerClassName)
+        Class<?> recordDeserializerClass = context.classLoader.loadClass(recordDeserializerClassName)
+        String beanSerializerSource = generatedTestSource(beanSerializerClassName)
+        String recordSerializerSource = generatedTestSource(recordSerializerClassName)
+        String recordDeserializerSource = generatedTestSource(recordDeserializerClassName)
+
+        then:
+        assertSerializeMethodUsesObjectEncoder(beanSerializerSource)
+        assertSerializeMethodUsesObjectEncoder(recordSerializerSource)
+        beanSerializerSource.contains("withPropertyPath(e0, type, ${simpleName(beanSerializerClassName)}.KEY_0, ${simpleName(beanSerializerClassName)}.ARGUMENT_0)")
+        recordSerializerSource.contains("withPropertyPath(e0, type, ${simpleName(recordSerializerClassName)}.KEY_0, ${simpleName(recordSerializerClassName)}.ARGUMENT_0)")
+        !beanSerializerSource.contains('withPropertyPath(e0, type, "value"')
+        !recordSerializerSource.contains('withPropertyPath(e0, type, "value"')
+        recordDeserializerSource.contains('String propertyValue0')
+        !recordDeserializerSource.contains('component0')
+        beanSerializerClass.declaredFields*.name.containsAll(['KEY_0', 'ARGUMENT_0', 'KEY_1', 'ARGUMENT_1', 'SERIALIZER_1'])
+        beanDeserializerClass.declaredFields*.name.containsAll(['KEY_0', 'ARGUMENT_0', 'KEY_1', 'ARGUMENT_1', 'DESERIALIZER_1'])
+        recordSerializerClass.declaredFields*.name.containsAll(['KEY_0', 'ARGUMENT_0', 'KEY_1', 'ARGUMENT_1', 'SERIALIZER_1'])
+        recordDeserializerClass.declaredFields*.name.containsAll(['KEY_0', 'ARGUMENT_0', 'KEY_1', 'ARGUMENT_1', 'DESERIALIZER_1'])
+        !beanSerializerClass.declaredFields*.name.any { it.contains('VALUE') || it.contains('TAGS') }
+        !beanDeserializerClass.declaredFields*.name.any { it.contains('VALUE') || it.contains('TAGS') }
+        !recordSerializerClass.declaredFields*.name.any { it.contains('VALUE') || it.contains('TAGS') }
+        !recordDeserializerClass.declaredFields*.name.any { it.contains('VALUE') || it.contains('TAGS') }
+
+        cleanup:
+        context.close()
+    }
+
+    @SuppressWarnings('JsonDuplicatePropertyKeys')
+    void 'test generated bean deserializer dispatch source for small boundary and large property sets'() {
+        given:
+        def context = ApplicationContext.run()
+        jsonMapper = context.getBean(JsonMapper)
+        def registry = jsonMapper.serdeRegistry
+        def decoderContext = registry.newDecoderContext(Object)
+
+        Class<?> smallType = SourceGenSmallDispatchBean.class
+        Class<?> boundaryType = SourceGenBoundaryDispatchBean.class
+        Class<?> largeType = SourceGenLargeDispatchBean.class
+        Argument smallArgument = Argument.of(smallType)
+        Argument boundaryArgument = Argument.of(boundaryType)
+        Argument largeArgument = Argument.of(largeType)
+
+        def smallDeserializer = buildDeserializer(context, smallType)
+        def boundaryDeserializer = buildDeserializer(context, boundaryType)
+        def largeDeserializer = buildDeserializer(context, largeType)
+        String smallDeserializerSource = generatedTestSource(smallDeserializer.class.name)
+        String boundaryDeserializerSource = generatedTestSource(boundaryDeserializer.class.name)
+        String largeDeserializerSource = generatedTestSource(largeDeserializer.class.name)
+
+        when:
+        def small = deserializeValue(smallDeserializer, decoderContext, smallArgument, '{"a":"x","b":7,"c":true}')
+        def boundary = deserializeValue(boundaryDeserializer, decoderContext, boundaryArgument, '{"a":"x","b":7,"c":true,"d":9,"e":3.5}')
+        def large = deserializeValue(largeDeserializer, decoderContext, largeArgument, '{"a":"x","b":7,"c":true,"d":9,"e":3.5,"f":"z"}')
+
+        then:
+        assertSmallDispatchSource(smallDeserializerSource)
+        assertSmallDispatchSource(boundaryDeserializerSource)
+        assertLargeDispatchSource(largeDeserializerSource, 'boolean value2 = false;', 'value2 = objectDecoder.decodeBoolean();')
+        small.getA() == 'x'
+        small.getB() == 7
+        small.isC()
+        boundary.getA() == 'x'
+        boundary.getB() == 7
+        boundary.isC()
+        boundary.getD() == 9L
+        boundary.getE() == 3.5d
+        large.getA() == 'x'
+        large.getB() == 7
+        large.isC()
+        large.getD() == 9L
+        large.getE() == 3.5d
+        large.getF() == 'z'
+
+        when:
+        def smallDuplicate = captureFailure {
+            deserializeValue(smallDeserializer, decoderContext, smallArgument, '{"a":"x","a":"y","b":7,"c":true}')
+        }
+        def boundaryDuplicate = captureFailure {
+            deserializeValue(boundaryDeserializer, decoderContext, boundaryArgument, '{"a":"x","b":7,"c":true,"d":9,"e":3.5,"e":1.0}')
+        }
+        def largeDuplicate = captureFailure {
+            deserializeValue(largeDeserializer, decoderContext, largeArgument, '{"a":"x","b":7,"c":true,"d":9,"e":3.5,"f":"z","f":"y"}')
+        }
+
+        then:
+        smallDuplicate instanceof SerdeException
+        boundaryDuplicate instanceof SerdeException
+        largeDuplicate instanceof SerdeException
+        smallDuplicate.message?.contains('a')
+        boundaryDuplicate.message?.contains('e')
+        largeDuplicate.message?.contains('f')
+
+        cleanup:
+        context.close()
+    }
+
+    @SuppressWarnings('JsonDuplicatePropertyKeys')
+    void 'test generated record deserializer dispatch source for small boundary and large property sets'() {
+        given:
+        def context = ApplicationContext.run()
+        jsonMapper = context.getBean(JsonMapper)
+        def registry = jsonMapper.serdeRegistry
+        def decoderContext = registry.newDecoderContext(Object)
+
+        Class<?> smallType = SourceGenSmallDispatchRecord.class
+        Class<?> boundaryType = SourceGenBoundaryDispatchRecord.class
+        Class<?> largeType = SourceGenLargeDispatchRecord.class
+        Argument smallArgument = Argument.of(smallType)
+        Argument boundaryArgument = Argument.of(boundaryType)
+        Argument largeArgument = Argument.of(largeType)
+
+        def smallDeserializer = buildDeserializer(context, smallType)
+        def boundaryDeserializer = buildDeserializer(context, boundaryType)
+        def largeDeserializer = buildDeserializer(context, largeType)
+        String smallDeserializerSource = generatedTestSource(smallDeserializer.class.name)
+        String boundaryDeserializerSource = generatedTestSource(boundaryDeserializer.class.name)
+        String largeDeserializerSource = generatedTestSource(largeDeserializer.class.name)
+
+        when:
+        def small = deserializeValue(smallDeserializer, decoderContext, smallArgument, '{"a":"x","b":7,"c":true}')
+        def boundary = deserializeValue(boundaryDeserializer, decoderContext, boundaryArgument, '{"a":"x","b":7,"c":true,"d":9,"e":3.5}')
+        def large = deserializeValue(largeDeserializer, decoderContext, largeArgument, '{"a":"x","b":7,"c":true,"d":9,"e":3.5,"f":"z"}')
+
+        then:
+        assertSmallDispatchSource(smallDeserializerSource)
+        assertSmallDispatchSource(boundaryDeserializerSource)
+        assertLargeDispatchSource(largeDeserializerSource, 'boolean propertyValue2 = false;', 'propertyValue2 = objectDecoder.decodeBoolean();')
+        small.a() == 'x'
+        small.b() == 7
+        small.c()
+        boundary.a() == 'x'
+        boundary.b() == 7
+        boundary.c()
+        boundary.d() == 9L
+        boundary.e() == 3.5d
+        large.a() == 'x'
+        large.b() == 7
+        large.c()
+        large.d() == 9L
+        large.e() == 3.5d
+        large.f() == 'z'
+
+        when:
+        def smallDuplicate = captureFailure {
+            deserializeValue(smallDeserializer, decoderContext, smallArgument, '{"a":"x","a":"y","b":7,"c":true}')
+        }
+        def boundaryDuplicate = captureFailure {
+            deserializeValue(boundaryDeserializer, decoderContext, boundaryArgument, '{"a":"x","b":7,"c":true,"d":9,"e":3.5,"e":1.0}')
+        }
+        def largeDuplicate = captureFailure {
+            deserializeValue(largeDeserializer, decoderContext, largeArgument, '{"a":"x","b":7,"c":true,"d":9,"e":3.5,"f":"z","f":"y"}')
+        }
+
+        then:
+        smallDuplicate instanceof SerdeException
+        boundaryDuplicate instanceof SerdeException
+        largeDuplicate instanceof SerdeException
+        smallDuplicate.message?.contains('a')
+        boundaryDuplicate.message?.contains('e')
+        largeDuplicate.message?.contains('f')
+
+        cleanup:
+        context.close()
+    }
+
+    private static void assertSerializeMethodUsesObjectEncoder(String serializerSource) {
+        String serializeMethodSource = serializerSource.substring(
+            serializerSource.indexOf('public void serialize('),
+            serializerSource.indexOf('public void serializeInto(')
+        )
+        assert serializeMethodSource.contains('Encoder objectEncoder = encoder.encodeObject(type);')
+        assert serializeMethodSource.contains('this.serializeInto(objectEncoder, context, type, value);')
+        assert serializeMethodSource.contains('objectEncoder.finishStructure();')
+        assert serializeMethodSource.indexOf('encoder.encodeObject(type)') < serializeMethodSource.indexOf('this.serializeInto')
+        assert serializeMethodSource.indexOf('this.serializeInto') < serializeMethodSource.indexOf('objectEncoder.finishStructure()')
+        assert !serializeMethodSource.contains('encodeKey')
+    }
+
+    private static void assertSmallDispatchSource(String deserializerSource) {
+        assert deserializerSource.contains('key.equals(')
+        assert !deserializerSource.contains('Objects.equals(key')
+        assert !deserializerSource.contains('switch (key)')
+    }
+
+    private static void assertLargeDispatchSource(String deserializerSource,
+                                                  String primitiveDefault,
+                                                  String primitiveDecode) {
+        assert deserializerSource.contains('switch (key)')
+        assert !deserializerSource.contains('key.equals(')
+        assert !deserializerSource.contains('Objects.equals(key')
+        assert !deserializerSource.contains('switchResult')
+        assert !deserializerSource.contains('matched' + 'Property')
+        assert !deserializerSource.contains('= switch (key)')
+        assert !deserializerSource.contains('yield')
+        assert deserializerSource.count('decodeKey()') == 2
+        assert deserializerSource.contains(primitiveDefault)
+        assert deserializerSource.contains(primitiveDecode)
+        assert !deserializerSource.contains('decodeBooleanNullable')
+    }
+
+    private Object buildDeserializer(def context, Class<?> type) {
+        def introspections = context.getBean(SerdeIntrospections)
+        def metadata = introspections.getSerializableIntrospection(Argument.of(type)).annotationMetadata
+        String deserializerClassName = metadata.stringValue(SerdeConfig, SerdeConfig.SOURCEGEN_DESERIALIZER_CLASS).orElse(null)
+        Class<?> deserializerClass = context.classLoader.loadClass(deserializerClassName)
+        (Deserializer) deserializerClass.getDeclaredConstructor().newInstance()
+    }
+
+    private static Object deserializeValue(Deserializer deserializer,
+                                           Deserializer.DecoderContext decoderContext,
+                                           Argument type,
+                                           String json) {
+        def jsonFactory = new JsonFactory()
+        def result
+        jsonFactory.createParser(json).withCloseable { parser ->
+            Decoder decoder = JacksonDecoder.create(parser, LimitingStream.DEFAULT_LIMITS)
+            result = deserializer.deserialize(decoder, decoderContext, type)
+        }
+        result
+    }
+
+    private static Exception captureFailure(Closure<?> action) {
+        try {
+            action.call()
+            return null
+        } catch (Exception e) {
+            return e
+        }
+    }
+
+    private static String simpleName(String className) {
+        className.substring(className.lastIndexOf('.') + 1)
+    }
+}

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeSourceGenSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeSourceGenSpec.groovy
@@ -88,7 +88,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
         then:
         assertSmallDispatchSource(smallDeserializerSource)
         assertSmallDispatchSource(boundaryDeserializerSource)
-        assertLargeDispatchSource(largeDeserializerSource, 'boolean value2 = false;', 'value2 = objectDecoder.decodeBoolean();')
+        assertLargeBeanDispatchSource(largeDeserializerSource)
         small.getA() == 'x'
         small.getB() == 7
         small.isC()
@@ -159,7 +159,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
         then:
         assertSmallDispatchSource(smallDeserializerSource)
         assertSmallDispatchSource(boundaryDeserializerSource)
-        assertLargeDispatchSource(largeDeserializerSource, 'boolean propertyValue2 = false;', 'propertyValue2 = objectDecoder.decodeBoolean();')
+        assertLargeRecordDispatchSource(largeDeserializerSource)
         small.a() == 'x'
         small.b() == 7
         small.c()
@@ -200,6 +200,25 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
         context.close()
     }
 
+    void 'test generated record constructor failures match runtime for small and large property sets'() {
+        given:
+        def context = ApplicationContext.run(['micronaut.serde.deserialization.strict-nullable': true])
+        jsonMapper = context.getBean(JsonMapper)
+
+        expect:
+        assertReadFailureMatches(jsonMapper, generatedType, runtimeType, json)
+
+        cleanup:
+        context.close()
+
+        where:
+        scenario                         | generatedType                                  | runtimeType                                         | json
+        'small missing non-null value'   | SourceGenSmallDispatchNonNullRecord.class      | SourceGenRuntimeSmallDispatchNonNullRecord.class    | '{"b":7,"c":true}'
+        'small explicit non-null null'   | SourceGenSmallDispatchNonNullRecord.class      | SourceGenRuntimeSmallDispatchNonNullRecord.class    | '{"a":null,"b":7,"c":true}'
+        'large missing non-null value'   | SourceGenLargeDispatchNonNullRecord.class      | SourceGenRuntimeLargeDispatchNonNullRecord.class    | '{"a":"x","b":7,"c":true,"d":9,"e":3.5}'
+        'large explicit non-null null'   | SourceGenLargeDispatchNonNullRecord.class      | SourceGenRuntimeLargeDispatchNonNullRecord.class    | '{"a":"x","b":7,"c":true,"d":9,"e":3.5,"f":null}'
+    }
+
     private static void assertSerializeMethodUsesObjectEncoder(String serializerSource) {
         String serializeMethodSource = serializerSource.substring(
             serializerSource.indexOf('public void serialize('),
@@ -221,9 +240,23 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
         assert !deserializerSource.contains('duplicateProperty')
     }
 
-    private static void assertLargeDispatchSource(String deserializerSource,
-                                                  String primitiveDefault,
-                                                  String primitiveDecode) {
+    private static void assertLargeBeanDispatchSource(String deserializerSource) {
+        assertLargeDispatchSource(deserializerSource)
+        assert !deserializerSource.contains('boolean value2 = false;')
+        assert !deserializerSource.contains('value2 = objectDecoder.decodeBoolean();')
+        assert deserializerSource.contains('bean.setC(objectDecoder.decodeBoolean());')
+        assert !deserializerSource.contains('decodeBooleanNullable')
+    }
+
+    private static void assertLargeRecordDispatchSource(String deserializerSource) {
+        assertLargeDispatchSource(deserializerSource)
+        assert deserializerSource.contains('boolean propertyValue2 = false;')
+        assert deserializerSource.contains('propertyValue2 = objectDecoder.decodeBoolean();')
+        assert !deserializerSource.contains('decodeBooleanNullable')
+        assert !deserializerSource.contains('if (!seenProperty')
+    }
+
+    private static void assertLargeDispatchSource(String deserializerSource) {
         assert deserializerSource.contains('switch (key)')
         assert !deserializerSource.contains('key.equals(')
         assert !deserializerSource.contains('Objects.equals(key')
@@ -234,9 +267,6 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
         assert deserializerSource.count('decodeKey()') == 2
         assert deserializerSource.contains('skipValue')
         assert !deserializerSource.contains('duplicateProperty')
-        assert deserializerSource.contains(primitiveDefault)
-        assert deserializerSource.contains(primitiveDecode)
-        assert !deserializerSource.contains('decodeBooleanNullable')
     }
 
     private Object buildDeserializer(def context, Class<?> type) {
@@ -258,6 +288,25 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
             result = deserializer.deserialize(decoder, decoderContext, type)
         }
         result
+    }
+
+    private static void assertReadFailureMatches(JsonMapper jsonMapper,
+                                                 Class<?> generatedType,
+                                                 Class<?> runtimeType,
+                                                 String json) {
+        def generatedFailure = readFailure(jsonMapper, generatedType, json)
+        def runtimeFailure = readFailure(jsonMapper, runtimeType, json)
+        assert generatedFailure != null
+        assert runtimeFailure != null
+    }
+
+    private static Throwable readFailure(JsonMapper jsonMapper, Class<?> type, String json) {
+        try {
+            jsonMapper.readValue(json, Argument.of(type))
+            return null
+        } catch (Throwable e) {
+            return e
+        }
     }
 
     private static String simpleName(String className) {

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeSourceGenSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeSourceGenSpec.groovy
@@ -8,7 +8,6 @@ import io.micronaut.serde.Deserializer
 import io.micronaut.serde.LimitingStream
 import io.micronaut.serde.SerdeIntrospections
 import io.micronaut.serde.config.annotation.SerdeConfig
-import io.micronaut.serde.exceptions.SerdeException
 import io.micronaut.serde.jackson.JacksonDecoder
 import io.micronaut.serde.jackson.JsonCompileSpec
 import tools.jackson.core.json.JsonFactory
@@ -106,23 +105,25 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
         large.getF() == 'z'
 
         when:
-        def smallDuplicate = captureFailure {
-            deserializeValue(smallDeserializer, decoderContext, smallArgument, '{"a":"x","a":"y","b":7,"c":true}')
-        }
-        def boundaryDuplicate = captureFailure {
-            deserializeValue(boundaryDeserializer, decoderContext, boundaryArgument, '{"a":"x","b":7,"c":true,"d":9,"e":3.5,"e":1.0}')
-        }
-        def largeDuplicate = captureFailure {
-            deserializeValue(largeDeserializer, decoderContext, largeArgument, '{"a":"x","b":7,"c":true,"d":9,"e":3.5,"f":"z","f":"y"}')
-        }
+        def smallDuplicate = deserializeValue(smallDeserializer, decoderContext, smallArgument, '{"a":"x","a":"y","b":7,"c":true}')
+        def boundaryDuplicate = deserializeValue(boundaryDeserializer, decoderContext, boundaryArgument, '{"a":"x","b":7,"c":true,"d":9,"e":3.5,"e":1.0}')
+        def largeDuplicate = deserializeValue(largeDeserializer, decoderContext, largeArgument, '{"a":"x","b":7,"c":true,"d":9,"e":3.5,"f":"z","f":"y"}')
 
         then:
-        smallDuplicate instanceof SerdeException
-        boundaryDuplicate instanceof SerdeException
-        largeDuplicate instanceof SerdeException
-        smallDuplicate.message?.contains('a')
-        boundaryDuplicate.message?.contains('e')
-        largeDuplicate.message?.contains('f')
+        smallDuplicate.getA() == 'x'
+        smallDuplicate.getB() == 7
+        smallDuplicate.isC()
+        boundaryDuplicate.getA() == 'x'
+        boundaryDuplicate.getB() == 7
+        boundaryDuplicate.isC()
+        boundaryDuplicate.getD() == 9L
+        boundaryDuplicate.getE() == 3.5d
+        largeDuplicate.getA() == 'x'
+        largeDuplicate.getB() == 7
+        largeDuplicate.isC()
+        largeDuplicate.getD() == 9L
+        largeDuplicate.getE() == 3.5d
+        largeDuplicate.getF() == 'z'
 
         cleanup:
         context.close()
@@ -175,23 +176,25 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
         large.f() == 'z'
 
         when:
-        def smallDuplicate = captureFailure {
-            deserializeValue(smallDeserializer, decoderContext, smallArgument, '{"a":"x","a":"y","b":7,"c":true}')
-        }
-        def boundaryDuplicate = captureFailure {
-            deserializeValue(boundaryDeserializer, decoderContext, boundaryArgument, '{"a":"x","b":7,"c":true,"d":9,"e":3.5,"e":1.0}')
-        }
-        def largeDuplicate = captureFailure {
-            deserializeValue(largeDeserializer, decoderContext, largeArgument, '{"a":"x","b":7,"c":true,"d":9,"e":3.5,"f":"z","f":"y"}')
-        }
+        def smallDuplicate = deserializeValue(smallDeserializer, decoderContext, smallArgument, '{"a":"x","a":"y","b":7,"c":true}')
+        def boundaryDuplicate = deserializeValue(boundaryDeserializer, decoderContext, boundaryArgument, '{"a":"x","b":7,"c":true,"d":9,"e":3.5,"e":1.0}')
+        def largeDuplicate = deserializeValue(largeDeserializer, decoderContext, largeArgument, '{"a":"x","b":7,"c":true,"d":9,"e":3.5,"f":"z","f":"y"}')
 
         then:
-        smallDuplicate instanceof SerdeException
-        boundaryDuplicate instanceof SerdeException
-        largeDuplicate instanceof SerdeException
-        smallDuplicate.message?.contains('a')
-        boundaryDuplicate.message?.contains('e')
-        largeDuplicate.message?.contains('f')
+        smallDuplicate.a() == 'x'
+        smallDuplicate.b() == 7
+        smallDuplicate.c()
+        boundaryDuplicate.a() == 'x'
+        boundaryDuplicate.b() == 7
+        boundaryDuplicate.c()
+        boundaryDuplicate.d() == 9L
+        boundaryDuplicate.e() == 3.5d
+        largeDuplicate.a() == 'x'
+        largeDuplicate.b() == 7
+        largeDuplicate.c()
+        largeDuplicate.d() == 9L
+        largeDuplicate.e() == 3.5d
+        largeDuplicate.f() == 'z'
 
         cleanup:
         context.close()
@@ -214,6 +217,8 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
         assert deserializerSource.contains('key.equals(')
         assert !deserializerSource.contains('Objects.equals(key')
         assert !deserializerSource.contains('switch (key)')
+        assert deserializerSource.contains('skipValue')
+        assert !deserializerSource.contains('duplicateProperty')
     }
 
     private static void assertLargeDispatchSource(String deserializerSource,
@@ -227,6 +232,8 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
         assert !deserializerSource.contains('= switch (key)')
         assert !deserializerSource.contains('yield')
         assert deserializerSource.count('decodeKey()') == 2
+        assert deserializerSource.contains('skipValue')
+        assert !deserializerSource.contains('duplicateProperty')
         assert deserializerSource.contains(primitiveDefault)
         assert deserializerSource.contains(primitiveDecode)
         assert !deserializerSource.contains('decodeBooleanNullable')
@@ -251,15 +258,6 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
             result = deserializer.deserialize(decoder, decoderContext, type)
         }
         result
-    }
-
-    private static Exception captureFailure(Closure<?> action) {
-        try {
-            action.call()
-            return null
-        } catch (Exception e) {
-            return e
-        }
     }
 
     private static String simpleName(String className) {

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/SerdeableGeneratedSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/SerdeableGeneratedSpec.groovy
@@ -1,0 +1,110 @@
+package io.micronaut.serde.jackson.compiletime
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.type.Argument
+import io.micronaut.serde.SerdeIntrospections
+import io.micronaut.serde.config.annotation.SerdeConfig
+import io.micronaut.serde.jackson.JsonCompileSpec
+
+class SerdeableGeneratedSpec extends JsonCompileSpec {
+
+    void 'test serdeable generated requires generated serializer and deserializer by default'() {
+        given:
+        def context = ApplicationContext.run()
+
+        expect:
+        assertEligibility(context, SourceGenGeneratedShape, true, true)
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test serdeable generated required false allows sourcegen fallback without generated classes'() {
+        given:
+        def context = ApplicationContext.run()
+
+        expect:
+        assertEligibility(context, SourceGenRequiredFalseUnsupportedShape, false, false)
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test serdeable generated skip disables both generated directions'() {
+        given:
+        def context = ApplicationContext.run()
+
+        expect:
+        assertEligibility(context, SourceGenSkippedShape, false, false)
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test serdeable generated can skip serializer or deserializer only'() {
+        given:
+        def context = ApplicationContext.run()
+
+        expect:
+        assertEligibility(context, SourceGenSkipSerializerShape, false, true)
+        assertEligibility(context, SourceGenSkipDeserializerShape, true, false)
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test serdeable generated directional skip permits unsupported skipped direction'() {
+        given:
+        def context = ApplicationContext.run()
+
+        expect:
+        assertEligibility(context, SourceGenAnyGetterSkipSerializerShape, false, true)
+
+        cleanup:
+        context.close()
+    }
+
+    private void assertEligibility(ApplicationContext context,
+                                   Class<?> beanType,
+                                   boolean serializerEligible,
+                                   boolean deserializerEligible) {
+        def serdeIntrospections = context.getBean(SerdeIntrospections)
+        def metadata = serdeIntrospections
+            .getSerializableIntrospection(Argument.of(beanType))
+            .annotationMetadata
+
+        assert metadata.booleanValue(SerdeConfig, SerdeConfig.SOURCEGEN_SERIALIZER_ELIGIBLE).orElse(false) == serializerEligible
+        assert metadata.booleanValue(SerdeConfig, SerdeConfig.SOURCEGEN_DESERIALIZER_ELIGIBLE).orElse(false) == deserializerEligible
+
+        assertGeneratedClassState(context, metadata, beanType, SerdeConfig.SOURCEGEN_SERIALIZER_CLASS, 'Serializer', serializerEligible)
+        assertGeneratedClassState(context, metadata, beanType, SerdeConfig.SOURCEGEN_DESERIALIZER_CLASS, 'Deserializer', deserializerEligible)
+    }
+
+    private void assertGeneratedClassState(ApplicationContext context,
+                                           def metadata,
+                                           Class<?> beanType,
+                                           String metadataMember,
+                                           String suffix,
+                                           boolean expectedGenerated) {
+        String expectedClassName = generatedClassName(beanType, suffix)
+        if (expectedGenerated) {
+            assert metadata.stringValue(SerdeConfig, metadataMember).orElse(null) == expectedClassName
+            assert context.classLoader.loadClass(expectedClassName) != null
+        } else {
+            assert !metadata.stringValue(SerdeConfig, metadataMember).present
+            assert loadClassOrNull(context, expectedClassName) == null
+        }
+    }
+
+    private static Class<?> loadClassOrNull(ApplicationContext context, String className) {
+        try {
+            return context.classLoader.loadClass(className)
+        } catch (ClassNotFoundException ignored) {
+            return null
+        }
+    }
+
+    private static String generatedClassName(Class<?> type, String suffix) {
+        "${type.package.name}.Serde${type.simpleName}${suffix}"
+    }
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenAnyGetterSkipSerializerShape.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenAnyGetterSkipSerializerShape.java
@@ -1,0 +1,30 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@SerdeableGenerated(skipSerializer = true)
+public class SourceGenAnyGetterSkipSerializerShape {
+    private String name;
+    private Map<String, Object> attributes = new LinkedHashMap<>();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenBoundaryDispatchBean.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenBoundaryDispatchBean.java
@@ -1,0 +1,54 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+@SerdeableGenerated
+@Introspected
+public class SourceGenBoundaryDispatchBean {
+    private String a;
+    private int b;
+    private boolean c;
+    private long d;
+    private double e;
+
+    public String getA() {
+        return a;
+    }
+
+    public void setA(String a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public boolean isC() {
+        return c;
+    }
+
+    public void setC(boolean c) {
+        this.c = c;
+    }
+
+    public long getD() {
+        return d;
+    }
+
+    public void setD(long d) {
+        this.d = d;
+    }
+
+    public double getE() {
+        return e;
+    }
+
+    public void setE(double e) {
+        this.e = e;
+    }
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenBoundaryDispatchRecord.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenBoundaryDispatchRecord.java
@@ -1,0 +1,9 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+@SerdeableGenerated
+@Introspected
+public record SourceGenBoundaryDispatchRecord(String a, int b, boolean c, long d, double e) {
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenGeneratedConstructorDefaults.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenGeneratedConstructorDefaults.java
@@ -1,0 +1,14 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+@SerdeableGenerated
+public record SourceGenGeneratedConstructorDefaults(
+    String name,
+    boolean active,
+    int count,
+    @Nullable String nullableName,
+    @Nullable Boolean nullableActive
+) {
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenGeneratedPropertyDefaults.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenGeneratedPropertyDefaults.java
@@ -1,0 +1,57 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+@SerdeableGenerated
+public class SourceGenGeneratedPropertyDefaults {
+    private String name = "default-name";
+    private boolean active = true;
+    private int count = 7;
+    @Nullable
+    private String nullableName = "default-nullable-name";
+    @Nullable
+    private Boolean nullableActive = Boolean.TRUE;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+
+    @Nullable
+    public String getNullableName() {
+        return nullableName;
+    }
+
+    public void setNullableName(@Nullable String nullableName) {
+        this.nullableName = nullableName;
+    }
+
+    @Nullable
+    public Boolean getNullableActive() {
+        return nullableActive;
+    }
+
+    public void setNullableActive(@Nullable Boolean nullableActive) {
+        this.nullableActive = nullableActive;
+    }
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenGeneratedShape.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenGeneratedShape.java
@@ -1,0 +1,7 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+@SerdeableGenerated
+public record SourceGenGeneratedShape(String name, int count) {
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenIndexedShapeBean.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenIndexedShapeBean.java
@@ -1,0 +1,29 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+import java.util.List;
+
+@SerdeableGenerated
+@Introspected
+public class SourceGenIndexedShapeBean {
+    private String value;
+    private List<String> tags;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenIndexedShapeRecord.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenIndexedShapeRecord.java
@@ -1,11 +1,11 @@
-package io.micronaut.serde.data;
+package io.micronaut.serde.jackson.compiletime;
 
 import io.micronaut.core.annotation.Introspected;
 import io.micronaut.serde.annotation.SerdeableGenerated;
 
 import java.util.List;
 
-@Introspected
 @SerdeableGenerated
-public record StringListConstructor(List<String> strs) {
+@Introspected
+public record SourceGenIndexedShapeRecord(String value, List<String> tags) {
 }

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenLargeDispatchBean.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenLargeDispatchBean.java
@@ -1,0 +1,63 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+@SerdeableGenerated
+@Introspected
+public class SourceGenLargeDispatchBean {
+    private String a;
+    private int b;
+    private boolean c;
+    private long d;
+    private double e;
+    private String f;
+
+    public String getA() {
+        return a;
+    }
+
+    public void setA(String a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public boolean isC() {
+        return c;
+    }
+
+    public void setC(boolean c) {
+        this.c = c;
+    }
+
+    public long getD() {
+        return d;
+    }
+
+    public void setD(long d) {
+        this.d = d;
+    }
+
+    public double getE() {
+        return e;
+    }
+
+    public void setE(double e) {
+        this.e = e;
+    }
+
+    public String getF() {
+        return f;
+    }
+
+    public void setF(String f) {
+        this.f = f;
+    }
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenLargeDispatchNonNullRecord.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenLargeDispatchNonNullRecord.java
@@ -1,0 +1,10 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+@SerdeableGenerated
+@Introspected
+public record SourceGenLargeDispatchNonNullRecord(String a, int b, boolean c, long d, double e, @NonNull String f) {
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenLargeDispatchRecord.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenLargeDispatchRecord.java
@@ -1,0 +1,9 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+@SerdeableGenerated
+@Introspected
+public record SourceGenLargeDispatchRecord(String a, int b, boolean c, long d, double e, String f) {
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenRequiredFalseUnsupportedShape.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenRequiredFalseUnsupportedShape.java
@@ -1,0 +1,18 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+@SerdeableGenerated(required = false)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SourceGenRequiredFalseUnsupportedShape {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenRuntimeConstructorDefaults.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenRuntimeConstructorDefaults.java
@@ -1,0 +1,14 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+@SerdeableGenerated(skipDeserializer = true)
+public record SourceGenRuntimeConstructorDefaults(
+    String name,
+    boolean active,
+    int count,
+    @Nullable String nullableName,
+    @Nullable Boolean nullableActive
+) {
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenRuntimeLargeDispatchNonNullRecord.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenRuntimeLargeDispatchNonNullRecord.java
@@ -1,0 +1,10 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+@SerdeableGenerated(skipDeserializer = true)
+@Introspected
+public record SourceGenRuntimeLargeDispatchNonNullRecord(String a, int b, boolean c, long d, double e, @NonNull String f) {
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenRuntimePropertyDefaults.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenRuntimePropertyDefaults.java
@@ -1,0 +1,57 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.core.annotation.Nullable;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+@SerdeableGenerated(skipDeserializer = true)
+public class SourceGenRuntimePropertyDefaults {
+    private String name = "default-name";
+    private boolean active = true;
+    private int count = 7;
+    @Nullable
+    private String nullableName = "default-nullable-name";
+    @Nullable
+    private Boolean nullableActive = Boolean.TRUE;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+
+    @Nullable
+    public String getNullableName() {
+        return nullableName;
+    }
+
+    public void setNullableName(@Nullable String nullableName) {
+        this.nullableName = nullableName;
+    }
+
+    @Nullable
+    public Boolean getNullableActive() {
+        return nullableActive;
+    }
+
+    public void setNullableActive(@Nullable Boolean nullableActive) {
+        this.nullableActive = nullableActive;
+    }
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenRuntimeSmallDispatchNonNullRecord.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenRuntimeSmallDispatchNonNullRecord.java
@@ -1,0 +1,10 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+@SerdeableGenerated(skipDeserializer = true)
+@Introspected
+public record SourceGenRuntimeSmallDispatchNonNullRecord(@NonNull String a, int b, boolean c) {
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenSkipDeserializerShape.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenSkipDeserializerShape.java
@@ -1,0 +1,7 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+@SerdeableGenerated(skipDeserializer = true)
+public record SourceGenSkipDeserializerShape(String name) {
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenSkipSerializerShape.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenSkipSerializerShape.java
@@ -1,0 +1,7 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+@SerdeableGenerated(skipSerializer = true)
+public record SourceGenSkipSerializerShape(String name) {
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenSkippedShape.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenSkippedShape.java
@@ -1,0 +1,7 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+@SerdeableGenerated(skip = true)
+public record SourceGenSkippedShape(String name) {
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenSmallDispatchBean.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenSmallDispatchBean.java
@@ -1,0 +1,36 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+@SerdeableGenerated
+@Introspected
+public class SourceGenSmallDispatchBean {
+    private String a;
+    private int b;
+    private boolean c;
+
+    public String getA() {
+        return a;
+    }
+
+    public void setA(String a) {
+        this.a = a;
+    }
+
+    public int getB() {
+        return b;
+    }
+
+    public void setB(int b) {
+        this.b = b;
+    }
+
+    public boolean isC() {
+        return c;
+    }
+
+    public void setC(boolean c) {
+        this.c = c;
+    }
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenSmallDispatchNonNullRecord.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenSmallDispatchNonNullRecord.java
@@ -1,0 +1,10 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+@SerdeableGenerated
+@Introspected
+public record SourceGenSmallDispatchNonNullRecord(@NonNull String a, int b, boolean c) {
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenSmallDispatchRecord.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenSmallDispatchRecord.java
@@ -1,0 +1,9 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+@SerdeableGenerated
+@Introspected
+public record SourceGenSmallDispatchRecord(String a, int b, boolean c) {
+}

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/SerdeAnnotationVisitor.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/SerdeAnnotationVisitor.java
@@ -47,6 +47,7 @@ import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
 import io.micronaut.serde.annotation.SerdeImport;
 import io.micronaut.serde.annotation.Serdeable;
+import io.micronaut.serde.annotation.SerdeableGenerated;
 import io.micronaut.serde.config.annotation.SerdeConfig;
 import io.micronaut.serde.config.naming.PropertyNamingStrategy;
 import io.micronaut.serde.processor.sourcegen.SerdeSourceGenClassNaming;
@@ -798,10 +799,21 @@ public class SerdeAnnotationVisitor implements TypeElementVisitor<SerdeConfig, S
 
     private void applySourceGenDecision(ClassElement element) {
         SimpleSerdeShapeDecision decision = sourceGenShapeAnalyzer.analyze(element);
+        validateRequiredGeneratedSerde(element, decision);
         element.annotate(SerdeConfig.class, builder -> {
             builder.member(SerdeConfig.SOURCEGEN_SHAPE, decision.shapeKind().name());
             builder.member(SerdeConfig.SOURCEGEN_SERIALIZER_ELIGIBLE, decision.serializerEligible());
             builder.member(SerdeConfig.SOURCEGEN_DESERIALIZER_ELIGIBLE, decision.deserializerEligible());
+            if (!decision.serializerFallbackReasons().isEmpty()) {
+                builder.member(SerdeConfig.SOURCEGEN_SERIALIZER_FALLBACK_REASONS, decision.serializerFallbackReasons().stream()
+                    .map(Enum::name)
+                    .toArray(String[]::new));
+            }
+            if (!decision.deserializerFallbackReasons().isEmpty()) {
+                builder.member(SerdeConfig.SOURCEGEN_DESERIALIZER_FALLBACK_REASONS, decision.deserializerFallbackReasons().stream()
+                    .map(Enum::name)
+                    .toArray(String[]::new));
+            }
             if (decision.serializerEligible()) {
                 builder.member(SerdeConfig.SOURCEGEN_SERIALIZER_CLASS, SerdeSourceGenClassNaming.generatedSerializerClassName(element));
             }
@@ -809,6 +821,22 @@ public class SerdeAnnotationVisitor implements TypeElementVisitor<SerdeConfig, S
                 builder.member(SerdeConfig.SOURCEGEN_DESERIALIZER_CLASS, SerdeSourceGenClassNaming.generatedDeserializerClassName(element));
             }
         });
+    }
+
+    private void validateRequiredGeneratedSerde(ClassElement element, SimpleSerdeShapeDecision decision) {
+        if (!element.hasAnnotation(SerdeableGenerated.class)
+            || !element.booleanValue(SerdeableGenerated.class, "required").orElse(true)
+            || element.booleanValue(SerdeableGenerated.class, "skip").orElse(false)) {
+            return;
+        }
+        if (!element.booleanValue(SerdeableGenerated.class, "skipSerializer").orElse(false) && !decision.serializerEligible()) {
+            throw new ProcessingException(element, "Source-generated serializer required for " + element.getName()
+                + " but generation is not supported. Fallback reasons: " + decision.serializerFallbackReasons());
+        }
+        if (!element.booleanValue(SerdeableGenerated.class, "skipDeserializer").orElse(false) && !decision.deserializerEligible()) {
+            throw new ProcessingException(element, "Source-generated deserializer required for " + element.getName()
+                + " but generation is not supported. Fallback reasons: " + decision.deserializerFallbackReasons());
+        }
     }
 
     private void visitProperties(ClassElement classElement, VisitorContext context) {

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/SerdeSourceGenVisitor.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/SerdeSourceGenVisitor.java
@@ -16,9 +16,13 @@
 package io.micronaut.serde.processor.sourcegen;
 
 import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.beans.visitor.IntrospectedTypeElementVisitor;
 import io.micronaut.inject.visitor.TypeElementVisitor;
 import io.micronaut.inject.visitor.VisitorContext;
-import io.micronaut.inject.beans.visitor.IntrospectedTypeElementVisitor;
+import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.Serializer;
+import io.micronaut.serde.annotation.Serdeable;
+import io.micronaut.serde.annotation.SerdeableGenerated;
 import io.micronaut.serde.processor.sourcegen.beans.BeanDeserializerSourceGen;
 import io.micronaut.serde.processor.sourcegen.beans.BeanSerdeShape;
 import io.micronaut.serde.processor.sourcegen.beans.BeanSerdeShapeResolver;
@@ -31,9 +35,6 @@ import io.micronaut.serde.processor.sourcegen.records.RecordDeserializerSourceGe
 import io.micronaut.serde.processor.sourcegen.records.RecordSerdeShape;
 import io.micronaut.serde.processor.sourcegen.records.RecordSerdeShapeResolver;
 import io.micronaut.serde.processor.sourcegen.records.RecordSerializerSourceGen;
-import io.micronaut.serde.annotation.Serdeable;
-import io.micronaut.serde.Deserializer;
-import io.micronaut.serde.Serializer;
 import io.micronaut.sourcegen.generator.SourceGenerator;
 import io.micronaut.sourcegen.generator.SourceGenerators;
 import io.micronaut.sourcegen.model.AnnotationDef;
@@ -62,6 +63,7 @@ public final class SerdeSourceGenVisitor implements TypeElementVisitor<Object, O
     public Set<String> getSupportedAnnotationNames() {
         return Set.of(
             Serdeable.class.getName(),
+            SerdeableGenerated.class.getName(),
             Serdeable.Serializable.class.getName(),
             Serdeable.Deserializable.class.getName()
         );
@@ -78,6 +80,7 @@ public final class SerdeSourceGenVisitor implements TypeElementVisitor<Object, O
             return;
         }
         if (!element.hasDeclaredAnnotation(Serdeable.class)
+            && !element.hasDeclaredAnnotation(SerdeableGenerated.class)
             && !element.hasDeclaredAnnotation(Serdeable.Serializable.class)
             && !element.hasDeclaredAnnotation(Serdeable.Deserializable.class)) {
             return;

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/SimpleSerdeShapeAnalyzer.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/SimpleSerdeShapeAnalyzer.java
@@ -15,8 +15,8 @@
  */
 package io.micronaut.serde.processor.sourcegen;
 
-import io.micronaut.core.annotation.Creator;
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.Creator;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.Element;
 import io.micronaut.inject.ast.ElementQuery;
@@ -27,6 +27,7 @@ import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.ast.PropertyElement;
 import io.micronaut.serde.FormatConfiguration;
 import io.micronaut.serde.annotation.Serdeable;
+import io.micronaut.serde.annotation.SerdeableGenerated;
 import io.micronaut.serde.config.annotation.SerdeConfig;
 import io.micronaut.serde.config.naming.PropertyNamingStrategy;
 
@@ -55,6 +56,13 @@ public final class SimpleSerdeShapeAnalyzer {
         EnumSet<SimpleSerdeShapeDecision.FallbackReason> serializerReasons = EnumSet.noneOf(SimpleSerdeShapeDecision.FallbackReason.class);
         EnumSet<SimpleSerdeShapeDecision.FallbackReason> deserializerReasons = EnumSet.noneOf(SimpleSerdeShapeDecision.FallbackReason.class);
         SimpleSerdeShapeDecision.ShapeKind shapeKind = resolveShapeKind(element);
+        boolean generated = element.hasAnnotation(SerdeableGenerated.class);
+        if (isSerializerSkipped(element)) {
+            failSerializer(serializerReasons, SimpleSerdeShapeDecision.FallbackReason.SOURCEGEN_SKIPPED);
+        }
+        if (isDeserializerSkipped(element)) {
+            failDeserializer(deserializerReasons, SimpleSerdeShapeDecision.FallbackReason.SOURCEGEN_SKIPPED);
+        }
 
         if (shapeKind == SimpleSerdeShapeDecision.ShapeKind.UNSUPPORTED) {
             failBoth(serializerReasons, deserializerReasons, SimpleSerdeShapeDecision.FallbackReason.UNSUPPORTED_SHAPE);
@@ -121,7 +129,8 @@ public final class SimpleSerdeShapeAnalyzer {
             && failBoth(serializerReasons, deserializerReasons, SimpleSerdeShapeDecision.FallbackReason.UNSUPPORTED_SHAPE)) {
             return decision(shapeKind, serializerReasons, deserializerReasons);
         }
-        if (serializerReasons.isEmpty() && deserializerReasons.isEmpty()
+        if (!generated
+            && serializerReasons.isEmpty() && deserializerReasons.isEmpty()
             && hasPotentialGlobalOrderingConflict(element)
             && failBoth(serializerReasons, deserializerReasons, SimpleSerdeShapeDecision.FallbackReason.UNSUPPORTED_SHAPE)) {
             return decision(shapeKind, serializerReasons, deserializerReasons);
@@ -154,7 +163,8 @@ public final class SimpleSerdeShapeAnalyzer {
             && failBoth(serializerReasons, deserializerReasons, SimpleSerdeShapeDecision.FallbackReason.UNSUPPORTED_SHAPE)) {
             return decision(shapeKind, serializerReasons, deserializerReasons);
         }
-        if (serializerReasons.isEmpty() && deserializerReasons.isEmpty()
+        if (!generated
+            && serializerReasons.isEmpty() && deserializerReasons.isEmpty()
             && hasPotentialGlobalNamingConflict(element)
             && failBoth(serializerReasons, deserializerReasons, SimpleSerdeShapeDecision.FallbackReason.UNSUPPORTED_SHAPE)) {
             return decision(shapeKind, serializerReasons, deserializerReasons);
@@ -393,6 +403,16 @@ public final class SimpleSerdeShapeAnalyzer {
             }
         }
         return true;
+    }
+
+    private boolean isSerializerSkipped(ClassElement element) {
+        return element.booleanValue(SerdeableGenerated.class, "skip").orElse(false)
+            || element.booleanValue(SerdeableGenerated.class, "skipSerializer").orElse(false);
+    }
+
+    private boolean isDeserializerSkipped(ClassElement element) {
+        return element.booleanValue(SerdeableGenerated.class, "skip").orElse(false)
+            || element.booleanValue(SerdeableGenerated.class, "skipDeserializer").orElse(false);
     }
 
     private boolean hasDirectIterableProperties(ClassElement element) {

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/SimpleSerdeShapeDecision.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/SimpleSerdeShapeDecision.java
@@ -57,6 +57,7 @@ public record SimpleSerdeShapeDecision(
         COMPLEX_CREATOR,
         COMPLEX_ENUM,
         SUBTYPED,
+        SOURCEGEN_SKIPPED,
         UNSUPPORTED_SHAPE
     }
 }

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanDeserializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanDeserializerSourceGen.java
@@ -78,6 +78,7 @@ public final class BeanDeserializerSourceGen {
     );
     private static final Method DECODE_OBJECT_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeObject", Argument.class);
     private static final Method DECODE_KEY_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeKey");
+    private static final Method SKIP_VALUE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "skipValue");
     private static final Method DECODE_STRING_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeStringNullable");
     private static final Method DECODE_BOOLEAN_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeBoolean");
     private static final Method DECODE_BOOLEAN_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeBooleanNullable");
@@ -99,12 +100,6 @@ public final class BeanDeserializerSourceGen {
     private static final Method DECODE_BIG_DECIMAL_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeBigDecimalNullable");
     private static final Method DECODE_NULL_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeNull");
     private static final Method FINISH_STRUCTURE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "finishStructure");
-    private static final Method DUPLICATE_PROPERTY_METHOD = ReflectionUtils.getRequiredMethod(
-        GeneratedSerdeExceptionUtil.class,
-        "duplicateProperty",
-        String.class,
-        Argument.class
-    );
     private static final Method HANDLE_UNKNOWN_PROPERTY_METHOD = ReflectionUtils.getRequiredMethod(
         GeneratedSerdeExceptionUtil.class,
         "handleUnknownProperty",
@@ -397,7 +392,7 @@ public final class BeanDeserializerSourceGen {
                 handledPropertyDef,
                 keyVariable.asStatementSwitch(
                     STRING_TYPE,
-                    buildSwitchCases(deserializerClassTypeDef, properties, keyFieldNames, seenPropertyVariables, propertyDeserializers, handledPropertyVariable, type),
+                    buildSwitchCases(objectDecoder, properties, seenPropertyVariables, propertyDeserializers, handledPropertyVariable),
                     handledPropertyVariable.ifFalse(unknownPropertyStatement)
                 )
             );
@@ -406,13 +401,10 @@ public final class BeanDeserializerSourceGen {
         for (int i = properties.size() - 1; i >= 0; i--) {
             BeanSerdeShape.BeanProperty property = properties.get(i);
             ExpressionDef propertyNameExpression = deserializerClassTypeDef.getStaticField(required(keyFieldNames, property.name()), STRING_TYPE);
-            StatementDef duplicatePropertyStatement = ClassTypeDef.of(GeneratedSerdeExceptionUtil.class)
-                .invokeStatic(DUPLICATE_PROPERTY_METHOD, propertyNameExpression, type)
-                .doThrow();
             VariableDef.Local seenPropertyVariable = seenPropertyVariables.get(i);
             switchStatement = keyVariable.invoke(STRING_EQUALS_METHOD, propertyNameExpression).ifTrue(
                 seenPropertyVariable.ifTrue(
-                    duplicatePropertyStatement,
+                    objectDecoder.invoke(SKIP_VALUE_METHOD),
                     StatementDef.multi(
                         seenPropertyVariable.assign(ExpressionDef.trueValue()),
                         propertyDeserializers.get(i)
@@ -424,29 +416,25 @@ public final class BeanDeserializerSourceGen {
         return switchStatement;
     }
 
-    private Map<ExpressionDef.Constant, StatementDef> buildSwitchCases(ClassTypeDef deserializerClassTypeDef,
+    private Map<ExpressionDef.Constant, StatementDef> buildSwitchCases(VariableDef objectDecoder,
                                                                        List<BeanSerdeShape.BeanProperty> properties,
-                                                                       Map<String, String> keyFieldNames,
                                                                        List<VariableDef.Local> seenPropertyVariables,
                                                                        List<StatementDef> propertyDeserializers,
-                                                                       VariableDef.Local handledPropertyVariable,
-                                                                       VariableDef.MethodParameter type) {
+                                                                       VariableDef.Local handledPropertyVariable) {
         Map<ExpressionDef.Constant, StatementDef> switchCases = new LinkedHashMap<>();
         for (int i = 0; i < properties.size(); i++) {
             BeanSerdeShape.BeanProperty property = properties.get(i);
-            ExpressionDef propertyNameExpression = deserializerClassTypeDef.getStaticField(required(keyFieldNames, property.name()), STRING_TYPE);
-            StatementDef duplicatePropertyStatement = ClassTypeDef.of(GeneratedSerdeExceptionUtil.class)
-                .invokeStatic(DUPLICATE_PROPERTY_METHOD, propertyNameExpression, type)
-                .doThrow();
             VariableDef.Local seenPropertyVariable = seenPropertyVariables.get(i);
             switchCases.put(ExpressionDef.constant(property.name()),
                 handledPropertyVariable.ifFalse(
-                    seenPropertyVariable.ifTrue(
-                        duplicatePropertyStatement,
-                        StatementDef.multi(
-                            handledPropertyVariable.assign(ExpressionDef.trueValue()),
-                            seenPropertyVariable.assign(ExpressionDef.trueValue()),
-                            propertyDeserializers.get(i)
+                    StatementDef.multi(
+                        handledPropertyVariable.assign(ExpressionDef.trueValue()),
+                        seenPropertyVariable.ifTrue(
+                            objectDecoder.invoke(SKIP_VALUE_METHOD),
+                            StatementDef.multi(
+                                seenPropertyVariable.assign(ExpressionDef.trueValue()),
+                                propertyDeserializers.get(i)
+                            )
                         )
                     )
                 )
@@ -480,7 +468,10 @@ public final class BeanDeserializerSourceGen {
                 deserializeAndAssign = StatementDef.multi(
                     deserializedValueDef,
                     objectDecoder.invoke(DECODE_NULL_METHOD).ifFalse(
-                        deserializedValueDef.variable().assign(objectDecoder.invoke(scalarDecodeMethod))
+                        StatementDef.multi(
+                            deserializedValueDef.variable().assign(objectDecoder.invoke(scalarDecodeMethod)),
+                            beanVariable.invoke(property.writeMethod(), deserializedValueDef.variable())
+                        )
                     )
                 );
             } else {
@@ -514,7 +505,7 @@ public final class BeanDeserializerSourceGen {
         StatementDef assignStatement = beanVariable.invoke(property.writeMethod(), deserializedValueDef.variable());
         StatementDef propertyAssignment;
         if (primitiveScalar) {
-            propertyAssignment = assignStatement;
+            propertyAssignment = StatementDef.multi();
         } else if (property.deserializationType().isPrimitive() || property.nullable()) {
             if (property.deserializationType().isPrimitive() && !property.deserializationType().isArray()) {
                 propertyAssignment = deserializedValueDef.variable().isNull().ifTrue(

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanDeserializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanDeserializerSourceGen.java
@@ -56,10 +56,12 @@ public final class BeanDeserializerSourceGen {
     private static final TypeDef DESERIALIZER_TYPE = TypeDef.of(Deserializer.class);
     private static final TypeDef NULLABLE_DESERIALIZER_TYPE = DESERIALIZER_TYPE.annotated(AnnotationDef.builder(Nullable.class).build());
     private static final TypeDef STRING_TYPE = TypeDef.of(String.class);
+    private static final int STRING_SWITCH_PROPERTY_THRESHOLD = 5;
     private static final String CONTEXT_PARAMETER = "context";
     private static final String VALUE_LOCAL_PREFIX = "value";
     private static final String GENERATED_VALUE_MEMBER = "value";
 
+    private static final Method STRING_EQUALS_METHOD = ReflectionUtils.getRequiredMethod(String.class, "equals", Object.class);
     private static final Method FIND_DESERIALIZER_METHOD = ReflectionUtils.getRequiredMethod(Deserializer.DecoderContext.class, "findDeserializer", Argument.class);
     private static final Method CREATE_SPECIFIC_DESERIALIZER_METHOD = ReflectionUtils.getRequiredMethod(
         Deserializer.class,
@@ -77,16 +79,25 @@ public final class BeanDeserializerSourceGen {
     private static final Method DECODE_OBJECT_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeObject", Argument.class);
     private static final Method DECODE_KEY_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeKey");
     private static final Method DECODE_STRING_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeStringNullable");
+    private static final Method DECODE_BOOLEAN_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeBoolean");
     private static final Method DECODE_BOOLEAN_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeBooleanNullable");
+    private static final Method DECODE_BYTE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeByte");
     private static final Method DECODE_BYTE_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeByteNullable");
+    private static final Method DECODE_SHORT_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeShort");
     private static final Method DECODE_SHORT_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeShortNullable");
+    private static final Method DECODE_CHAR_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeChar");
     private static final Method DECODE_CHAR_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeCharNullable");
+    private static final Method DECODE_INT_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeInt");
     private static final Method DECODE_INT_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeIntNullable");
+    private static final Method DECODE_LONG_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeLong");
     private static final Method DECODE_LONG_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeLongNullable");
+    private static final Method DECODE_FLOAT_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeFloat");
     private static final Method DECODE_FLOAT_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeFloatNullable");
+    private static final Method DECODE_DOUBLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeDouble");
     private static final Method DECODE_DOUBLE_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeDoubleNullable");
     private static final Method DECODE_BIG_INTEGER_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeBigIntegerNullable");
     private static final Method DECODE_BIG_DECIMAL_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeBigDecimalNullable");
+    private static final Method DECODE_NULL_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeNull");
     private static final Method FINISH_STRUCTURE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "finishStructure");
     private static final Method DUPLICATE_PROPERTY_METHOD = ReflectionUtils.getRequiredMethod(
         GeneratedSerdeExceptionUtil.class,
@@ -148,8 +159,8 @@ public final class BeanDeserializerSourceGen {
 
         int index = 0;
         for (BeanSerdeShape.BeanProperty property : beanSerdeShape.properties()) {
-            String keyFieldName = constantFieldName("KEY", property.name(), index);
-            String argumentFieldName = constantFieldName("ARGUMENT", property.name(), index);
+            String keyFieldName = indexedName("KEY", index);
+            String argumentFieldName = indexedName("ARGUMENT", index);
             keyFieldNames.put(property.name(), keyFieldName);
             argumentFieldNames.put(property.name(), argumentFieldName);
 
@@ -163,7 +174,7 @@ public final class BeanDeserializerSourceGen {
                 .initializer(BeanSerdeSourceGenUtils.argumentExpression(lookupType))
                 .build());
             if (scalarDecoderMethod(property.deserializationType()) == null) {
-                String deserializerFieldName = constantFieldName("DESERIALIZER", property.name(), index);
+                String deserializerFieldName = indexedName("DESERIALIZER", index);
                 deserializerFieldNames.put(property.name(), deserializerFieldName);
                 fields.add(FieldDef.builder(deserializerFieldName, DESERIALIZER_TYPE)
                     .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
@@ -185,6 +196,11 @@ public final class BeanDeserializerSourceGen {
             .addMethod(generateCreateSpecificMethod(beanTypeDef, deserializerClassTypeDef, argumentFieldNames, deserializerFieldNames))
             .addMethod(generateDeserializeMethod(element, beanTypeDef, deserializerClassTypeDef, beanSerdeShape, keyFieldNames, argumentFieldNames, deserializerFieldNames));
 
+        if (beanSerdeShape.properties().size() > STRING_SWITCH_PROPERTY_THRESHOLD) {
+            classDefBuilder.addAnnotation(AnnotationDef.builder(SuppressWarnings.class)
+                .addMember(GENERATED_VALUE_MEMBER, "FallThrough")
+                .build());
+        }
         if (!deserializerFieldNames.isEmpty()) {
             classDefBuilder.addMethod(generateSpecializedConstructor(deserializerFieldNames));
         }
@@ -249,7 +265,7 @@ public final class BeanDeserializerSourceGen {
                     ExpressionDef argumentExpression = deserializerClassTypeDef.getStaticField(argumentFieldName, ARGUMENT_TYPE);
                     StatementDef.DefineAndAssign deserializerDef = context.invoke(FIND_DESERIALIZER_METHOD, argumentExpression)
                         .invoke(CREATE_SPECIFIC_DESERIALIZER_METHOD, context, argumentExpression)
-                        .newLocal(BeanSerdeSourceGenUtils.localName("deserializer", propertyName, index));
+                        .newLocal(BeanSerdeSourceGenUtils.localName("deserializer", index));
                     statements.add(deserializerDef);
                     deserializerValues.add(deserializerDef.variable());
                     constructorParameterTypes.add(DESERIALIZER_TYPE);
@@ -300,9 +316,8 @@ public final class BeanDeserializerSourceGen {
                 List<BeanSerdeShape.BeanProperty> properties = beanSerdeShape.properties();
                 List<VariableDef.Local> seenPropertyVariables = new ArrayList<>(properties.size());
                 for (int i = 0; i < properties.size(); i++) {
-                    BeanSerdeShape.BeanProperty property = properties.get(i);
                     StatementDef.DefineAndAssign seenPropertyDef = ExpressionDef.falseValue()
-                        .newLocal(BeanSerdeSourceGenUtils.localName("seenProperty", property.name(), i));
+                        .newLocal(BeanSerdeSourceGenUtils.localName("seenProperty", i));
                     statements.add(seenPropertyDef);
                     seenPropertyVariables.add(seenPropertyDef.variable());
                 }
@@ -348,16 +363,12 @@ public final class BeanDeserializerSourceGen {
                     seenPropertyVariables,
                     propertyDeserializers
                 );
-                if (properties.isEmpty()) {
-                    statements.add(keyVariable.isNonNull().whileLoop(switchStatement));
-                } else {
-                    statements.add(keyVariable.isNonNull().whileLoop(
-                        StatementDef.multi(
-                            switchStatement,
-                            keyVariable.assign(objectDecoder.invoke(DECODE_KEY_METHOD))
-                        )
-                    ));
-                }
+                statements.add(keyVariable.isNonNull().whileLoop(
+                    StatementDef.multi(
+                        switchStatement,
+                        keyVariable.assign(objectDecoder.invoke(DECODE_KEY_METHOD))
+                    )
+                ));
                 statements.add(objectDecoder.invoke(FINISH_STRUCTURE_METHOD));
                 statements.add(beanVariable.returning());
 
@@ -379,18 +390,17 @@ public final class BeanDeserializerSourceGen {
         if (properties.isEmpty()) {
             return unknownPropertyStatement;
         }
-        if (properties.size() > 3) {
-            return keyVariable.asExpressionSwitch(
-                TypeDef.Primitive.BOOLEAN,
-                buildSwitchCases(deserializerClassTypeDef, properties, keyFieldNames, seenPropertyVariables, propertyDeserializers, type),
-                new ExpressionDef.SwitchYieldCase(
-                    TypeDef.Primitive.BOOLEAN,
-                    StatementDef.multi(
-                        unknownPropertyStatement,
-                        ExpressionDef.trueValue().returning()
-                    )
+        if (properties.size() > STRING_SWITCH_PROPERTY_THRESHOLD) {
+            StatementDef.DefineAndAssign handledPropertyDef = ExpressionDef.falseValue().newLocal("handledProperty");
+            VariableDef.Local handledPropertyVariable = handledPropertyDef.variable();
+            return StatementDef.multi(
+                handledPropertyDef,
+                keyVariable.asStatementSwitch(
+                    STRING_TYPE,
+                    buildSwitchCases(deserializerClassTypeDef, properties, keyFieldNames, seenPropertyVariables, propertyDeserializers, handledPropertyVariable, type),
+                    handledPropertyVariable.ifFalse(unknownPropertyStatement)
                 )
-            ).newLocal("switchResult");
+            );
         }
         StatementDef switchStatement = unknownPropertyStatement;
         for (int i = properties.size() - 1; i >= 0; i--) {
@@ -400,7 +410,7 @@ public final class BeanDeserializerSourceGen {
                 .invokeStatic(DUPLICATE_PROPERTY_METHOD, propertyNameExpression, type)
                 .doThrow();
             VariableDef.Local seenPropertyVariable = seenPropertyVariables.get(i);
-            switchStatement = keyVariable.equalsStructurally(propertyNameExpression).ifTrue(
+            switchStatement = keyVariable.invoke(STRING_EQUALS_METHOD, propertyNameExpression).ifTrue(
                 seenPropertyVariable.ifTrue(
                     duplicatePropertyStatement,
                     StatementDef.multi(
@@ -414,13 +424,14 @@ public final class BeanDeserializerSourceGen {
         return switchStatement;
     }
 
-    private Map<ExpressionDef.Constant, ExpressionDef> buildSwitchCases(ClassTypeDef deserializerClassTypeDef,
-                                                                        List<BeanSerdeShape.BeanProperty> properties,
-                                                                        Map<String, String> keyFieldNames,
-                                                                        List<VariableDef.Local> seenPropertyVariables,
-                                                                        List<StatementDef> propertyDeserializers,
-                                                                        VariableDef.MethodParameter type) {
-        Map<ExpressionDef.Constant, ExpressionDef> switchCases = new LinkedHashMap<>();
+    private Map<ExpressionDef.Constant, StatementDef> buildSwitchCases(ClassTypeDef deserializerClassTypeDef,
+                                                                       List<BeanSerdeShape.BeanProperty> properties,
+                                                                       Map<String, String> keyFieldNames,
+                                                                       List<VariableDef.Local> seenPropertyVariables,
+                                                                       List<StatementDef> propertyDeserializers,
+                                                                       VariableDef.Local handledPropertyVariable,
+                                                                       VariableDef.MethodParameter type) {
+        Map<ExpressionDef.Constant, StatementDef> switchCases = new LinkedHashMap<>();
         for (int i = 0; i < properties.size(); i++) {
             BeanSerdeShape.BeanProperty property = properties.get(i);
             ExpressionDef propertyNameExpression = deserializerClassTypeDef.getStaticField(required(keyFieldNames, property.name()), STRING_TYPE);
@@ -429,17 +440,14 @@ public final class BeanDeserializerSourceGen {
                 .doThrow();
             VariableDef.Local seenPropertyVariable = seenPropertyVariables.get(i);
             switchCases.put(ExpressionDef.constant(property.name()),
-                new ExpressionDef.SwitchYieldCase(
-                    TypeDef.Primitive.BOOLEAN,
-                    StatementDef.multi(
-                        seenPropertyVariable.ifTrue(
-                            duplicatePropertyStatement,
-                            StatementDef.multi(
-                                seenPropertyVariable.assign(ExpressionDef.trueValue()),
-                                propertyDeserializers.get(i)
-                            )
-                        ),
-                        ExpressionDef.trueValue().returning()
+                handledPropertyVariable.ifFalse(
+                    seenPropertyVariable.ifTrue(
+                        duplicatePropertyStatement,
+                        StatementDef.multi(
+                            handledPropertyVariable.assign(ExpressionDef.trueValue()),
+                            seenPropertyVariable.assign(ExpressionDef.trueValue()),
+                            propertyDeserializers.get(i)
+                        )
                     )
                 )
             );
@@ -462,17 +470,29 @@ public final class BeanDeserializerSourceGen {
         ExpressionDef argumentExpression = deserializerClassTypeDef.getStaticField(required(argumentFieldNames, property.name()), ARGUMENT_TYPE);
         ExpressionDef propertyNameExpression = deserializerClassTypeDef.getStaticField(required(keyFieldNames, property.name()), STRING_TYPE);
         Method scalarDecodeMethod = scalarDecoderMethod(property.deserializationType());
+        boolean primitiveScalar = scalarDecodeMethod != null && property.deserializationType().isPrimitive() && !property.deserializationType().isArray();
         StatementDef.DefineAndAssign deserializedValueDef;
         StatementDef deserializeAndAssign;
         if (scalarDecodeMethod != null) {
-            deserializedValueDef = objectDecoder.invoke(scalarDecodeMethod)
-                .cast(BeanSerdeSourceGenUtils.deserializedCastType(property.deserializationType()))
-                .newLocal(BeanSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, property.name(), index));
-            deserializeAndAssign = deserializedValueDef;
+            if (primitiveScalar) {
+                deserializedValueDef = BeanSerdeSourceGenUtils.primitiveDefaultValueExpression(property.deserializationType())
+                    .newLocal(BeanSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
+                deserializeAndAssign = StatementDef.multi(
+                    deserializedValueDef,
+                    objectDecoder.invoke(DECODE_NULL_METHOD).ifFalse(
+                        deserializedValueDef.variable().assign(objectDecoder.invoke(scalarDecodeMethod))
+                    )
+                );
+            } else {
+                deserializedValueDef = objectDecoder.invoke(scalarDecodeMethod)
+                    .cast(BeanSerdeSourceGenUtils.deserializedCastType(property.deserializationType()))
+                    .newLocal(BeanSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
+                deserializeAndAssign = deserializedValueDef;
+            }
         } else {
             String deserializerFieldName = required(deserializerFieldNames, property.name());
             StatementDef.DefineAndAssign deserializerDef = new StatementDef.DefineAndAssign(
-                new VariableDef.Local(BeanSerdeSourceGenUtils.localName("deserializer", property.name(), index), NULLABLE_DESERIALIZER_TYPE),
+                new VariableDef.Local(BeanSerdeSourceGenUtils.localName("deserializer", index), NULLABLE_DESERIALIZER_TYPE),
                 aThis.field(deserializerFieldName, DESERIALIZER_TYPE)
             );
             StatementDef initializeDeserializerStatement = deserializerDef.variable().isNull().ifTrue(
@@ -484,7 +504,7 @@ public final class BeanDeserializerSourceGen {
                 objectDecoder,
                 context,
                 argumentExpression
-            ).cast(BeanSerdeSourceGenUtils.deserializedCastType(property.deserializationType())).newLocal(BeanSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, property.name(), index));
+            ).cast(BeanSerdeSourceGenUtils.deserializedCastType(property.deserializationType())).newLocal(BeanSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
             deserializeAndAssign = StatementDef.multi(
                 deserializerDef,
                 initializeDeserializerStatement,
@@ -493,7 +513,9 @@ public final class BeanDeserializerSourceGen {
         }
         StatementDef assignStatement = beanVariable.invoke(property.writeMethod(), deserializedValueDef.variable());
         StatementDef propertyAssignment;
-        if (property.deserializationType().isPrimitive() || property.nullable()) {
+        if (primitiveScalar) {
+            propertyAssignment = assignStatement;
+        } else if (property.deserializationType().isPrimitive() || property.nullable()) {
             if (property.deserializationType().isPrimitive() && !property.deserializationType().isArray()) {
                 propertyAssignment = deserializedValueDef.variable().isNull().ifTrue(
                     beanVariable.invoke(property.writeMethod(), BeanSerdeSourceGenUtils.primitiveDefaultValueExpression(property.deserializationType())),
@@ -526,8 +548,8 @@ public final class BeanDeserializerSourceGen {
             );
     }
 
-    private String constantFieldName(String prefix, String propertyName, int index) {
-        return prefix + "_" + propertyName.replaceAll("[^A-Za-z0-9]", "_").toUpperCase() + "_" + index;
+    private String indexedName(String prefix, int index) {
+        return prefix + "_" + index;
     }
 
     private @Nullable Method scalarDecoderMethod(ClassElement type) {
@@ -535,14 +557,22 @@ public final class BeanDeserializerSourceGen {
             return null;
         }
         return switch (type.getName()) {
-            case "boolean", "java.lang.Boolean" -> DECODE_BOOLEAN_NULLABLE_METHOD;
-            case "byte", "java.lang.Byte" -> DECODE_BYTE_NULLABLE_METHOD;
-            case "short", "java.lang.Short" -> DECODE_SHORT_NULLABLE_METHOD;
-            case "char", "java.lang.Character" -> DECODE_CHAR_NULLABLE_METHOD;
-            case "int", "java.lang.Integer" -> DECODE_INT_NULLABLE_METHOD;
-            case "long", "java.lang.Long" -> DECODE_LONG_NULLABLE_METHOD;
-            case "float", "java.lang.Float" -> DECODE_FLOAT_NULLABLE_METHOD;
-            case "double", "java.lang.Double" -> DECODE_DOUBLE_NULLABLE_METHOD;
+            case "boolean" -> DECODE_BOOLEAN_METHOD;
+            case "java.lang.Boolean" -> DECODE_BOOLEAN_NULLABLE_METHOD;
+            case "byte" -> DECODE_BYTE_METHOD;
+            case "java.lang.Byte" -> DECODE_BYTE_NULLABLE_METHOD;
+            case "short" -> DECODE_SHORT_METHOD;
+            case "java.lang.Short" -> DECODE_SHORT_NULLABLE_METHOD;
+            case "char" -> DECODE_CHAR_METHOD;
+            case "java.lang.Character" -> DECODE_CHAR_NULLABLE_METHOD;
+            case "int" -> DECODE_INT_METHOD;
+            case "java.lang.Integer" -> DECODE_INT_NULLABLE_METHOD;
+            case "long" -> DECODE_LONG_METHOD;
+            case "java.lang.Long" -> DECODE_LONG_NULLABLE_METHOD;
+            case "float" -> DECODE_FLOAT_METHOD;
+            case "java.lang.Float" -> DECODE_FLOAT_NULLABLE_METHOD;
+            case "double" -> DECODE_DOUBLE_METHOD;
+            case "java.lang.Double" -> DECODE_DOUBLE_NULLABLE_METHOD;
             case "java.lang.String" -> DECODE_STRING_NULLABLE_METHOD;
             case "java.math.BigInteger" -> DECODE_BIG_INTEGER_NULLABLE_METHOD;
             case "java.math.BigDecimal" -> DECODE_BIG_DECIMAL_NULLABLE_METHOD;

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanDeserializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanDeserializerSourceGen.java
@@ -459,27 +459,30 @@ public final class BeanDeserializerSourceGen {
         ExpressionDef propertyNameExpression = deserializerClassTypeDef.getStaticField(required(keyFieldNames, property.name()), STRING_TYPE);
         Method scalarDecodeMethod = scalarDecoderMethod(property.deserializationType());
         boolean primitiveScalar = scalarDecodeMethod != null && property.deserializationType().isPrimitive() && !property.deserializationType().isArray();
+        if (scalarDecodeMethod != null && primitiveScalar) {
+            StatementDef deserializeAndAssign = objectDecoder.invoke(DECODE_NULL_METHOD).ifFalse(
+                beanVariable.invoke(property.writeMethod(), objectDecoder.invoke(scalarDecodeMethod))
+            );
+            return StatementDef.doTry(deserializeAndAssign)
+                .doCatch(ClassTypeDef.of(Throwable.class), exceptionVariable ->
+                    ClassTypeDef.of(GeneratedSerdeExceptionUtil.class)
+                        .invokeStatic(
+                            WITH_PROPERTY_PATH_THROWABLE_METHOD,
+                            exceptionVariable,
+                            type,
+                            propertyNameExpression,
+                            argumentExpression
+                        )
+                        .doThrow()
+                );
+        }
         StatementDef.DefineAndAssign deserializedValueDef;
         StatementDef deserializeAndAssign;
         if (scalarDecodeMethod != null) {
-            if (primitiveScalar) {
-                deserializedValueDef = BeanSerdeSourceGenUtils.primitiveDefaultValueExpression(property.deserializationType())
-                    .newLocal(BeanSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
-                deserializeAndAssign = StatementDef.multi(
-                    deserializedValueDef,
-                    objectDecoder.invoke(DECODE_NULL_METHOD).ifFalse(
-                        StatementDef.multi(
-                            deserializedValueDef.variable().assign(objectDecoder.invoke(scalarDecodeMethod)),
-                            beanVariable.invoke(property.writeMethod(), deserializedValueDef.variable())
-                        )
-                    )
-                );
-            } else {
-                deserializedValueDef = objectDecoder.invoke(scalarDecodeMethod)
-                    .cast(BeanSerdeSourceGenUtils.deserializedCastType(property.deserializationType()))
-                    .newLocal(BeanSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
-                deserializeAndAssign = deserializedValueDef;
-            }
+            deserializedValueDef = objectDecoder.invoke(scalarDecodeMethod)
+                .cast(BeanSerdeSourceGenUtils.deserializedCastType(property.deserializationType()))
+                .newLocal(BeanSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
+            deserializeAndAssign = deserializedValueDef;
         } else {
             String deserializerFieldName = required(deserializerFieldNames, property.name());
             StatementDef.DefineAndAssign deserializerDef = new StatementDef.DefineAndAssign(
@@ -502,11 +505,9 @@ public final class BeanDeserializerSourceGen {
                 deserializedValueDef
             );
         }
-        StatementDef assignStatement = beanVariable.invoke(property.writeMethod(), deserializedValueDef.variable());
         StatementDef propertyAssignment;
-        if (primitiveScalar) {
-            propertyAssignment = StatementDef.multi();
-        } else if (property.deserializationType().isPrimitive() || property.nullable()) {
+        if (property.deserializationType().isPrimitive() || property.nullable()) {
+            StatementDef assignStatement = beanVariable.invoke(property.writeMethod(), deserializedValueDef.variable());
             if (property.deserializationType().isPrimitive() && !property.deserializationType().isArray()) {
                 propertyAssignment = deserializedValueDef.variable().isNull().ifTrue(
                     beanVariable.invoke(property.writeMethod(), BeanSerdeSourceGenUtils.primitiveDefaultValueExpression(property.deserializationType())),
@@ -516,6 +517,7 @@ public final class BeanDeserializerSourceGen {
                 propertyAssignment = assignStatement;
             }
         } else {
+            StatementDef assignStatement = beanVariable.invoke(property.writeMethod(), deserializedValueDef.variable());
             propertyAssignment = deserializedValueDef.variable().isNull().ifTrue(
                 StatementDef.multi(),
                 assignStatement

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanSerdeSourceGenUtils.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanSerdeSourceGenUtils.java
@@ -206,7 +206,7 @@ final class BeanSerdeSourceGenUtils {
         };
     }
 
-    static String localName(String prefix, String componentName, int index) {
-        return prefix + componentName.replace("$", "_") + index;
+    static String localName(String prefix, int index) {
+        return prefix + index;
     }
 }

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanSerializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanSerializerSourceGen.java
@@ -121,8 +121,8 @@ public final class BeanSerializerSourceGen {
 
         int index = 0;
         for (BeanSerdeShape.BeanProperty property : beanSerdeShape.properties()) {
-            String keyFieldName = constantFieldName("KEY", property.name(), index);
-            String argumentFieldName = constantFieldName("ARGUMENT", property.name(), index);
+            String keyFieldName = indexedName("KEY", index);
+            String argumentFieldName = indexedName("ARGUMENT", index);
             keyFieldNames.put(property.name(), keyFieldName);
             argumentFieldNames.put(property.name(), argumentFieldName);
 
@@ -135,7 +135,7 @@ public final class BeanSerializerSourceGen {
                 .initializer(BeanSerdeSourceGenUtils.argumentExpression(property.serializationType()))
                 .build());
             if (scalarEncoderMethod(property.serializationType()) == null) {
-                String serializerFieldName = constantFieldName("SERIALIZER", property.name(), index);
+                String serializerFieldName = indexedName("SERIALIZER", index);
                 serializerFieldNames.put(property.name(), serializerFieldName);
                 fields.add(FieldDef.builder(serializerFieldName, SERIALIZER_TYPE)
                     .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
@@ -156,7 +156,7 @@ public final class BeanSerializerSourceGen {
             .addFields(fields)
             .addMethod(generateNoArgsConstructor(serializerFieldNames))
             .addMethod(generateCreateSpecificMethod(beanTypeDef, serializerClassTypeDef, argumentFieldNames, serializerFieldNames))
-            .addMethod(generateSerializeMethod(beanTypeDef, serializerClassTypeDef, beanSerdeShape, keyFieldNames, argumentFieldNames, serializerFieldNames))
+            .addMethod(generateSerializeMethod(beanTypeDef))
             .addMethod(generateSerializeIntoMethod(beanTypeDef, serializerClassTypeDef, beanSerdeShape, keyFieldNames, argumentFieldNames, serializerFieldNames));
 
         if (!serializerFieldNames.isEmpty()) {
@@ -224,7 +224,7 @@ public final class BeanSerializerSourceGen {
                     ExpressionDef argumentExpression = serializerClassTypeDef.getStaticField(argumentFieldName, ARGUMENT_TYPE);
                     StatementDef.DefineAndAssign serializerDef = context.invoke(FIND_SERIALIZER_METHOD, argumentExpression)
                         .invoke(CREATE_SPECIFIC_SERIALIZER_METHOD, context, argumentExpression)
-                        .newLocal(BeanSerdeSourceGenUtils.localName("serializer", propertyName, index));
+                        .newLocal(BeanSerdeSourceGenUtils.localName("serializer", index));
                     statements.add(serializerDef);
                     serializerValues.add(serializerDef.variable());
                     constructorParameterTypes.add(SERIALIZER_TYPE);
@@ -243,12 +243,7 @@ public final class BeanSerializerSourceGen {
             });
     }
 
-    private MethodDef generateSerializeMethod(TypeDef beanTypeDef,
-                                              ClassTypeDef serializerClassTypeDef,
-                                              BeanSerdeShape beanSerdeShape,
-                                              Map<String, String> keyFieldNames,
-                                              Map<String, String> argumentFieldNames,
-                                              Map<String, String> serializerFieldNames) {
+    private MethodDef generateSerializeMethod(TypeDef beanTypeDef) {
         return MethodDef.builder("serialize")
             .addModifiers(Modifier.PUBLIC)
             .overrides()
@@ -266,7 +261,7 @@ public final class BeanSerializerSourceGen {
                 List<StatementDef> objectStatements = new ArrayList<>();
                 StatementDef.DefineAndAssign objectEncoderDef = encoder.invoke(ENCODE_OBJECT_METHOD, type).newLocal("objectEncoder");
                 objectStatements.add(objectEncoderDef);
-                objectStatements.addAll(serializeIntoStatements(aThis, serializerClassTypeDef, objectEncoderDef.variable(), context, type, value, beanSerdeShape, keyFieldNames, argumentFieldNames, serializerFieldNames));
+                objectStatements.add(aThis.invoke("serializeInto", TypeDef.VOID, objectEncoderDef.variable(), context, type, value));
                 objectStatements.add(objectEncoderDef.variable().invoke(FINISH_STRUCTURE_METHOD));
 
                 return value.isNull().ifTrue(
@@ -310,7 +305,7 @@ public final class BeanSerializerSourceGen {
         int index = 0;
         for (BeanSerdeShape.BeanProperty property : beanSerdeShape.properties()) {
             statements.add(encoder.invoke(ENCODE_KEY_METHOD, serializerClassTypeDef.getStaticField(required(keyFieldNames, property.name()), STRING_TYPE)));
-            statements.add(serializeProperty(aThis, serializerClassTypeDef, encoder, context, type, value, property, index++, argumentFieldNames, serializerFieldNames));
+            statements.add(serializeProperty(aThis, serializerClassTypeDef, encoder, context, type, value, property, index++, keyFieldNames, argumentFieldNames, serializerFieldNames));
         }
         return statements;
     }
@@ -324,9 +319,11 @@ public final class BeanSerializerSourceGen {
                                            VariableDef.MethodParameter value,
                                            BeanSerdeShape.BeanProperty property,
                                            int index,
+                                           Map<String, String> keyFieldNames,
                                            Map<String, String> argumentFieldNames,
                                            Map<String, String> serializerFieldNames) {
         ExpressionDef argumentExpression = serializerClassTypeDef.getStaticField(required(argumentFieldNames, property.name()), ARGUMENT_TYPE);
+        ExpressionDef propertyNameExpression = serializerClassTypeDef.getStaticField(required(keyFieldNames, property.name()), STRING_TYPE);
         Method scalarMethod = scalarEncoderMethod(property.serializationType());
         ExpressionDef propertyValue = value.invoke(property.readMethod());
         if (scalarMethod != null) {
@@ -334,7 +331,7 @@ public final class BeanSerializerSourceGen {
             if (property.serializationType().isPrimitive() && !property.serializationType().isArray()) {
                 scalarStatement = objectEncoder.invoke(scalarMethod, propertyValue);
             } else {
-                StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(BeanSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, property.name(), index));
+                StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(BeanSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
                 scalarStatement = StatementDef.multi(
                     propertyValueDef,
                     propertyValueDef.variable().isNull().ifTrue(
@@ -343,11 +340,11 @@ public final class BeanSerializerSourceGen {
                     )
                 );
             }
-            return wrapWithPropertyPath(scalarStatement, type, property.name(), argumentExpression);
+            return wrapWithPropertyPath(scalarStatement, type, propertyNameExpression, argumentExpression);
         }
         String serializerFieldName = required(serializerFieldNames, property.name());
         StatementDef.DefineAndAssign serializerDef = new StatementDef.DefineAndAssign(
-            new VariableDef.Local(BeanSerdeSourceGenUtils.localName("serializer", property.name(), index), NULLABLE_SERIALIZER_TYPE),
+            new VariableDef.Local(BeanSerdeSourceGenUtils.localName("serializer", index), NULLABLE_SERIALIZER_TYPE),
             aThis.field(serializerFieldName, SERIALIZER_TYPE)
         );
         StatementDef initializeSerializerStatement = serializerDef.variable().isNull().ifTrue(
@@ -367,9 +364,9 @@ public final class BeanSerializerSourceGen {
             )
         );
         if (property.serializationType().isPrimitive() && !property.serializationType().isArray()) {
-            return wrapWithPropertyPath(serializeStatement, type, property.name(), argumentExpression);
+            return wrapWithPropertyPath(serializeStatement, type, propertyNameExpression, argumentExpression);
         }
-        StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(BeanSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, property.name(), index));
+        StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(BeanSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
         return wrapWithPropertyPath(StatementDef.multi(
             propertyValueDef,
             propertyValueDef.variable().isNull().ifTrue(
@@ -386,11 +383,11 @@ public final class BeanSerializerSourceGen {
                     )
                 )
             )
-        ), type, property.name(), argumentExpression);
+        ), type, propertyNameExpression, argumentExpression);
     }
 
-    private String constantFieldName(String prefix, String propertyName, int index) {
-        return prefix + "_" + propertyName.replaceAll("[^A-Za-z0-9]", "_").toUpperCase() + "_" + index;
+    private String indexedName(String prefix, int index) {
+        return prefix + "_" + index;
     }
 
     private @Nullable Method scalarEncoderMethod(ClassElement type) {
@@ -412,7 +409,7 @@ public final class BeanSerializerSourceGen {
 
     private StatementDef wrapWithPropertyPath(StatementDef statement,
                                               VariableDef.MethodParameter type,
-                                              String propertyName,
+                                              ExpressionDef propertyNameExpression,
                                               ExpressionDef argumentExpression) {
         return StatementDef.doTry(statement)
             .doCatch(ClassTypeDef.of(Throwable.class), exceptionVariable ->
@@ -421,7 +418,7 @@ public final class BeanSerializerSourceGen {
                         WITH_PROPERTY_PATH_THROWABLE_METHOD,
                         exceptionVariable,
                         type,
-                        ExpressionDef.constant(propertyName),
+                        propertyNameExpression,
                         argumentExpression
                     )
                     .doThrow()

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordDeserializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordDeserializerSourceGen.java
@@ -76,6 +76,7 @@ public final class RecordDeserializerSourceGen {
     );
     private static final Method DECODE_OBJECT_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeObject", Argument.class);
     private static final Method DECODE_KEY_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeKey");
+    private static final Method SKIP_VALUE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "skipValue");
     private static final Method DECODE_STRING_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeStringNullable");
     private static final Method DECODE_BOOLEAN_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeBoolean");
     private static final Method DECODE_BOOLEAN_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeBooleanNullable");
@@ -97,12 +98,6 @@ public final class RecordDeserializerSourceGen {
     private static final Method DECODE_BIG_DECIMAL_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeBigDecimalNullable");
     private static final Method DECODE_NULL_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeNull");
     private static final Method FINISH_STRUCTURE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "finishStructure");
-    private static final Method DUPLICATE_PROPERTY_METHOD = ReflectionUtils.getRequiredMethod(
-        GeneratedSerdeExceptionUtil.class,
-        "duplicateProperty",
-        String.class,
-        Argument.class
-    );
     private static final Method HANDLE_UNKNOWN_PROPERTY_METHOD = ReflectionUtils.getRequiredMethod(
         GeneratedSerdeExceptionUtil.class,
         "handleUnknownProperty",
@@ -378,7 +373,7 @@ public final class RecordDeserializerSourceGen {
                 handledPropertyDef,
                 keyVariable.asStatementSwitch(
                     STRING_TYPE,
-                    buildSwitchCases(deserializerClassTypeDef, components, keyFieldNames, seenPropertyVariables, componentDeserializers, handledPropertyVariable, type),
+                    buildSwitchCases(objectDecoder, components, seenPropertyVariables, componentDeserializers, handledPropertyVariable),
                     handledPropertyVariable.ifFalse(unknownPropertyStatement)
                 )
             );
@@ -387,13 +382,10 @@ public final class RecordDeserializerSourceGen {
         for (int i = components.size() - 1; i >= 0; i--) {
             RecordSerdeShape.RecordComponent component = components.get(i);
             ExpressionDef componentNameExpression = deserializerClassTypeDef.getStaticField(required(keyFieldNames, component.name()), STRING_TYPE);
-            StatementDef duplicatePropertyStatement = ClassTypeDef.of(GeneratedSerdeExceptionUtil.class)
-                .invokeStatic(DUPLICATE_PROPERTY_METHOD, componentNameExpression, type)
-                .doThrow();
             VariableDef.Local seenPropertyVariable = seenPropertyVariables.get(i);
             switchStatement = keyVariable.invoke(STRING_EQUALS_METHOD, componentNameExpression).ifTrue(
                 seenPropertyVariable.ifTrue(
-                    duplicatePropertyStatement,
+                    objectDecoder.invoke(SKIP_VALUE_METHOD),
                     StatementDef.multi(
                         seenPropertyVariable.assign(ExpressionDef.trueValue()),
                         componentDeserializers.get(i)
@@ -405,29 +397,25 @@ public final class RecordDeserializerSourceGen {
         return switchStatement;
     }
 
-    private Map<ExpressionDef.Constant, StatementDef> buildSwitchCases(ClassTypeDef deserializerClassTypeDef,
+    private Map<ExpressionDef.Constant, StatementDef> buildSwitchCases(VariableDef objectDecoder,
                                                                        List<RecordSerdeShape.RecordComponent> components,
-                                                                       Map<String, String> keyFieldNames,
                                                                        List<VariableDef.Local> seenPropertyVariables,
                                                                        List<StatementDef> componentDeserializers,
-                                                                       VariableDef.Local handledPropertyVariable,
-                                                                       VariableDef.MethodParameter type) {
+                                                                       VariableDef.Local handledPropertyVariable) {
         Map<ExpressionDef.Constant, StatementDef> switchCases = new LinkedHashMap<>();
         for (int i = 0; i < components.size(); i++) {
             RecordSerdeShape.RecordComponent component = components.get(i);
-            ExpressionDef componentNameExpression = deserializerClassTypeDef.getStaticField(required(keyFieldNames, component.name()), STRING_TYPE);
-            StatementDef duplicatePropertyStatement = ClassTypeDef.of(GeneratedSerdeExceptionUtil.class)
-                .invokeStatic(DUPLICATE_PROPERTY_METHOD, componentNameExpression, type)
-                .doThrow();
             VariableDef.Local seenPropertyVariable = seenPropertyVariables.get(i);
             switchCases.put(ExpressionDef.constant(component.name()),
                 handledPropertyVariable.ifFalse(
-                    seenPropertyVariable.ifTrue(
-                        duplicatePropertyStatement,
-                        StatementDef.multi(
-                            handledPropertyVariable.assign(ExpressionDef.trueValue()),
-                            seenPropertyVariable.assign(ExpressionDef.trueValue()),
-                            componentDeserializers.get(i)
+                    StatementDef.multi(
+                        handledPropertyVariable.assign(ExpressionDef.trueValue()),
+                        seenPropertyVariable.ifTrue(
+                            objectDecoder.invoke(SKIP_VALUE_METHOD),
+                            StatementDef.multi(
+                                seenPropertyVariable.assign(ExpressionDef.trueValue()),
+                                componentDeserializers.get(i)
+                            )
                         )
                     )
                 )
@@ -454,7 +442,8 @@ public final class RecordDeserializerSourceGen {
         StatementDef deserializeAndAssign;
         if (scalarDecodeMethod != null) {
             if (component.type().isPrimitive() && !component.type().isArray()) {
-                deserializeAndAssign = objectDecoder.invoke(DECODE_NULL_METHOD).ifFalse(
+                deserializeAndAssign = objectDecoder.invoke(DECODE_NULL_METHOD).ifTrue(
+                    valueVariable.assign(RecordSerdeSourceGenUtils.defaultValueExpression(component.type(), component.propertyElement().isNonNull())),
                     valueVariable.assign(objectDecoder.invoke(scalarDecodeMethod))
                 );
             } else {

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordDeserializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordDeserializerSourceGen.java
@@ -106,6 +106,15 @@ public final class RecordDeserializerSourceGen {
         String.class,
         Argument.class
     );
+    private static final Method CHECK_STRICT_NULLABLE_CONSTRUCTOR_PARAMETER_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeExceptionUtil.class,
+        "checkStrictNullableConstructorParameter",
+        Deserializer.DecoderContext.class,
+        Object.class,
+        Argument.class,
+        String.class,
+        Argument.class
+    );
     private static final Method WITH_RUNTIME_FALLBACK_DESERIALIZER_METHOD = ReflectionUtils.getRequiredMethod(
         GeneratedSerdeFallbackUtil.class,
         "withRuntimeObjectFallback",
@@ -342,10 +351,17 @@ public final class RecordDeserializerSourceGen {
                 statements.add(objectDecoder.invoke(FINISH_STRUCTURE_METHOD));
                 for (int i = 0; i < components.size(); i++) {
                     RecordSerdeShape.RecordComponent component = components.get(i);
-                    boolean nonNull = component.propertyElement().isNonNull();
-                    statements.add(seenPropertyVariables.get(i).ifFalse(
-                        valueVariables.get(i).assign(RecordSerdeSourceGenUtils.defaultValueExpression(component.type(), nonNull))
-                    ));
+                    if (requiresStrictNullableCheck(component)) {
+                        statements.add(ClassTypeDef.of(GeneratedSerdeExceptionUtil.class)
+                            .invokeStatic(
+                                CHECK_STRICT_NULLABLE_CONSTRUCTOR_PARAMETER_METHOD,
+                                context,
+                                valueVariables.get(i).cast(TypeDef.OBJECT),
+                                type,
+                                deserializerClassTypeDef.getStaticField(required(keyFieldNames, component.name()), STRING_TYPE),
+                                deserializerClassTypeDef.getStaticField(required(argumentFieldNames, component.name()), ARGUMENT_TYPE)
+                            ));
+                    }
                 }
                 statements.add(ClassTypeDef.of(element).instantiate(recordSerdeShape.canonicalConstructor(), constructorValues).returning());
                 return StatementDef.multi(statements);
@@ -491,6 +507,12 @@ public final class RecordDeserializerSourceGen {
 
     private String indexedName(String prefix, int index) {
         return prefix + "_" + index;
+    }
+
+    private boolean requiresStrictNullableCheck(RecordSerdeShape.RecordComponent component) {
+        return component.propertyElement().isNonNull()
+            && !component.propertyElement().isNullable()
+            && (!component.type().isPrimitive() || component.type().isArray());
     }
 
     private static String required(Map<String, String> names, String key) {

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordDeserializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordDeserializerSourceGen.java
@@ -33,9 +33,11 @@ import io.micronaut.sourcegen.model.MethodDef;
 import io.micronaut.sourcegen.model.StatementDef;
 import io.micronaut.sourcegen.model.TypeDef;
 import io.micronaut.sourcegen.model.VariableDef;
+import jakarta.inject.Singleton;
+import org.jspecify.annotations.Nullable;
 
-import javax.lang.model.element.Modifier;
 import javax.annotation.processing.Generated;
+import javax.lang.model.element.Modifier;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -44,8 +46,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import jakarta.inject.Singleton;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Generates optimized source deserializers for records.
@@ -55,9 +55,11 @@ public final class RecordDeserializerSourceGen {
     private static final TypeDef ARGUMENT_TYPE = TypeDef.of(Argument.class);
     private static final TypeDef DESERIALIZER_TYPE = TypeDef.of(Deserializer.class);
     private static final TypeDef STRING_TYPE = TypeDef.of(String.class);
+    private static final int STRING_SWITCH_PROPERTY_THRESHOLD = 5;
     private static final String CONTEXT_PARAMETER = "context";
     private static final String GENERATED_VALUE_MEMBER = "value";
 
+    private static final Method STRING_EQUALS_METHOD = ReflectionUtils.getRequiredMethod(String.class, "equals", Object.class);
     private static final Method FIND_DESERIALIZER_METHOD = ReflectionUtils.getRequiredMethod(Deserializer.DecoderContext.class, "findDeserializer", Argument.class);
     private static final Method CREATE_SPECIFIC_DESERIALIZER_METHOD = ReflectionUtils.getRequiredMethod(
         Deserializer.class,
@@ -75,16 +77,25 @@ public final class RecordDeserializerSourceGen {
     private static final Method DECODE_OBJECT_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeObject", Argument.class);
     private static final Method DECODE_KEY_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeKey");
     private static final Method DECODE_STRING_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeStringNullable");
+    private static final Method DECODE_BOOLEAN_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeBoolean");
     private static final Method DECODE_BOOLEAN_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeBooleanNullable");
+    private static final Method DECODE_BYTE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeByte");
     private static final Method DECODE_BYTE_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeByteNullable");
+    private static final Method DECODE_SHORT_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeShort");
     private static final Method DECODE_SHORT_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeShortNullable");
+    private static final Method DECODE_CHAR_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeChar");
     private static final Method DECODE_CHAR_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeCharNullable");
+    private static final Method DECODE_INT_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeInt");
     private static final Method DECODE_INT_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeIntNullable");
+    private static final Method DECODE_LONG_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeLong");
     private static final Method DECODE_LONG_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeLongNullable");
+    private static final Method DECODE_FLOAT_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeFloat");
     private static final Method DECODE_FLOAT_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeFloatNullable");
+    private static final Method DECODE_DOUBLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeDouble");
     private static final Method DECODE_DOUBLE_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeDoubleNullable");
     private static final Method DECODE_BIG_INTEGER_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeBigIntegerNullable");
     private static final Method DECODE_BIG_DECIMAL_NULLABLE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeBigDecimalNullable");
+    private static final Method DECODE_NULL_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "decodeNull");
     private static final Method FINISH_STRUCTURE_METHOD = ReflectionUtils.getRequiredMethod(Decoder.class, "finishStructure");
     private static final Method DUPLICATE_PROPERTY_METHOD = ReflectionUtils.getRequiredMethod(
         GeneratedSerdeExceptionUtil.class,
@@ -126,8 +137,8 @@ public final class RecordDeserializerSourceGen {
 
         int index = 0;
         for (RecordSerdeShape.RecordComponent component : recordSerdeShape.components()) {
-            String keyFieldName = constantFieldName("KEY", component.name(), index);
-            String argumentFieldName = constantFieldName("ARGUMENT", component.name(), index);
+            String keyFieldName = indexedName("KEY", index);
+            String argumentFieldName = indexedName("ARGUMENT", index);
             keyFieldNames.put(component.name(), keyFieldName);
             argumentFieldNames.put(component.name(), argumentFieldName);
 
@@ -141,7 +152,7 @@ public final class RecordDeserializerSourceGen {
                 .initializer(RecordSerdeSourceGenUtils.argumentExpression(lookupType))
                 .build());
             if (scalarDecoderMethod(component.type()) == null) {
-                String deserializerFieldName = constantFieldName("DESERIALIZER", component.name(), index);
+                String deserializerFieldName = indexedName("DESERIALIZER", index);
                 deserializerFieldNames.put(component.name(), deserializerFieldName);
                 fields.add(FieldDef.builder(deserializerFieldName, DESERIALIZER_TYPE)
                     .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
@@ -163,6 +174,11 @@ public final class RecordDeserializerSourceGen {
             .addMethod(generateCreateSpecificMethod(recordTypeDef, deserializerClassTypeDef, argumentFieldNames, deserializerFieldNames))
             .addMethod(generateDeserializeMethod(element, recordTypeDef, deserializerClassTypeDef, recordSerdeShape, keyFieldNames, argumentFieldNames, deserializerFieldNames));
 
+        if (recordSerdeShape.components().size() > STRING_SWITCH_PROPERTY_THRESHOLD) {
+            classDefBuilder.addAnnotation(AnnotationDef.builder(SuppressWarnings.class)
+                .addMember(GENERATED_VALUE_MEMBER, "FallThrough")
+                .build());
+        }
         if (!deserializerFieldNames.isEmpty()) {
             classDefBuilder.addMethod(generateSpecializedConstructor(deserializerFieldNames));
         }
@@ -227,7 +243,7 @@ public final class RecordDeserializerSourceGen {
                     ExpressionDef argumentExpression = deserializerClassTypeDef.getStaticField(argumentFieldName, ARGUMENT_TYPE);
                     StatementDef.DefineAndAssign deserializerDef = context.invoke(FIND_DESERIALIZER_METHOD, argumentExpression)
                         .invoke(CREATE_SPECIFIC_DESERIALIZER_METHOD, context, argumentExpression)
-                        .newLocal(RecordSerdeSourceGenUtils.localName("deserializer", componentName, index));
+                        .newLocal(RecordSerdeSourceGenUtils.localName("deserializer", index));
                     statements.add(deserializerDef);
                     deserializerValues.add(deserializerDef.variable());
                     constructorParameterTypes.add(DESERIALIZER_TYPE);
@@ -274,22 +290,23 @@ public final class RecordDeserializerSourceGen {
                 List<RecordSerdeShape.RecordComponent> components = recordSerdeShape.components();
                 List<VariableDef.Local> seenPropertyVariables = new ArrayList<>(components.size());
                 for (int i = 0; i < components.size(); i++) {
-                    RecordSerdeShape.RecordComponent component = components.get(i);
                     StatementDef.DefineAndAssign seenPropertyDef = ExpressionDef.falseValue()
-                        .newLocal(RecordSerdeSourceGenUtils.localName("seenProperty", component.name(), i));
+                        .newLocal(RecordSerdeSourceGenUtils.localName("seenProperty", i));
                     statements.add(seenPropertyDef);
                     seenPropertyVariables.add(seenPropertyDef.variable());
                 }
 
                 List<ExpressionDef> constructorValues = new ArrayList<>(recordSerdeShape.components().size());
+                List<VariableDef> valueVariables = new ArrayList<>(components.size());
                 List<StatementDef> componentDeserializers = new ArrayList<>(components.size());
                 int index = 0;
                 for (RecordSerdeShape.RecordComponent component : components) {
                     boolean nonNull = component.propertyElement().isNonNull();
                     StatementDef.DefineAndAssign valueDef = RecordSerdeSourceGenUtils.defaultValueExpression(component.type(), nonNull)
-                        .newLocal(RecordSerdeSourceGenUtils.localName("component", component.name(), index));
+                        .newLocal(RecordSerdeSourceGenUtils.localName("propertyValue", index));
                     statements.add(valueDef);
                     VariableDef valueVariable = valueDef.variable();
+                    valueVariables.add(valueVariable);
                     constructorValues.add(valueVariable);
                     componentDeserializers.add(deserializeComponent(
                         aThis,
@@ -321,17 +338,20 @@ public final class RecordDeserializerSourceGen {
                     seenPropertyVariables,
                     componentDeserializers
                 );
-                if (components.isEmpty()) {
-                    statements.add(keyVariable.isNonNull().whileLoop(switchStatement));
-                } else {
-                    statements.add(keyVariable.isNonNull().whileLoop(
-                        StatementDef.multi(
-                            switchStatement,
-                            keyVariable.assign(objectDecoder.invoke(DECODE_KEY_METHOD))
-                        )
+                statements.add(keyVariable.isNonNull().whileLoop(
+                    StatementDef.multi(
+                        switchStatement,
+                        keyVariable.assign(objectDecoder.invoke(DECODE_KEY_METHOD))
+                    )
+                ));
+                statements.add(objectDecoder.invoke(FINISH_STRUCTURE_METHOD));
+                for (int i = 0; i < components.size(); i++) {
+                    RecordSerdeShape.RecordComponent component = components.get(i);
+                    boolean nonNull = component.propertyElement().isNonNull();
+                    statements.add(seenPropertyVariables.get(i).ifFalse(
+                        valueVariables.get(i).assign(RecordSerdeSourceGenUtils.defaultValueExpression(component.type(), nonNull))
                     ));
                 }
-                statements.add(objectDecoder.invoke(FINISH_STRUCTURE_METHOD));
                 statements.add(ClassTypeDef.of(element).instantiate(recordSerdeShape.canonicalConstructor(), constructorValues).returning());
                 return StatementDef.multi(statements);
             });
@@ -351,18 +371,17 @@ public final class RecordDeserializerSourceGen {
         if (components.isEmpty()) {
             return unknownPropertyStatement;
         }
-        if (components.size() > 3) {
-            return keyVariable.asExpressionSwitch(
-                TypeDef.Primitive.BOOLEAN,
-                buildSwitchCases(deserializerClassTypeDef, components, keyFieldNames, seenPropertyVariables, componentDeserializers, type),
-                new ExpressionDef.SwitchYieldCase(
-                    TypeDef.Primitive.BOOLEAN,
-                    StatementDef.multi(
-                        unknownPropertyStatement,
-                        ExpressionDef.trueValue().returning()
-                    )
+        if (components.size() > STRING_SWITCH_PROPERTY_THRESHOLD) {
+            StatementDef.DefineAndAssign handledPropertyDef = ExpressionDef.falseValue().newLocal("handledProperty");
+            VariableDef.Local handledPropertyVariable = handledPropertyDef.variable();
+            return StatementDef.multi(
+                handledPropertyDef,
+                keyVariable.asStatementSwitch(
+                    STRING_TYPE,
+                    buildSwitchCases(deserializerClassTypeDef, components, keyFieldNames, seenPropertyVariables, componentDeserializers, handledPropertyVariable, type),
+                    handledPropertyVariable.ifFalse(unknownPropertyStatement)
                 )
-            ).newLocal("switchResult");
+            );
         }
         StatementDef switchStatement = unknownPropertyStatement;
         for (int i = components.size() - 1; i >= 0; i--) {
@@ -372,7 +391,7 @@ public final class RecordDeserializerSourceGen {
                 .invokeStatic(DUPLICATE_PROPERTY_METHOD, componentNameExpression, type)
                 .doThrow();
             VariableDef.Local seenPropertyVariable = seenPropertyVariables.get(i);
-            switchStatement = keyVariable.equalsStructurally(componentNameExpression).ifTrue(
+            switchStatement = keyVariable.invoke(STRING_EQUALS_METHOD, componentNameExpression).ifTrue(
                 seenPropertyVariable.ifTrue(
                     duplicatePropertyStatement,
                     StatementDef.multi(
@@ -386,13 +405,14 @@ public final class RecordDeserializerSourceGen {
         return switchStatement;
     }
 
-    private Map<ExpressionDef.Constant, ExpressionDef> buildSwitchCases(ClassTypeDef deserializerClassTypeDef,
-                                                                        List<RecordSerdeShape.RecordComponent> components,
-                                                                        Map<String, String> keyFieldNames,
-                                                                        List<VariableDef.Local> seenPropertyVariables,
-                                                                        List<StatementDef> componentDeserializers,
-                                                                        VariableDef.MethodParameter type) {
-        Map<ExpressionDef.Constant, ExpressionDef> switchCases = new LinkedHashMap<>();
+    private Map<ExpressionDef.Constant, StatementDef> buildSwitchCases(ClassTypeDef deserializerClassTypeDef,
+                                                                       List<RecordSerdeShape.RecordComponent> components,
+                                                                       Map<String, String> keyFieldNames,
+                                                                       List<VariableDef.Local> seenPropertyVariables,
+                                                                       List<StatementDef> componentDeserializers,
+                                                                       VariableDef.Local handledPropertyVariable,
+                                                                       VariableDef.MethodParameter type) {
+        Map<ExpressionDef.Constant, StatementDef> switchCases = new LinkedHashMap<>();
         for (int i = 0; i < components.size(); i++) {
             RecordSerdeShape.RecordComponent component = components.get(i);
             ExpressionDef componentNameExpression = deserializerClassTypeDef.getStaticField(required(keyFieldNames, component.name()), STRING_TYPE);
@@ -401,17 +421,14 @@ public final class RecordDeserializerSourceGen {
                 .doThrow();
             VariableDef.Local seenPropertyVariable = seenPropertyVariables.get(i);
             switchCases.put(ExpressionDef.constant(component.name()),
-                new ExpressionDef.SwitchYieldCase(
-                    TypeDef.Primitive.BOOLEAN,
-                    StatementDef.multi(
-                        seenPropertyVariable.ifTrue(
-                            duplicatePropertyStatement,
-                            StatementDef.multi(
-                                seenPropertyVariable.assign(ExpressionDef.trueValue()),
-                                componentDeserializers.get(i)
-                            )
-                        ),
-                        ExpressionDef.trueValue().returning()
+                handledPropertyVariable.ifFalse(
+                    seenPropertyVariable.ifTrue(
+                        duplicatePropertyStatement,
+                        StatementDef.multi(
+                            handledPropertyVariable.assign(ExpressionDef.trueValue()),
+                            seenPropertyVariable.assign(ExpressionDef.trueValue()),
+                            componentDeserializers.get(i)
+                        )
                     )
                 )
             );
@@ -436,13 +453,21 @@ public final class RecordDeserializerSourceGen {
         Method scalarDecodeMethod = scalarDecoderMethod(component.type());
         StatementDef deserializeAndAssign;
         if (scalarDecodeMethod != null) {
-            deserializeAndAssign = valueVariable.assign(
-                objectDecoder.invoke(scalarDecodeMethod).cast(RecordSerdeSourceGenUtils.deserializedCastType(component.type()))
-            );
+            if (component.type().isPrimitive() && !component.type().isArray()) {
+                deserializeAndAssign = objectDecoder.invoke(DECODE_NULL_METHOD).ifFalse(
+                    valueVariable.assign(objectDecoder.invoke(scalarDecodeMethod))
+                );
+            } else {
+                ExpressionDef decodedValue = objectDecoder.invoke(scalarDecodeMethod);
+                if (!component.type().isPrimitive() || component.type().isArray()) {
+                    decodedValue = decodedValue.cast(RecordSerdeSourceGenUtils.deserializedCastType(component.type()));
+                }
+                deserializeAndAssign = valueVariable.assign(decodedValue);
+            }
         } else {
             String deserializerFieldName = required(deserializerFieldNames, component.name());
             StatementDef.DefineAndAssign deserializerDef = aThis.field(deserializerFieldName, DESERIALIZER_TYPE)
-                .newLocal(RecordSerdeSourceGenUtils.localName("deserializer", component.name(), index));
+                .newLocal(RecordSerdeSourceGenUtils.localName("deserializer", index));
             StatementDef initializeDeserializerStatement = deserializerDef.variable().isNull().ifTrue(
                 deserializerDef.variable().assign(context.invoke(FIND_DESERIALIZER_METHOD, argumentExpression).invoke(CREATE_SPECIFIC_DESERIALIZER_METHOD, context, argumentExpression))
             );
@@ -475,8 +500,8 @@ public final class RecordDeserializerSourceGen {
             );
     }
 
-    private String constantFieldName(String prefix, String componentName, int index) {
-        return prefix + "_" + componentName.replaceAll("[^A-Za-z0-9]", "_").toUpperCase() + "_" + index;
+    private String indexedName(String prefix, int index) {
+        return prefix + "_" + index;
     }
 
     private static String required(Map<String, String> names, String key) {
@@ -504,14 +529,22 @@ public final class RecordDeserializerSourceGen {
             return null;
         }
         return switch (type.getName()) {
-            case "boolean", "java.lang.Boolean" -> DECODE_BOOLEAN_NULLABLE_METHOD;
-            case "byte", "java.lang.Byte" -> DECODE_BYTE_NULLABLE_METHOD;
-            case "short", "java.lang.Short" -> DECODE_SHORT_NULLABLE_METHOD;
-            case "char", "java.lang.Character" -> DECODE_CHAR_NULLABLE_METHOD;
-            case "int", "java.lang.Integer" -> DECODE_INT_NULLABLE_METHOD;
-            case "long", "java.lang.Long" -> DECODE_LONG_NULLABLE_METHOD;
-            case "float", "java.lang.Float" -> DECODE_FLOAT_NULLABLE_METHOD;
-            case "double", "java.lang.Double" -> DECODE_DOUBLE_NULLABLE_METHOD;
+            case "boolean" -> DECODE_BOOLEAN_METHOD;
+            case "java.lang.Boolean" -> DECODE_BOOLEAN_NULLABLE_METHOD;
+            case "byte" -> DECODE_BYTE_METHOD;
+            case "java.lang.Byte" -> DECODE_BYTE_NULLABLE_METHOD;
+            case "short" -> DECODE_SHORT_METHOD;
+            case "java.lang.Short" -> DECODE_SHORT_NULLABLE_METHOD;
+            case "char" -> DECODE_CHAR_METHOD;
+            case "java.lang.Character" -> DECODE_CHAR_NULLABLE_METHOD;
+            case "int" -> DECODE_INT_METHOD;
+            case "java.lang.Integer" -> DECODE_INT_NULLABLE_METHOD;
+            case "long" -> DECODE_LONG_METHOD;
+            case "java.lang.Long" -> DECODE_LONG_NULLABLE_METHOD;
+            case "float" -> DECODE_FLOAT_METHOD;
+            case "java.lang.Float" -> DECODE_FLOAT_NULLABLE_METHOD;
+            case "double" -> DECODE_DOUBLE_METHOD;
+            case "java.lang.Double" -> DECODE_DOUBLE_NULLABLE_METHOD;
             case "java.lang.String" -> DECODE_STRING_NULLABLE_METHOD;
             case "java.math.BigInteger" -> DECODE_BIG_INTEGER_NULLABLE_METHOD;
             case "java.math.BigDecimal" -> DECODE_BIG_DECIMAL_NULLABLE_METHOD;

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerdeSourceGenUtils.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerdeSourceGenUtils.java
@@ -153,8 +153,8 @@ final class RecordSerdeSourceGenUtils {
         };
     }
 
-    static String localName(String prefix, String componentName, int index) {
-        return prefix + componentName.replace("$", "_") + index;
+    static String localName(String prefix, int index) {
+        return prefix + index;
     }
 
     private static List<? extends ClassElement> resolveTypeArguments(ClassElement classElement) {

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerializerSourceGen.java
@@ -26,17 +26,19 @@ import io.micronaut.serde.processor.sourcegen.SerdeSourceGenClassNaming;
 import io.micronaut.serde.util.GeneratedSerdeExceptionUtil;
 import io.micronaut.serde.util.GeneratedSerdeFallbackUtil;
 import io.micronaut.sourcegen.model.AnnotationDef;
-import io.micronaut.sourcegen.model.ClassTypeDef;
 import io.micronaut.sourcegen.model.ClassDef;
+import io.micronaut.sourcegen.model.ClassTypeDef;
 import io.micronaut.sourcegen.model.ExpressionDef;
 import io.micronaut.sourcegen.model.FieldDef;
 import io.micronaut.sourcegen.model.MethodDef;
 import io.micronaut.sourcegen.model.StatementDef;
 import io.micronaut.sourcegen.model.TypeDef;
 import io.micronaut.sourcegen.model.VariableDef;
+import jakarta.inject.Singleton;
+import org.jspecify.annotations.Nullable;
 
-import javax.lang.model.element.Modifier;
 import javax.annotation.processing.Generated;
+import javax.lang.model.element.Modifier;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -44,8 +46,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import jakarta.inject.Singleton;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Generates optimized source serializers for records.
@@ -116,8 +116,8 @@ public final class RecordSerializerSourceGen {
 
         int index = 0;
         for (RecordSerdeShape.RecordComponent component : recordSerdeShape.components()) {
-            String keyFieldName = constantFieldName("KEY", component.name(), index);
-            String argumentFieldName = constantFieldName("ARGUMENT", component.name(), index);
+            String keyFieldName = indexedName("KEY", index);
+            String argumentFieldName = indexedName("ARGUMENT", index);
             keyFieldNames.put(component.name(), keyFieldName);
             argumentFieldNames.put(component.name(), argumentFieldName);
 
@@ -130,7 +130,7 @@ public final class RecordSerializerSourceGen {
                 .initializer(RecordSerdeSourceGenUtils.argumentExpression(component.type()))
                 .build());
             if (scalarEncoderMethod(component.type()) == null) {
-                String serializerFieldName = constantFieldName("SERIALIZER", component.name(), index);
+                String serializerFieldName = indexedName("SERIALIZER", index);
                 serializerFieldNames.put(component.name(), serializerFieldName);
                 fields.add(FieldDef.builder(serializerFieldName, SERIALIZER_TYPE)
                     .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
@@ -151,7 +151,7 @@ public final class RecordSerializerSourceGen {
             .addFields(fields)
             .addMethod(generateNoArgsConstructor(serializerFieldNames))
             .addMethod(generateCreateSpecificMethod(recordTypeDef, serializerClassTypeDef, argumentFieldNames, serializerFieldNames))
-            .addMethod(generateSerializeMethod(recordTypeDef, serializerClassTypeDef, recordSerdeShape, keyFieldNames, argumentFieldNames, serializerFieldNames))
+            .addMethod(generateSerializeMethod(recordTypeDef))
             .addMethod(generateSerializeIntoMethod(recordTypeDef, serializerClassTypeDef, recordSerdeShape, keyFieldNames, argumentFieldNames, serializerFieldNames));
 
         if (!serializerFieldNames.isEmpty()) {
@@ -219,7 +219,7 @@ public final class RecordSerializerSourceGen {
                     ExpressionDef argumentExpression = serializerClassTypeDef.getStaticField(argumentFieldName, ARGUMENT_TYPE);
                     StatementDef.DefineAndAssign serializerDef = context.invoke(FIND_SERIALIZER_METHOD, argumentExpression)
                         .invoke(CREATE_SPECIFIC_SERIALIZER_METHOD, context, argumentExpression)
-                        .newLocal(RecordSerdeSourceGenUtils.localName("serializer", componentName, index));
+                        .newLocal(RecordSerdeSourceGenUtils.localName("serializer", index));
                     statements.add(serializerDef);
                     serializerValues.add(serializerDef.variable());
                     constructorParameterTypes.add(SERIALIZER_TYPE);
@@ -238,12 +238,7 @@ public final class RecordSerializerSourceGen {
             });
     }
 
-    private MethodDef generateSerializeMethod(TypeDef recordTypeDef,
-                                              ClassTypeDef serializerClassTypeDef,
-                                              RecordSerdeShape recordSerdeShape,
-                                              Map<String, String> keyFieldNames,
-                                              Map<String, String> argumentFieldNames,
-                                              Map<String, String> serializerFieldNames) {
+    private MethodDef generateSerializeMethod(TypeDef recordTypeDef) {
         return MethodDef.builder("serialize")
             .addModifiers(Modifier.PUBLIC)
             .overrides()
@@ -261,7 +256,7 @@ public final class RecordSerializerSourceGen {
                 List<StatementDef> objectStatements = new ArrayList<>();
                 StatementDef.DefineAndAssign objectEncoderDef = encoder.invoke(ENCODE_OBJECT_METHOD, type).newLocal("objectEncoder");
                 objectStatements.add(objectEncoderDef);
-                objectStatements.addAll(serializeIntoStatements(aThis, serializerClassTypeDef, objectEncoderDef.variable(), context, type, value, recordSerdeShape, keyFieldNames, argumentFieldNames, serializerFieldNames));
+                objectStatements.add(aThis.invoke("serializeInto", TypeDef.VOID, objectEncoderDef.variable(), context, type, value));
                 objectStatements.add(objectEncoderDef.variable().invoke(FINISH_STRUCTURE_METHOD));
 
                 return value.isNull().ifTrue(
@@ -305,7 +300,7 @@ public final class RecordSerializerSourceGen {
         int index = 0;
         for (RecordSerdeShape.RecordComponent component : recordSerdeShape.components()) {
             statements.add(encoder.invoke(ENCODE_KEY_METHOD, serializerClassTypeDef.getStaticField(required(keyFieldNames, component.name()), STRING_TYPE)));
-            statements.add(serializeComponent(aThis, serializerClassTypeDef, encoder, context, type, value, component, index++, argumentFieldNames, serializerFieldNames));
+            statements.add(serializeComponent(aThis, serializerClassTypeDef, encoder, context, type, value, component, index++, keyFieldNames, argumentFieldNames, serializerFieldNames));
         }
         return statements;
     }
@@ -319,30 +314,32 @@ public final class RecordSerializerSourceGen {
                                             VariableDef.MethodParameter value,
                                             RecordSerdeShape.RecordComponent component,
                                             int index,
+                                            Map<String, String> keyFieldNames,
                                             Map<String, String> argumentFieldNames,
                                             Map<String, String> serializerFieldNames) {
         ExpressionDef argumentExpression = serializerClassTypeDef.getStaticField(required(argumentFieldNames, component.name()), ARGUMENT_TYPE);
+        ExpressionDef propertyNameExpression = serializerClassTypeDef.getStaticField(required(keyFieldNames, component.name()), STRING_TYPE);
         Method scalarMethod = scalarEncoderMethod(component.type());
-        ExpressionDef componentValue = value.getPropertyValue(component.propertyElement());
+        ExpressionDef propertyValue = value.getPropertyValue(component.propertyElement());
         if (scalarMethod != null) {
             StatementDef scalarStatement;
             if (component.type().isPrimitive() && !component.type().isArray()) {
-                scalarStatement = objectEncoder.invoke(scalarMethod, componentValue);
+                scalarStatement = objectEncoder.invoke(scalarMethod, propertyValue);
             } else {
-                StatementDef.DefineAndAssign componentValueDef = componentValue.newLocal(RecordSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, component.name(), index));
+                StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(RecordSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
                 scalarStatement = StatementDef.multi(
-                    componentValueDef,
-                    componentValueDef.variable().isNull().ifTrue(
+                    propertyValueDef,
+                    propertyValueDef.variable().isNull().ifTrue(
                         objectEncoder.invoke(ENCODE_NULL_METHOD),
-                        StatementDef.multi(objectEncoder.invoke(scalarMethod, componentValueDef.variable()))
+                        StatementDef.multi(objectEncoder.invoke(scalarMethod, propertyValueDef.variable()))
                     )
                 );
             }
-            return wrapWithPropertyPath(scalarStatement, type, component.name(), argumentExpression);
+            return wrapWithPropertyPath(scalarStatement, type, propertyNameExpression, argumentExpression);
         }
         String serializerFieldName = required(serializerFieldNames, component.name());
         StatementDef.DefineAndAssign serializerDef = aThis.field(serializerFieldName, SERIALIZER_TYPE)
-            .newLocal(RecordSerdeSourceGenUtils.localName("serializer", component.name(), index));
+            .newLocal(RecordSerdeSourceGenUtils.localName("serializer", index));
         StatementDef initializeSerializerStatement = serializerDef.variable().isNull().ifTrue(
             serializerDef.variable().assign(context.invoke(FIND_SERIALIZER_METHOD, argumentExpression).invoke(CREATE_SPECIFIC_SERIALIZER_METHOD, context, argumentExpression))
         );
@@ -356,16 +353,16 @@ public final class RecordSerializerSourceGen {
                 objectEncoder,
                 context,
                 argumentExpression,
-                componentValue.cast(TypeDef.OBJECT)
+                propertyValue.cast(TypeDef.OBJECT)
             )
         );
         if (component.type().isPrimitive() && !component.type().isArray()) {
-            return wrapWithPropertyPath(serializeStatement, type, component.name(), argumentExpression);
+            return wrapWithPropertyPath(serializeStatement, type, propertyNameExpression, argumentExpression);
         }
-        StatementDef.DefineAndAssign componentValueDef = componentValue.newLocal(RecordSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, component.name(), index));
+        StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(RecordSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
         return wrapWithPropertyPath(StatementDef.multi(
-            componentValueDef,
-            componentValueDef.variable().isNull().ifTrue(
+            propertyValueDef,
+            propertyValueDef.variable().isNull().ifTrue(
                 objectEncoder.invoke(ENCODE_NULL_METHOD),
                 StatementDef.multi(
                     serializerDef,
@@ -375,15 +372,15 @@ public final class RecordSerializerSourceGen {
                         objectEncoder,
                         context,
                         argumentExpression,
-                        componentValueDef.variable().cast(TypeDef.OBJECT)
+                        propertyValueDef.variable().cast(TypeDef.OBJECT)
                     )
                 )
             )
-        ), type, component.name(), argumentExpression);
+        ), type, propertyNameExpression, argumentExpression);
     }
 
-    private String constantFieldName(String prefix, String componentName, int index) {
-        return prefix + "_" + componentName.replaceAll("[^A-Za-z0-9]", "_").toUpperCase() + "_" + index;
+    private String indexedName(String prefix, int index) {
+        return prefix + "_" + index;
     }
 
     private static String required(Map<String, String> names, String key) {
@@ -409,7 +406,7 @@ public final class RecordSerializerSourceGen {
 
     private StatementDef wrapWithPropertyPath(StatementDef statement,
                                               VariableDef.MethodParameter type,
-                                              String propertyName,
+                                              ExpressionDef propertyNameExpression,
                                               ExpressionDef argumentExpression) {
         return StatementDef.doTry(statement)
             .doCatch(ClassTypeDef.of(Throwable.class), exceptionVariable ->
@@ -418,7 +415,7 @@ public final class RecordSerializerSourceGen {
                         WITH_PROPERTY_PATH_THROWABLE_METHOD,
                         exceptionVariable,
                         type,
-                        ExpressionDef.constant(propertyName),
+                        propertyNameExpression,
                         argumentExpression
                     )
                     .doThrow()


### PR DESCRIPTION
  Key changes:

  - Added @SerdeableGenerated in serde-api/src/main/java/io/micronaut/serde/annotation/SerdeableGenerated.java with required, skip, skipSerializer, and skipDeserializer.
  - Added processor validation so required=true fails compilation when a non-skipped generated serializer/deserializer is unsupported.
  - Updated sourcegen naming and serializer/deserializer generation: indexed fields/locals, encodeObject plus serializeInto, static key fields for property paths, string switch for more than 5 properties, primitive boolean
    decode without decodeBooleanNullable, and pre-constructor missing-property checks.
  - Added compile-time fixture tests under io.micronaut.serde.jackson.compiletime.
  - Annotated eligible benchmark data/sourcegen benchmark shapes directly with @SerdeableGenerated; no BenchmarkCompileTimeSerdeTypes fixture is generated/kept.
