### PR TITLE
Reproduce nested KSP serde issue

### DIFF
--- a/doc-examples/example-kotlin-ksp/src/test/kotlin/example/NestedPolymorphicSerdeKspTest.kt
+++ b/doc-examples/example-kotlin-ksp/src/test/kotlin/example/NestedPolymorphicSerdeKspTest.kt
@@ -1,0 +1,105 @@
+package example
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonTypeName
+import io.micronaut.core.beans.BeanIntrospector
+import io.micronaut.core.type.Argument
+import io.micronaut.serde.ObjectMapper
+import io.micronaut.serde.annotation.Serdeable
+import io.micronaut.serde.config.annotation.SerdeConfig
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets
+import java.util.Optional
+
+@MicronautTest
+class NestedPolymorphicSerdeKspTest {
+
+    @Test
+    fun `top-level sealed subtype carries JSON type metadata`() {
+        assertTypeMetadata(TopLevelData.Foo::class.java, "foo")
+        assertTypeMetadata(TopLevelData.Bar::class.java, "bar")
+    }
+
+    @Test
+    fun `top-level sealed interface serializes with discriminator when declared type is used`(objectMapper: ObjectMapper) {
+        val argument = Argument.of(TopLevelData::class.java)
+        val json = String(
+            objectMapper.writeValueAsBytes(argument, TopLevelData.Foo(123L)),
+            StandardCharsets.UTF_8
+        )
+
+        assertEquals("""{"kind":"foo","value":123}""", json)
+    }
+
+    @Test
+    fun `nested sealed subtype carries JSON type metadata`() {
+        assertTypeMetadata(NestedDynamicData.Data.Foo::class.java, "foo")
+        assertTypeMetadata(NestedDynamicData.Data.Bar::class.java, "bar")
+    }
+
+    @Test
+    fun `nested sealed interface serializes with discriminator when declared type is used`(objectMapper: ObjectMapper) {
+        val argument = Argument.of(NestedDynamicData.Data::class.java)
+        val json = String(
+            objectMapper.writeValueAsBytes(argument, NestedDynamicData.Data.Foo(123L)),
+            StandardCharsets.UTF_8
+        )
+
+        assertEquals("""{"kind":"foo","value":123}""", json)
+
+        val loaded = objectMapper.readValue(json, argument)
+        assertInstanceOf(NestedDynamicData.Data.Foo::class.java, loaded)
+        assertEquals(123L, (loaded as NestedDynamicData.Data.Foo).value)
+    }
+
+    private fun assertTypeMetadata(type: Class<*>, expectedTypeName: String) {
+        val introspection = BeanIntrospector.SHARED.findIntrospection(type).get()
+
+        assertEquals(Optional.of(expectedTypeName), introspection.stringValue(SerdeConfig::class.java, SerdeConfig.TYPE_NAME))
+        assertEquals(Optional.of("kind"), introspection.stringValue(SerdeConfig::class.java, SerdeConfig.TYPE_PROPERTY))
+        assertArrayEquals(
+            arrayOf(expectedTypeName),
+            introspection.getValue(SerdeConfig::class.java, SerdeConfig.TYPE_NAMES, Array<String>::class.java).get()
+        )
+    }
+}
+
+@Serdeable
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+sealed interface TopLevelData {
+
+    @Serdeable
+    @JsonTypeName("foo")
+    data class Foo(
+        val value: Long,
+    ) : TopLevelData
+
+    @Serdeable
+    @JsonTypeName("bar")
+    data class Bar(
+        val name: String,
+    ) : TopLevelData
+}
+
+class NestedDynamicData {
+    @Serdeable
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+    sealed interface Data {
+
+        @Serdeable
+        @JsonTypeName("foo")
+        data class Foo(
+            val value: Long,
+        ) : Data
+
+        @Serdeable
+        @JsonTypeName("bar")
+        data class Bar(
+            val name: String,
+        ) : Data
+    }
+}

--- a/doc-examples/example-kotlin/src/test/kotlin/example/NestedPolymorphicSerdeKaptTest.kt
+++ b/doc-examples/example-kotlin/src/test/kotlin/example/NestedPolymorphicSerdeKaptTest.kt
@@ -1,0 +1,71 @@
+package example
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonTypeName
+import io.micronaut.core.beans.BeanIntrospector
+import io.micronaut.core.type.Argument
+import io.micronaut.serde.ObjectMapper
+import io.micronaut.serde.annotation.Serdeable
+import io.micronaut.serde.config.annotation.SerdeConfig
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets
+import java.util.Optional
+
+@MicronautTest
+class NestedPolymorphicSerdeKaptTest {
+
+    @Test
+    fun `nested sealed subtype carries JSON type metadata`() {
+        assertTypeMetadata(KaptNestedDynamicData.Data.Foo::class.java, "foo")
+        assertTypeMetadata(KaptNestedDynamicData.Data.Bar::class.java, "bar")
+    }
+
+    @Test
+    fun `nested sealed interface serializes with discriminator when declared type is used`(objectMapper: ObjectMapper) {
+        val argument = Argument.of(KaptNestedDynamicData.Data::class.java)
+        val json = String(
+            objectMapper.writeValueAsBytes(argument, KaptNestedDynamicData.Data.Foo(123L)),
+            StandardCharsets.UTF_8
+        )
+
+        assertEquals("""{"kind":"foo","value":123}""", json)
+
+        val loaded = objectMapper.readValue(json, argument)
+        assertInstanceOf(KaptNestedDynamicData.Data.Foo::class.java, loaded)
+        assertEquals(123L, (loaded as KaptNestedDynamicData.Data.Foo).value)
+    }
+
+    private fun assertTypeMetadata(type: Class<*>, expectedTypeName: String) {
+        val introspection = BeanIntrospector.SHARED.findIntrospection(type).get()
+
+        assertEquals(Optional.of(expectedTypeName), introspection.stringValue(SerdeConfig::class.java, SerdeConfig.TYPE_NAME))
+        assertEquals(Optional.of("kind"), introspection.stringValue(SerdeConfig::class.java, SerdeConfig.TYPE_PROPERTY))
+        assertArrayEquals(
+            arrayOf(expectedTypeName),
+            introspection.getValue(SerdeConfig::class.java, SerdeConfig.TYPE_NAMES, Array<String>::class.java).get()
+        )
+    }
+}
+
+class KaptNestedDynamicData {
+    @Serdeable
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "kind")
+    sealed interface Data {
+
+        @Serdeable
+        @JsonTypeName("foo")
+        data class Foo(
+            val value: Long,
+        ) : Data
+
+        @Serdeable
+        @JsonTypeName("bar")
+        data class Bar(
+            val name: String,
+        ) : Data
+    }
+}


### PR DESCRIPTION
Add KSP and KAPT comparison tests for nested sealed polymorphic types.
KSP misses discriminator metadata for nested subtypes and serializes without the "kind" field, while the same model works with KAPT.

Originally reported in https://github.com/micronaut-projects/micronaut-serialization/issues/1337