### PR TITLE
Add Jackson temporal format parity tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,4 +53,12 @@ if (System.getenv("SONAR_TOKEN") != null) {
             )
         }
     }
+
+    subprojects {
+        if (name.contains("tck", ignoreCase = true)) {
+            configure<SonarExtension> {
+                setSkipProject(true)
+            }
+        }
+    }
 }

--- a/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/GlobalFeaturesSpec.groovy
+++ b/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/GlobalFeaturesSpec.groovy
@@ -17,11 +17,19 @@ package io.micronaut.serde.jackson
 
 import io.micronaut.core.type.Argument
 
+import java.sql.Time
 import java.time.Instant
+import java.time.Month
+import java.time.MonthDay
 import java.time.OffsetDateTime
+import java.time.OffsetTime
+import java.time.YearMonth
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
+import java.util.Calendar
+import java.util.GregorianCalendar
+import java.util.TimeZone
 
 abstract class GlobalFeaturesSpec extends JsonCompileSpec {
 
@@ -433,6 +441,121 @@ class Test {
             context.close()
     }
 
+    void "test global date timestamp features for scalar temporal values"() {
+        given:
+            def context = buildContext('test.Test', """
+package test;
+
+import io.micronaut.serde.annotation.Serdeable;
+import java.sql.Time;
+import java.time.Month;
+import java.time.MonthDay;
+import java.time.OffsetTime;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+@Serdeable
+class Test {
+    private OffsetTime offsetTime;
+    private YearMonth yearMonth;
+    private MonthDay monthDay;
+    private Month month;
+    private ZoneOffset zoneOffset;
+    private Time sqlTime;
+    private TimeZone timeZone;
+    private Calendar calendar;
+    private GregorianCalendar gregorianCalendar;
+    public OffsetTime getOffsetTime() {
+        return offsetTime;
+    }
+    public void setOffsetTime(OffsetTime offsetTime) {
+        this.offsetTime = offsetTime;
+    }
+    public YearMonth getYearMonth() {
+        return yearMonth;
+    }
+    public void setYearMonth(YearMonth yearMonth) {
+        this.yearMonth = yearMonth;
+    }
+    public MonthDay getMonthDay() {
+        return monthDay;
+    }
+    public void setMonthDay(MonthDay monthDay) {
+        this.monthDay = monthDay;
+    }
+    public Month getMonth() {
+        return month;
+    }
+    public void setMonth(Month month) {
+        this.month = month;
+    }
+    public ZoneOffset getZoneOffset() {
+        return zoneOffset;
+    }
+    public void setZoneOffset(ZoneOffset zoneOffset) {
+        this.zoneOffset = zoneOffset;
+    }
+    public Time getSqlTime() {
+        return sqlTime;
+    }
+    public void setSqlTime(Time sqlTime) {
+        this.sqlTime = sqlTime;
+    }
+    public TimeZone getTimeZone() {
+        return timeZone;
+    }
+    public void setTimeZone(TimeZone timeZone) {
+        this.timeZone = timeZone;
+    }
+    public Calendar getCalendar() {
+        return calendar;
+    }
+    public void setCalendar(Calendar calendar) {
+        this.calendar = calendar;
+    }
+    public GregorianCalendar getGregorianCalendar() {
+        return gregorianCalendar;
+    }
+    public void setGregorianCalendar(GregorianCalendar gregorianCalendar) {
+        this.gregorianCalendar = gregorianCalendar;
+    }
+}
+""", [
+                offsetTime: OffsetTime.of(12, 30, 45, 123456789, ZoneOffset.ofHours(2)),
+                yearMonth: YearMonth.of(2024, 9),
+                monthDay: MonthDay.of(9, 8),
+                month: Month.SEPTEMBER,
+                zoneOffset: ZoneOffset.ofHoursMinutes(5, 30),
+                sqlTime: Time.valueOf('12:30:45'),
+                timeZone: TimeZone.getTimeZone('Europe/Paris'),
+                calendar: calendar('Europe/Paris', 123),
+                gregorianCalendar: calendar('Europe/Paris', 123)
+            ], dateTimestampNanosecondsDisabledConfig())
+
+        expect:
+            validateJsonWithoutOrder(
+                jsonMapper,
+                '{"offsetTime":[12,30,45,123,"+02:00"],"yearMonth":[2024,9],"monthDay":"--09-08","month":9,"zoneOffset":"+05:30","sqlTime":"12:30:45","timeZone":"Europe/Paris","calendar":1725791445123,"gregorianCalendar":1725791445123}',
+                writeJson(jsonMapper, beanUnderTest)
+            )
+            def read = jsonMapper.readValue('{"offsetTime":[13,31,46,987,"+03:00"],"yearMonth":[2025,10],"monthDay":"--10-09","month":10,"zoneOffset":"+02:30","sqlTime":"13:31:46","timeZone":"America/New_York","calendar":1725885045000,"gregorianCalendar":1725885045000}', typeUnderTest)
+            read.offsetTime == OffsetTime.of(13, 31, 46, 987000000, ZoneOffset.ofHours(3))
+            read.yearMonth == YearMonth.of(2025, 10)
+            read.monthDay == MonthDay.of(10, 9)
+            read.month == Month.OCTOBER
+            read.zoneOffset == ZoneOffset.ofHoursMinutes(2, 30)
+            read.sqlTime == Time.valueOf('13:31:46')
+            read.timeZone.ID == 'America/New_York'
+            read.calendar.timeInMillis == 1725885045000L
+            read.gregorianCalendar.timeInMillis == 1725885045000L
+
+        cleanup:
+            context.close()
+    }
+
     void "test global write dates with zone id"() {
         given:
             def context = buildContext('test.Test', """
@@ -494,5 +617,13 @@ class Test {
 
         cleanup:
             context.close()
+    }
+
+    private static GregorianCalendar calendar(String timeZoneId, int millis = 0) {
+        def calendar = new GregorianCalendar(TimeZone.getTimeZone(timeZoneId))
+        calendar.clear()
+        calendar.set(2024, Calendar.SEPTEMBER, 8, 12, 30, 45)
+        calendar.set(Calendar.MILLISECOND, millis)
+        calendar
     }
 }

--- a/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonFormatSpec.groovy
+++ b/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonFormatSpec.groovy
@@ -22,16 +22,24 @@ import io.micronaut.serde.jackson.shape.EnumObjectShapeBean
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
+import java.sql.Time
 import java.sql.Timestamp
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.Month
+import java.time.MonthDay
 import java.time.OffsetDateTime
+import java.time.OffsetTime
 import java.time.Year
+import java.time.YearMonth
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
+import java.util.Calendar
+import java.util.GregorianCalendar
+import java.util.TimeZone
 
 abstract class JsonFormatSpec extends JsonCompileSpec {
     private static final String LITERAL_Z_TIMESTAMP = '2026-05-07T08:22:23Z'
@@ -2015,8 +2023,12 @@ class Test {
             'java.time.LocalTime',
             'java.time.LocalDateTime',
             'java.time.OffsetDateTime',
+            'java.time.OffsetTime',
             'java.time.ZonedDateTime',
-            'java.time.Year'
+            'java.time.Year',
+            'java.time.YearMonth',
+            'java.time.MonthDay',
+            'java.time.Month'
         ] as Set
     }
 
@@ -2182,6 +2194,9 @@ class Test {
         'java.time.OffsetDateTime' | OffsetDateTime.of(2024, 9, 8, 12, 30, 45, 123000000, ZoneOffset.UTC)            | '{"value":"2024-09-08T12:30:45.123Z"}'
         'java.time.ZonedDateTime' | ZonedDateTime.of(2024, 9, 8, 12, 30, 45, 123000000, ZoneOffset.UTC)              | '{"value":"2024-09-08T12:30:45.123Z"}'
         'java.time.Year'          | Year.of(2024)                                                                   | '{"value":"2024"}'
+        'java.time.YearMonth'     | YearMonth.of(2024, 9)                                                           | '{"value":"2024-09"}'
+        'java.time.MonthDay'      | MonthDay.of(9, 8)                                                               | '{"value":"--09-08"}'
+        'java.sql.Time'           | Time.valueOf('12:30:45')                                                        | '{"value":"12:30:45"}'
     }
 
     void "test json format string shape overrides global numeric time shape"() {
@@ -2244,6 +2259,37 @@ class Test {
         context.close()
     }
 
+    void "test json format string shape with pattern for offset time"() {
+        given:
+        def context = buildContext('test.Test', """
+package test;
+
+import io.micronaut.serde.annotation.Serdeable;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.OffsetTime;
+
+@Serdeable
+class Test {
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm XXX")
+    private OffsetTime value;
+    public void setValue(OffsetTime value) {
+        this.value = value;
+    }
+    public OffsetTime getValue() {
+        return value;
+    }
+}
+""", [value: OffsetTime.of(12, 30, 45, 123000000, ZoneOffset.ofHours(2))])
+
+        expect:
+        writeJson(jsonMapper, beanUnderTest) == '{"value":"12:30 +02:00"}'
+        jsonMapper.readValue('{"value":"13:45 +03:00"}', typeUnderTest).value ==
+            OffsetTime.of(13, 45, 0, 0, ZoneOffset.ofHours(3))
+
+        cleanup:
+        context.close()
+    }
+
     @Unroll
     void "test json format literal z pattern for temporal #typeName"() {
         given:
@@ -2280,6 +2326,41 @@ class Test {
         typeName = variation.typeName
         expectedValue = variation.expectedValue
         resolver = variation.resolver
+    }
+
+    @Unroll
+    void "test json format pattern for #typeName"() {
+        given:
+        def context = buildContext('test.Test', """
+package test;
+
+import io.micronaut.serde.annotation.Serdeable;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+@Serdeable
+class Test {
+    @JsonFormat(pattern = "yyyy/MM/dd HH:mm:ss Z", timezone = "UTC")
+    private $typeName value;
+    public void setValue($typeName value) {
+        this.value = value;
+    }
+    public $typeName getValue() {
+        return value;
+    }
+}
+""", [value: writeValue])
+
+        expect:
+        writeJson(jsonMapper, beanUnderTest) == '{"value":"2024/09/08 10:30:45 +0000"}'
+        resolver(jsonMapper.readValue('{"value":"2024/09/09 12:30:45 +0000"}', typeUnderTest).value) == 1725885045000L
+
+        cleanup:
+        context.close()
+
+        where:
+        typeName                      | writeValue               | resolver
+        'java.util.Calendar'          | calendar('Europe/Paris') | { Calendar c -> c.timeInMillis }
+        'java.util.GregorianCalendar' | calendar('Europe/Paris') | { GregorianCalendar c -> c.timeInMillis }
     }
 
     void "test json format nullable delegating temporal properties"() {
@@ -2346,6 +2427,41 @@ class Test {
     }
 
     @Unroll
+    void "test json format number shape for #typeName"() {
+        given:
+        def context = buildContext('test.Test', """
+package test;
+
+import io.micronaut.serde.annotation.Serdeable;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+@Serdeable
+class Test {
+    @JsonFormat(shape = JsonFormat.Shape.NUMBER)
+    private $typeName value;
+    public void setValue($typeName value) {
+        this.value = value;
+    }
+    public $typeName getValue() {
+        return value;
+    }
+}
+""", [value: writeValue])
+
+        expect:
+        writeJson(jsonMapper, beanUnderTest) == '{"value":1725791445123}'
+        resolver(jsonMapper.readValue('{"value":1725885045000}', typeUnderTest).value) == 1725885045000L
+
+        cleanup:
+        context.close()
+
+        where:
+        typeName                      | writeValue                    | resolver
+        'java.util.Calendar'          | calendar('Europe/Paris', 123) | { Calendar c -> c.timeInMillis }
+        'java.util.GregorianCalendar' | calendar('Europe/Paris', 123) | { GregorianCalendar c -> c.timeInMillis }
+    }
+
+    @Unroll
     void "test json format pattern without explicit shape for temporal #typeName"() {
         given:
         def context = buildContext('test.Test', """
@@ -2385,6 +2501,43 @@ class Test {
         'java.time.OffsetDateTime' | [pattern: "yyyy-MM-dd'T'HH:mm:ss.SSSX", timezone: 'UTC']             | OffsetDateTime.of(2024, 9, 8, 12, 30, 45, 123000000, ZoneOffset.UTC) | '{"value":"2024-09-08T12:30:45.123Z"}' | '{"value":"2024-09-09T12:30:45.123Z"}'    | OffsetDateTime.of(2024, 9, 9, 12, 30, 45, 123000000, ZoneOffset.UTC) | { OffsetDateTime t -> t.toInstant() }
         'java.time.ZonedDateTime'  | [pattern: "yyyy-MM-dd'T'HH:mm:ss.SSSX", timezone: 'UTC']             | ZonedDateTime.of(2024, 9, 8, 12, 30, 45, 123000000, ZoneOffset.UTC) | '{"value":"2024-09-08T12:30:45.123Z"}'  | '{"value":"2024-09-09T12:30:45.123Z"}'    | ZonedDateTime.of(2024, 9, 9, 12, 30, 45, 123000000, ZoneOffset.UTC)  | { ZonedDateTime t -> t.toInstant() }
         'java.time.Year'           | [pattern: "'year:' yyyy"]                                            | Year.of(2024)                                                    | '{"value":"year: 2024"}'                  | '{"value":"year: 2025"}'                  | Year.of(2025)                                                | { Year y -> y }
+        'java.time.YearMonth'      | [pattern: 'uuuu/MM']                                                  | YearMonth.of(2024, 9)                                            | '{"value":"2024/09"}'                     | '{"value":"2025/10"}'                     | YearMonth.of(2025, 10)                                      | { YearMonth y -> y }
+        'java.time.MonthDay'       | [pattern: 'MM/dd']                                                    | MonthDay.of(9, 8)                                                | '{"value":"09/08"}'                       | '{"value":"10/09"}'                       | MonthDay.of(10, 9)                                          | { MonthDay m -> m }
+        'java.time.Month'          | [pattern: 'MMM', locale: 'en_US']                                     | Month.SEPTEMBER                                                  | '{"value":"Sep"}'                         | '{"value":"Oct"}'                         | Month.OCTOBER                                               | { Month m -> m }
+    }
+
+    @Unroll
+    void "test json format scalar sql time shape #shape"() {
+        given:
+        def context = buildContext('test.Test', """
+package test;
+
+import io.micronaut.serde.annotation.Serdeable;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.sql.Time;
+
+@Serdeable
+class Test {
+    @JsonFormat(shape = JsonFormat.Shape.$shape)
+    private Time value;
+    public void setValue(Time value) {
+        this.value = value;
+    }
+    public Time getValue() {
+        return value;
+    }
+}
+""", [value: Time.valueOf('12:30:45')])
+
+        expect:
+        writeJson(jsonMapper, beanUnderTest) == '{"value":"12:30:45"}'
+        jsonMapper.readValue('{"value":"13:31:46"}', typeUnderTest).value == Time.valueOf('13:31:46')
+
+        cleanup:
+        context.close()
+
+        where:
+        shape << ['STRING', 'NUMBER', 'NUMBER_FLOAT', 'NUMBER_INT']
     }
 
     @Unroll
@@ -2511,6 +2664,37 @@ class Test {
         context.close()
     }
 
+    void "test json format array timestamp shape for offset time"() {
+        given:
+        def context = buildContext('test.Test', """
+package test;
+
+import io.micronaut.serde.annotation.Serdeable;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.OffsetTime;
+
+@Serdeable
+class Test {
+    @JsonFormat(shape = JsonFormat.Shape.ARRAY)
+    private OffsetTime value;
+    public void setValue(OffsetTime value) {
+        this.value = value;
+    }
+    public OffsetTime getValue() {
+        return value;
+    }
+}
+""", [value: OffsetTime.of(12, 30, 45, 123456789, ZoneOffset.ofHours(2))])
+
+        expect:
+        writeJson(jsonMapper, beanUnderTest) == '{"value":[12,30,45,123456789,"+02:00"]}'
+        jsonMapper.readValue('{"value":[13,31,46,987654321,"+03:00"]}', typeUnderTest).value ==
+            OffsetTime.of(13, 31, 46, 987654321, ZoneOffset.ofHours(3))
+
+        cleanup:
+        context.close()
+    }
+
     @Unroll
     void "test json format temporal array timestamps as milliseconds for #typeName"() {
         given:
@@ -2550,6 +2734,44 @@ class Test {
         typeName                  | writeValue                                           | expectedWriteJson                    | readJson                             | readExpectedValue
         'java.time.LocalTime'     | LocalTime.of(12, 30, 45, 123456789)                  | '{"value":[12,30,45,123]}'           | '{"value":[12,30,45,123]}'           | LocalTime.of(12, 30, 45, 123000000)
         'java.time.LocalDateTime' | LocalDateTime.of(2024, 9, 8, 12, 30, 45, 123456789) | '{"value":[2024,9,8,12,30,45,123]}' | '{"value":[2024,9,8,12,30,45,123]}' | LocalDateTime.of(2024, 9, 8, 12, 30, 45, 123000000)
+        'java.time.OffsetTime'    | OffsetTime.of(12, 30, 45, 123456789, ZoneOffset.ofHours(2)) | '{"value":[12,30,45,123,"+02:00"]}' | '{"value":[12,30,45,123,"+02:00"]}' | OffsetTime.of(12, 30, 45, 123000000, ZoneOffset.ofHours(2))
+    }
+
+    @Unroll
+    void "test json format scalar timezone value for #typeName"() {
+        given:
+        def context = buildContext('test.Test', """
+package test;
+
+import io.micronaut.serde.annotation.Serdeable;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+@Serdeable
+class Test {
+    @JsonFormat(shape = JsonFormat.Shape.$shape, pattern = "ignored")
+    private $typeName value;
+    public void setValue($typeName value) {
+        this.value = value;
+    }
+    public $typeName getValue() {
+        return value;
+    }
+}
+""", [value: writeValue])
+
+        expect:
+        writeJson(jsonMapper, beanUnderTest) == expectedWriteJson
+        resolver(jsonMapper.readValue(readJson, typeUnderTest).value) == expectedReadValue
+
+        cleanup:
+        context.close()
+
+        where:
+        typeName               | shape    | writeValue                           | expectedWriteJson          | readJson                       | expectedReadValue  | resolver
+        'java.time.ZoneOffset' | 'STRING' | ZoneOffset.ofHoursMinutes(5, 30)     | '{"value":"+05:30"}'       | '{"value":"+02:30"}'           | '+02:30'           | { ZoneOffset z -> z.toString() }
+        'java.time.ZoneOffset' | 'NUMBER' | ZoneOffset.ofHoursMinutes(5, 30)     | '{"value":"+05:30"}'       | '{"value":"+02:30"}'           | '+02:30'           | { ZoneOffset z -> z.toString() }
+        'java.util.TimeZone'   | 'STRING' | TimeZone.getTimeZone('Europe/Paris') | '{"value":"Europe/Paris"}' | '{"value":"America/New_York"}' | 'America/New_York' | { TimeZone t -> t.ID }
+        'java.util.TimeZone'   | 'NUMBER' | TimeZone.getTimeZone('Europe/Paris') | '{"value":"Europe/Paris"}' | '{"value":"America/New_York"}' | 'America/New_York' | { TimeZone t -> t.ID }
     }
 
     void "test json format write dates with zone id for zoned date time"() {
@@ -2744,6 +2966,14 @@ class Test {
                 resolver: { OffsetDateTime v -> v.toInstant() }
             ],
             [
+                typeName: 'java.time.OffsetTime',
+                writeValue: OffsetTime.of(12, 30, 45, 456789123, ZoneOffset.ofHours(2)),
+                writeExpectedByShape: temporalShapeExpected('"12:30:45.456789123+02:00"', '"12:30:45.456789123+02:00"', '[12,30,45,456789123,"+02:00"]', '[12,30,45,456789123,"+02:00"]'),
+                readByShape: temporalShapeExpected('"12:30:45+02:00"', '"12:30:45+02:00"', '[12,30,45,"+02:00"]', '[12,30,45,"+02:00"]'),
+                readExpectedValue: OffsetTime.of(12, 30, 45, 0, ZoneOffset.ofHours(2)),
+                resolver: { OffsetTime v -> v }
+            ],
+            [
                 typeName: 'java.time.ZonedDateTime',
                 writeValue: ZonedDateTime.of(1970, 1, 1, 0, 2, 3, 456789123, ZoneOffset.UTC),
                 writeExpectedByShape: temporalShapeExpected('"1970-01-01T00:02:03.456789123Z"', '"1970-01-01T00:02:03.456789123Z"', '123.456789123', '123456'),
@@ -2758,6 +2988,30 @@ class Test {
                 readByShape: temporalShapeExpected('2024', '"2024"', '2024', '2024'),
                 readExpectedValue: Year.of(2024),
                 resolver: { Year v -> v }
+            ],
+            [
+                typeName: 'java.time.YearMonth',
+                writeValue: YearMonth.of(2024, 9),
+                writeExpectedByShape: temporalShapeExpected('"2024-09"', '"2024-09"', '[2024,9]', '[2024,9]'),
+                readByShape: temporalShapeExpected('"2024-09"', '"2024-09"', '[2024,9]', '[2024,9]'),
+                readExpectedValue: YearMonth.of(2024, 9),
+                resolver: { YearMonth v -> v }
+            ],
+            [
+                typeName: 'java.time.MonthDay',
+                writeValue: MonthDay.of(9, 8),
+                writeExpectedByShape: temporalShapeExpected('"--09-08"', '"--09-08"', '[9,8]', '[9,8]'),
+                readByShape: temporalShapeExpected('"--09-08"', '"--09-08"', '[9,8]', '[9,8]'),
+                readExpectedValue: MonthDay.of(9, 8),
+                resolver: { MonthDay v -> v }
+            ],
+            [
+                typeName: 'java.time.Month',
+                writeValue: Month.SEPTEMBER,
+                writeExpectedByShape: temporalShapeExpected('9', '9', '[9]', '[9]'),
+                readByShape: temporalShapeExpected('9', '9', '[9]', '[9]'),
+                readExpectedValue: Month.SEPTEMBER,
+                resolver: { Month v -> v }
             ]
         ]
     }
@@ -2830,6 +3084,14 @@ class Test {
         SHAPE_PROPERTIES.every { property ->
             resolver.call(bean."${property.field}") == expectedValue
         }
+    }
+
+    private static GregorianCalendar calendar(String timeZoneId, int millis = 0) {
+        def calendar = new GregorianCalendar(TimeZone.getTimeZone(timeZoneId))
+        calendar.clear()
+        calendar.set(2024, Calendar.SEPTEMBER, 8, 12, 30, 45)
+        calendar.set(Calendar.MILLISECOND, millis)
+        calendar
     }
 
     private static List<Map<String, Object>> enumFormatShapeVariations() {

--- a/serde-jsonb/src/main/java/io/micronaut/serde/jsonb/JsonbConfiguredSerde.java
+++ b/serde-jsonb/src/main/java/io/micronaut/serde/jsonb/JsonbConfiguredSerde.java
@@ -166,14 +166,6 @@ public final class JsonbConfiguredSerde implements Serde<Object> {
         );
         return new Deserializer<>() {
             @Override
-            public @Nullable Object deserializeNullable(Decoder decoder, DecoderContext context, Argument<? super Object> type) throws IOException {
-                if (decoder.decodeNull()) {
-                    return null;
-                }
-                return deserialize(decoder, context, type);
-            }
-
-            @Override
             public Object deserialize(Decoder decoder, DecoderContext context, Argument<? super Object> type) throws IOException {
                 JsonbRuntimeCustomizations.ConfigDeserializer configuredDeserializer = customizations.deserializer(type.asType());
                 if (configuredDeserializer != null) {

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/CalendarSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/CalendarSerde.java
@@ -18,27 +18,39 @@ package io.micronaut.serde.support.serdes;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Deserializer;
 import io.micronaut.serde.Encoder;
+import io.micronaut.serde.FormatConfiguration;
+import io.micronaut.serde.FormattedSerde;
+import io.micronaut.serde.Serde;
+import io.micronaut.serde.Serializer;
 import io.micronaut.serde.config.SerdeConfiguration;
+import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.SerdeRegistrar;
+import io.micronaut.serde.support.util.SerdeFeatures;
 
 import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
+import java.util.Optional;
 import java.util.TimeZone;
 
 /**
  * Serde mapping for calendar values.
  */
 @Internal
-final class CalendarSerde implements SerdeRegistrar<Calendar> {
+final class CalendarSerde implements FormattedSerde<Calendar>, SerdeRegistrar<Calendar> {
     private static final Argument<Calendar> ARGUMENT = Argument.of(Calendar.class);
     private static final DateTimeFormatter STRICT_IJSON_FORMATTER = DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss'Z'xxx");
     private final boolean strictIJson;
+    private final SerdeConfiguration.TimeShape writeShape;
+    private final Optional<SimpleDateFormat> configuredDateFormat;
 
     /**
      * @param serdeConfiguration The active Serde configuration used to select
@@ -46,6 +58,51 @@ final class CalendarSerde implements SerdeRegistrar<Calendar> {
      */
     CalendarSerde(SerdeConfiguration serdeConfiguration) {
         this.strictIJson = serdeConfiguration.isWriteDateTimesAsStrictIJson();
+        this.writeShape = serdeConfiguration.getTimeWriteShape();
+        this.configuredDateFormat = configuredDateFormat(serdeConfiguration);
+    }
+
+    @Override
+    public Serializer<Calendar> createSpecific(EncoderContext context, Argument<? extends Calendar> type) {
+        context = SerdeFeatures.withFeatures(context, type.getAnnotationMetadata());
+        FormatConfiguration format = FormatConfiguration.from(type.getAnnotationMetadata());
+        return format == null ? createSpecificWithoutFormat() : createSpecific(context, type, format);
+    }
+
+    @Override
+    public Serializer<Calendar> createSpecific(EncoderContext context,
+                                               Argument<? extends Calendar> type,
+                                               FormatConfiguration format) {
+        if (format.shape().isNumeric()) {
+            return new TimestampMillisCalendarSerde();
+        }
+        Optional<SimpleDateFormat> dateFormat = format.createDateFormat();
+        if (dateFormat.isPresent()) {
+            return new FormattedCalendarSerde(dateFormat.get());
+        }
+        return this;
+    }
+
+    @Override
+    public Deserializer<Calendar> createSpecific(DecoderContext context, Argument<? super Calendar> type)
+        throws SerdeException {
+        context = SerdeFeatures.withFeatures(context, type.getAnnotationMetadata());
+        FormatConfiguration format = FormatConfiguration.from(type.getAnnotationMetadata());
+        return format == null ? createSpecificWithoutFormat() : createSpecific(context, type, format);
+    }
+
+    @Override
+    public Deserializer<Calendar> createSpecific(DecoderContext context,
+                                                 Argument<? super Calendar> type,
+                                                 FormatConfiguration format) throws SerdeException {
+        if (format.shape().isNumeric()) {
+            return new TimestampMillisCalendarSerde();
+        }
+        Optional<SimpleDateFormat> dateFormat = format.createDateFormat();
+        if (dateFormat.isPresent()) {
+            return new FormattedCalendarSerde(dateFormat.get());
+        }
+        return this;
     }
 
     @Override
@@ -111,5 +168,80 @@ final class CalendarSerde implements SerdeRegistrar<Calendar> {
     @Override
     public Argument<Calendar> getType() {
         return ARGUMENT;
+    }
+
+    private Serde<Calendar> createSpecificWithoutFormat() {
+        if (configuredDateFormat.isPresent()) {
+            return new FormattedCalendarSerde(configuredDateFormat.get());
+        }
+        if (writeShape != SerdeConfiguration.TimeShape.STRING) {
+            return new TimestampMillisCalendarSerde();
+        }
+        return this;
+    }
+
+    private static Optional<SimpleDateFormat> configuredDateFormat(SerdeConfiguration configuration) {
+        return configuration.getDateFormat().map(pattern -> {
+            SimpleDateFormat dateFormat = configuration.getLocale()
+                .map(locale -> new SimpleDateFormat(pattern, locale))
+                .orElseGet(() -> new SimpleDateFormat(pattern));
+            configuration.getTimeZone().ifPresent(dateFormat::setTimeZone);
+            return dateFormat;
+        });
+    }
+
+    private static final class TimestampMillisCalendarSerde implements Serde<Calendar> {
+        @Override
+        public void serialize(Encoder encoder,
+                              EncoderContext context,
+                              Argument<? extends Calendar> type,
+                              Calendar value) throws IOException {
+            encoder.encodeLong(value.getTimeInMillis());
+        }
+
+        @Override
+        public Calendar deserialize(Decoder decoder,
+                                    DecoderContext decoderContext,
+                                    Argument<? super Calendar> type) throws IOException {
+            Calendar calendar = Calendar.getInstance();
+            calendar.setTimeInMillis(decoder.decodeLong());
+            return calendar;
+        }
+    }
+
+    private static final class FormattedCalendarSerde implements Serde<Calendar> {
+        private final SimpleDateFormat dateFormat;
+        private final String pattern;
+
+        private FormattedCalendarSerde(SimpleDateFormat dateFormat) {
+            this.dateFormat = dateFormat;
+            this.pattern = dateFormat.toPattern();
+        }
+
+        @Override
+        public void serialize(Encoder encoder,
+                              EncoderContext context,
+                              Argument<? extends Calendar> type,
+                              Calendar value) throws IOException {
+            synchronized (dateFormat) {
+                encoder.encodeString(dateFormat.format(value.getTime()));
+            }
+        }
+
+        @Override
+        public Calendar deserialize(Decoder decoder,
+                                    DecoderContext decoderContext,
+                                    Argument<? super Calendar> type) throws IOException {
+            String value = decoder.decodeString();
+            try {
+                Calendar calendar = Calendar.getInstance(dateFormat.getTimeZone());
+                synchronized (dateFormat) {
+                    calendar.setTime(dateFormat.parse(value));
+                }
+                return calendar;
+            } catch (ParseException e) {
+                throw new SerdeException("Error decoding calendar of type " + type + " using pattern " + pattern + ": " + e.getMessage(), e);
+            }
+        }
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/GregorianCalendarSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/GregorianCalendarSerde.java
@@ -18,7 +18,12 @@ package io.micronaut.serde.support.serdes;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Deserializer;
 import io.micronaut.serde.Encoder;
+import io.micronaut.serde.FormatConfiguration;
+import io.micronaut.serde.FormattedSerde;
+import io.micronaut.serde.Serializer;
+import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.SerdeRegistrar;
 import org.jspecify.annotations.Nullable;
 
@@ -30,7 +35,7 @@ import java.util.GregorianCalendar;
  * Serde mapping for {@link GregorianCalendar}.
  */
 @Internal
-final class GregorianCalendarSerde implements SerdeRegistrar<GregorianCalendar> {
+final class GregorianCalendarSerde implements FormattedSerde<GregorianCalendar>, SerdeRegistrar<GregorianCalendar> {
     private static final Argument<GregorianCalendar> ARGUMENT = Argument.of(GregorianCalendar.class);
     private static final Argument<Calendar> CALENDAR_ARGUMENT = Argument.of(Calendar.class);
 
@@ -41,6 +46,31 @@ final class GregorianCalendarSerde implements SerdeRegistrar<GregorianCalendar> 
      */
     GregorianCalendarSerde(CalendarSerde calendarSerde) {
         this.calendarSerde = calendarSerde;
+    }
+
+    @Override
+    public Serializer<GregorianCalendar> createSpecific(EncoderContext context, Argument<? extends GregorianCalendar> type) {
+        return serializer(calendarSerde.createSpecific(context, calendarType(type)));
+    }
+
+    @Override
+    public Serializer<GregorianCalendar> createSpecific(EncoderContext context,
+                                                        Argument<? extends GregorianCalendar> type,
+                                                        FormatConfiguration format) {
+        return serializer(calendarSerde.createSpecific(context, calendarType(type), format));
+    }
+
+    @Override
+    public Deserializer<GregorianCalendar> createSpecific(DecoderContext context, Argument<? super GregorianCalendar> type)
+        throws SerdeException {
+        return deserializer(calendarSerde.createSpecific(context, calendarSuperType(type)));
+    }
+
+    @Override
+    public Deserializer<GregorianCalendar> createSpecific(DecoderContext context,
+                                                          Argument<? super GregorianCalendar> type,
+                                                          FormatConfiguration format) throws SerdeException {
+        return deserializer(calendarSerde.createSpecific(context, calendarSuperType(type), format));
     }
 
     @Override
@@ -68,5 +98,53 @@ final class GregorianCalendarSerde implements SerdeRegistrar<GregorianCalendar> 
     @Override
     public Argument<GregorianCalendar> getType() {
         return ARGUMENT;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Argument<? extends Calendar> calendarType(Argument<? extends GregorianCalendar> type) {
+        return (Argument) type;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static Argument<? super Calendar> calendarSuperType(Argument<? super GregorianCalendar> type) {
+        return (Argument) type;
+    }
+
+    private static Serializer<GregorianCalendar> serializer(Serializer<Calendar> serializer) {
+        return new Serializer<>() {
+            @Override
+            public void serialize(Encoder encoder,
+                                  EncoderContext context,
+                                  Argument<? extends GregorianCalendar> type,
+                                  GregorianCalendar value) throws IOException {
+                serializer.serialize(encoder, context, calendarType(type), value);
+            }
+        };
+    }
+
+    private static Deserializer<GregorianCalendar> deserializer(Deserializer<Calendar> deserializer) {
+        return new Deserializer<>() {
+            @Override
+            public GregorianCalendar deserialize(Decoder decoder,
+                                                 DecoderContext decoderContext,
+                                                 Argument<? super GregorianCalendar> type) throws IOException {
+                return toGregorianCalendar(deserializer.deserialize(decoder, decoderContext, calendarSuperType(type)));
+            }
+
+            @Override
+            public @Nullable GregorianCalendar deserializeNullable(Decoder decoder,
+                                                                   DecoderContext context,
+                                                                   Argument<? super GregorianCalendar> type) throws IOException {
+                Calendar calendar = deserializer.deserializeNullable(decoder, context, calendarSuperType(type));
+                return calendar == null ? null : toGregorianCalendar(calendar);
+            }
+        };
+    }
+
+    private static GregorianCalendar toGregorianCalendar(Calendar calendar) {
+        GregorianCalendar gregorianCalendar = new GregorianCalendar(calendar.getTimeZone());
+        gregorianCalendar.clear();
+        gregorianCalendar.setTimeInMillis(calendar.getTimeInMillis());
+        return gregorianCalendar;
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/GregorianCalendarSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/GregorianCalendarSerde.java
@@ -88,14 +88,6 @@ final class GregorianCalendarSerde implements FormattedSerde<GregorianCalendar>,
     }
 
     @Override
-    public @Nullable GregorianCalendar deserializeNullable(Decoder decoder, DecoderContext context, Argument<? super GregorianCalendar> type) throws IOException {
-        if (decoder.decodeNull()) {
-            return null;
-        }
-        return deserialize(decoder, context, type);
-    }
-
-    @Override
     public Argument<GregorianCalendar> getType() {
         return ARGUMENT;
     }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/MonthDaySerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/MonthDaySerde.java
@@ -110,14 +110,6 @@ final class MonthDaySerde implements FormattedSerde<MonthDay>, SerdeRegistrar<Mo
     }
 
     @Override
-    public @Nullable MonthDay deserializeNullable(Decoder decoder, DecoderContext context, Argument<? super MonthDay> type) throws IOException {
-        if (decoder.decodeNull()) {
-            return null;
-        }
-        return deserialize(decoder, context, type);
-    }
-
-    @Override
     public Argument<MonthDay> getType() {
         return ARGUMENT;
     }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/MonthDaySerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/MonthDaySerde.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.FormatConfiguration;
+import io.micronaut.serde.FormattedSerde;
+import io.micronaut.serde.Serializer;
+import io.micronaut.serde.config.SerdeConfiguration;
+import io.micronaut.serde.exceptions.SerdeException;
+import io.micronaut.serde.support.SerdeRegistrar;
+import io.micronaut.serde.support.util.SerdeFeatures;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.time.MonthDay;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Serde mapping for {@link MonthDay}.
+ */
+@Internal
+final class MonthDaySerde implements FormattedSerde<MonthDay>, SerdeRegistrar<MonthDay> {
+    private static final Argument<MonthDay> ARGUMENT = Argument.of(MonthDay.class);
+
+    @Nullable
+    private final DateTimeFormatter formatter;
+    private final boolean arrayShape;
+
+    MonthDaySerde(SerdeConfiguration configuration) {
+        this(DefaultFormattedTemporalSerde.createFormatter(configuration).orElse(null), false);
+    }
+
+    private MonthDaySerde(@Nullable DateTimeFormatter formatter, boolean arrayShape) {
+        this.formatter = formatter;
+        this.arrayShape = arrayShape;
+    }
+
+    @Override
+    public Serializer<MonthDay> createSpecific(EncoderContext context, Argument<? extends MonthDay> type) {
+        context = SerdeFeatures.withFeatures(context, type.getAnnotationMetadata());
+        FormatConfiguration format = FormatConfiguration.from(type.getAnnotationMetadata());
+        return format == null ? this : createSpecific(context, type, format);
+    }
+
+    @Override
+    public Serializer<MonthDay> createSpecific(EncoderContext context,
+                                               Argument<? extends MonthDay> type,
+                                               FormatConfiguration format) {
+        return new MonthDaySerde(formatter(format), TemporalArrayShapeSupport.isNumericOrArrayShape(format));
+    }
+
+    @Override
+    public Deserializer<MonthDay> createSpecific(DecoderContext context, Argument<? super MonthDay> type)
+        throws SerdeException {
+        context = SerdeFeatures.withFeatures(context, type.getAnnotationMetadata());
+        FormatConfiguration format = FormatConfiguration.from(type.getAnnotationMetadata());
+        return format == null ? this : createSpecific(context, type, format);
+    }
+
+    @Override
+    public Deserializer<MonthDay> createSpecific(DecoderContext context,
+                                                 Argument<? super MonthDay> type,
+                                                 FormatConfiguration format) throws SerdeException {
+        return new MonthDaySerde(formatter(format), TemporalArrayShapeSupport.isNumericOrArrayShape(format));
+    }
+
+    @Override
+    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends MonthDay> type, MonthDay value) throws IOException {
+        if (arrayShape) {
+            try (Encoder arrayEncoder = encoder.encodeArray(type)) {
+                arrayEncoder.encodeInt(value.getMonthValue());
+                arrayEncoder.encodeInt(value.getDayOfMonth());
+            }
+            return;
+        }
+        encoder.encodeString(formatter == null ? value.toString() : formatter.format(value));
+    }
+
+    @Override
+    public MonthDay deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super MonthDay> type) throws IOException {
+        if (arrayShape) {
+            try (Decoder arrayDecoder = decoder.decodeArray(Argument.INT)) {
+                MonthDay value = MonthDay.of(arrayDecoder.decodeInt(), arrayDecoder.decodeInt());
+                if (arrayDecoder.hasNextArrayValue()) {
+                    throw decoder.createDeserializationException("Expected MonthDay array with month and day", null);
+                }
+                return value;
+            }
+        }
+        String value = decoder.decodeString();
+        return formatter == null ? MonthDay.parse(value) : MonthDay.parse(value, formatter);
+    }
+
+    @Override
+    public @Nullable MonthDay deserializeNullable(Decoder decoder, DecoderContext context, Argument<? super MonthDay> type) throws IOException {
+        if (decoder.decodeNull()) {
+            return null;
+        }
+        return deserialize(decoder, context, type);
+    }
+
+    @Override
+    public Argument<MonthDay> getType() {
+        return ARGUMENT;
+    }
+
+    @Nullable
+    private DateTimeFormatter formatter(FormatConfiguration format) {
+        return format.createDateTimeFormatter().orElse(formatter);
+    }
+
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/MonthSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/MonthSerde.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.FormatConfiguration;
+import io.micronaut.serde.FormattedSerde;
+import io.micronaut.serde.Serializer;
+import io.micronaut.serde.exceptions.SerdeException;
+import io.micronaut.serde.support.SerdeRegistrar;
+import io.micronaut.serde.support.util.SerdeFeatures;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.time.DateTimeException;
+import java.time.Month;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Serde mapping for {@link Month}.
+ */
+@Internal
+final class MonthSerde implements FormattedSerde<Month>, SerdeRegistrar<Month> {
+    private static final Argument<Month> ARGUMENT = Argument.of(Month.class);
+
+    @Nullable
+    private final DateTimeFormatter formatter;
+    private final boolean arrayShape;
+
+    MonthSerde() {
+        this(null, false);
+    }
+
+    private MonthSerde(@Nullable DateTimeFormatter formatter, boolean arrayShape) {
+        this.formatter = formatter;
+        this.arrayShape = arrayShape;
+    }
+
+    @Override
+    public Serializer<Month> createSpecific(EncoderContext context, Argument<? extends Month> type) {
+        context = SerdeFeatures.withFeatures(context, type.getAnnotationMetadata());
+        FormatConfiguration format = FormatConfiguration.from(type.getAnnotationMetadata());
+        return format == null ? this : createSpecific(context, type, format);
+    }
+
+    @Override
+    public Serializer<Month> createSpecific(EncoderContext context,
+                                            Argument<? extends Month> type,
+                                            FormatConfiguration format) {
+        return new MonthSerde(format.createDateTimeFormatter().orElse(formatter), TemporalArrayShapeSupport.isNumericOrArrayShape(format));
+    }
+
+    @Override
+    public Deserializer<Month> createSpecific(DecoderContext context, Argument<? super Month> type)
+        throws SerdeException {
+        context = SerdeFeatures.withFeatures(context, type.getAnnotationMetadata());
+        FormatConfiguration format = FormatConfiguration.from(type.getAnnotationMetadata());
+        return format == null ? this : createSpecific(context, type, format);
+    }
+
+    @Override
+    public Deserializer<Month> createSpecific(DecoderContext context,
+                                              Argument<? super Month> type,
+                                              FormatConfiguration format) throws SerdeException {
+        return new MonthSerde(format.createDateTimeFormatter().orElse(formatter), TemporalArrayShapeSupport.isNumericOrArrayShape(format));
+    }
+
+    @Override
+    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends Month> type, Month value) throws IOException {
+        if (arrayShape) {
+            try (Encoder arrayEncoder = encoder.encodeArray(type)) {
+                serializeScalar(arrayEncoder, value);
+            }
+            return;
+        }
+        serializeScalar(encoder, value);
+    }
+
+    @Override
+    public Month deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super Month> type) throws IOException {
+        if (arrayShape) {
+            try (Decoder arrayDecoder = decoder.decodeArray(formatter == null ? Argument.INT : Argument.STRING)) {
+                Month value = deserializeScalar(arrayDecoder);
+                if (arrayDecoder.hasNextArrayValue()) {
+                    throw decoder.createDeserializationException("Expected Month array with one value", null);
+                }
+                return value;
+            }
+        }
+        return deserializeScalar(decoder);
+    }
+
+    @Override
+    public @Nullable Month deserializeNullable(Decoder decoder, DecoderContext context, Argument<? super Month> type) throws IOException {
+        if (decoder.decodeNull()) {
+            return null;
+        }
+        return deserialize(decoder, context, type);
+    }
+
+    @Override
+    public Argument<Month> getType() {
+        return ARGUMENT;
+    }
+
+    private void serializeScalar(Encoder encoder, Month value) throws IOException {
+        if (formatter == null) {
+            encoder.encodeInt(value.getValue());
+        } else {
+            encoder.encodeString(formatter.format(value));
+        }
+    }
+
+    private Month deserializeScalar(Decoder decoder) throws IOException {
+        if (formatter == null) {
+            return month(decoder, decoder.decodeInt());
+        }
+        return month(decoder, decoder.decodeString());
+    }
+
+    private Month month(Decoder decoder, String value) throws IOException {
+        if (formatter != null) {
+            try {
+                return Month.from(formatter.parse(value));
+            } catch (DateTimeException e) {
+                throw decoder.createDeserializationException("Invalid Month value", value);
+            }
+        }
+        try {
+            return month(decoder, Integer.parseInt(value));
+        } catch (NumberFormatException ignored) {
+            // Fall through to enum-name handling.
+        }
+        try {
+            return Month.valueOf(value);
+        } catch (IllegalArgumentException e) {
+            throw decoder.createDeserializationException("Invalid Month value", value);
+        }
+    }
+
+    private static Month month(Decoder decoder, int value) throws IOException {
+        try {
+            return Month.of(value);
+        } catch (DateTimeException e) {
+            throw decoder.createDeserializationException("Month number outside 1-12 range", value);
+        }
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/MonthSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/MonthSerde.java
@@ -108,14 +108,6 @@ final class MonthSerde implements FormattedSerde<Month>, SerdeRegistrar<Month> {
     }
 
     @Override
-    public @Nullable Month deserializeNullable(Decoder decoder, DecoderContext context, Argument<? super Month> type) throws IOException {
-        if (decoder.decodeNull()) {
-            return null;
-        }
-        return deserialize(decoder, context, type);
-    }
-
-    @Override
     public Argument<Month> getType() {
         return ARGUMENT;
     }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/OffsetTimeSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/OffsetTimeSerde.java
@@ -18,28 +18,109 @@ package io.micronaut.serde.support.serdes;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Deserializer;
 import io.micronaut.serde.Encoder;
+import io.micronaut.serde.FormatConfiguration;
+import io.micronaut.serde.FormattedSerde;
+import io.micronaut.serde.Serializer;
+import io.micronaut.serde.config.DeserializationConfiguration;
+import io.micronaut.serde.config.SerdeConfiguration;
+import io.micronaut.serde.config.SerializationConfiguration;
+import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.SerdeRegistrar;
+import io.micronaut.serde.support.util.SerdeFeatures;
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
+import java.time.LocalTime;
 import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 
 /**
  * Serde mapping for {@link OffsetTime}.
  */
 @Internal
-final class OffsetTimeSerde implements SerdeRegistrar<OffsetTime> {
+final class OffsetTimeSerde implements FormattedSerde<OffsetTime>, SerdeRegistrar<OffsetTime> {
     private static final Argument<OffsetTime> ARGUMENT = Argument.of(OffsetTime.class);
+
+    private final DateTimeFormatter formatter;
+    private final boolean arrayShape;
+
+    OffsetTimeSerde() {
+        this(DateTimeFormatter.ISO_OFFSET_TIME, false);
+    }
+
+    OffsetTimeSerde(SerdeConfiguration configuration) {
+        this(DateTimeFormatter.ISO_OFFSET_TIME, configuration.getTimeWriteShape() != SerdeConfiguration.TimeShape.STRING);
+    }
+
+    private OffsetTimeSerde(DateTimeFormatter formatter, boolean arrayShape) {
+        this.formatter = formatter;
+        this.arrayShape = arrayShape;
+    }
+
+    @Override
+    public Serializer<OffsetTime> createSpecific(EncoderContext context, Argument<? extends OffsetTime> type) {
+        context = SerdeFeatures.withFeatures(context, type.getAnnotationMetadata());
+        FormatConfiguration format = FormatConfiguration.from(type.getAnnotationMetadata());
+        return format == null ? this : createSpecific(context, type, format);
+    }
+
+    @Override
+    public Serializer<OffsetTime> createSpecific(EncoderContext context,
+                                                 Argument<? extends OffsetTime> type,
+                                                 FormatConfiguration format) {
+        if (TemporalArrayShapeSupport.isNumericOrArrayShape(format)) {
+            return new OffsetTimeSerde(formatter(format), true);
+        }
+        return new OffsetTimeSerde(formatter(format), false);
+    }
+
+    @Override
+    public Deserializer<OffsetTime> createSpecific(DecoderContext context, Argument<? super OffsetTime> type)
+        throws SerdeException {
+        context = SerdeFeatures.withFeatures(context, type.getAnnotationMetadata());
+        FormatConfiguration format = FormatConfiguration.from(type.getAnnotationMetadata());
+        return format == null ? this : createSpecific(context, type, format);
+    }
+
+    @Override
+    public Deserializer<OffsetTime> createSpecific(DecoderContext context,
+                                                   Argument<? super OffsetTime> type,
+                                                   FormatConfiguration format) throws SerdeException {
+        if (TemporalArrayShapeSupport.isNumericOrArrayShape(format)) {
+            return new OffsetTimeSerde(formatter(format), true);
+        }
+        return new OffsetTimeSerde(formatter(format), false);
+    }
 
     @Override
     public void serialize(Encoder encoder, EncoderContext context, Argument<? extends OffsetTime> type, OffsetTime value) throws IOException {
-        encoder.encodeString(value.toString());
+        if (arrayShape) {
+            try (Encoder arrayEncoder = encoder.encodeArray(type)) {
+                TemporalArrayShapeSupport.serializeLocalTime(
+                    arrayEncoder,
+                    value.toLocalTime(),
+                    context.getFeatures().contains(SerializationConfiguration.Feature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)
+                );
+                arrayEncoder.encodeString(value.getOffset().toString());
+            }
+            return;
+        }
+        encoder.encodeString(formatter.format(value));
     }
 
     @Override
     public OffsetTime deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super OffsetTime> type) throws IOException {
-        return OffsetTime.parse(decoder.decodeString());
+        if (arrayShape) {
+            return deserializeArray(decoder, decoderContext);
+        }
+        return OffsetTime.from(formatter.parse(decoder.decodeString()));
     }
 
     @Override
@@ -53,5 +134,53 @@ final class OffsetTimeSerde implements SerdeRegistrar<OffsetTime> {
     @Override
     public Argument<OffsetTime> getType() {
         return ARGUMENT;
+    }
+
+    private DateTimeFormatter formatter(FormatConfiguration format) {
+        String pattern = format.pattern();
+        if (pattern == null) {
+            return formatter;
+        }
+        Locale locale = format.parseLocale();
+        DateTimeFormatter resolved = locale == null
+            ? DateTimeFormatter.ofPattern(pattern)
+            : DateTimeFormatter.ofPattern(pattern, locale);
+        if (Boolean.FALSE.equals(format.lenient())) {
+            resolved = resolved.withResolverStyle(ResolverStyle.STRICT);
+        }
+        if (format.timezone() != null) {
+            resolved = resolved.withZone(format.parseTimeZone().toZoneId());
+        }
+        return resolved;
+    }
+
+    private static OffsetTime deserializeArray(Decoder decoder, DecoderContext context) throws IOException {
+        List<String> values = new ArrayList<>(5);
+        try (Decoder arrayDecoder = decoder.decodeArray(Argument.OBJECT_ARGUMENT)) {
+            while (arrayDecoder.hasNextArrayValue()) {
+                values.add(arrayDecoder.decodeString());
+            }
+        }
+        if (values.size() < 3 || values.size() > 5) {
+            throw decoder.createDeserializationException("Expected OffsetTime array", values);
+        }
+        String offset = values.get(values.size() - 1);
+        int numericValues = values.size() - 1;
+        int hour = intValue(decoder, values.get(0));
+        int minute = intValue(decoder, values.get(1));
+        int second = numericValues > 2 ? intValue(decoder, values.get(2)) : 0;
+        int nano = numericValues > 3 ? intValue(decoder, values.get(3)) : 0;
+        if (!context.getFeatures().contains(DeserializationConfiguration.Feature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)) {
+            nano *= 1_000_000;
+        }
+        return OffsetTime.of(LocalTime.of(hour, minute, second, nano), ZoneOffset.of(offset));
+    }
+
+    private static int intValue(Decoder decoder, String value) throws IOException {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw decoder.createDeserializationException("Expected numeric OffsetTime array value", value);
+        }
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/OffsetTimeSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/OffsetTimeSerde.java
@@ -29,7 +29,6 @@ import io.micronaut.serde.config.SerializationConfiguration;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.SerdeRegistrar;
 import io.micronaut.serde.support.util.SerdeFeatures;
-import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.time.LocalTime;
@@ -121,14 +120,6 @@ final class OffsetTimeSerde implements FormattedSerde<OffsetTime>, SerdeRegistra
             return deserializeArray(decoder, decoderContext);
         }
         return OffsetTime.from(formatter.parse(decoder.decodeString()));
-    }
-
-    @Override
-    public @Nullable OffsetTime deserializeNullable(Decoder decoder, DecoderContext context, Argument<? super OffsetTime> type) throws IOException {
-        if (decoder.decodeNull()) {
-            return null;
-        }
-        return deserialize(decoder, context, type);
     }
 
     @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/PriorityQueueSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/PriorityQueueSerde.java
@@ -24,7 +24,6 @@ import io.micronaut.serde.Serializer;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.SerdeRegistrar;
 import jakarta.inject.Singleton;
-import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.util.PriorityQueue;
@@ -57,15 +56,6 @@ final class PriorityQueueSerde implements SerdeRegistrar<PriorityQueue<Object>> 
         Argument<Object> elementType = elementType(type);
         Deserializer<? extends Object> elementDeserializer = context.findDeserializer(elementType).createSpecific(context, elementType);
         return new Deserializer<>() {
-            @Override
-            @SuppressWarnings("java:S2638")
-            public @Nullable PriorityQueue<Object> deserializeNullable(Decoder decoder, DecoderContext context, Argument<? super PriorityQueue<Object>> type) throws IOException {
-                if (decoder.decodeNull()) {
-                    return null;
-                }
-                return deserialize(decoder, context, type);
-            }
-
             @Override
             public PriorityQueue<Object> deserialize(Decoder decoder, DecoderContext context, Argument<? super PriorityQueue<Object>> type) throws IOException {
                 PriorityQueue<Object> queue = new PriorityQueue<>();

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/Serdes.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/Serdes.java
@@ -109,7 +109,7 @@ public final class Serdes {
         consumer.accept(new GregorianCalendarSerde(calendarSerde));
         consumer.accept(new TimeZoneSerde(serdeConfiguration));
         consumer.accept(new ZoneOffsetSerde());
-        consumer.accept(new OffsetTimeSerde());
+        consumer.accept(new OffsetTimeSerde(serdeConfiguration));
         consumer.accept(new ByteArraySerde(serdeConfiguration));
         consumer.accept(new DurationSerde(serdeConfiguration));
         SERDES.forEach(consumer);
@@ -122,8 +122,12 @@ public final class Serdes {
         consumer.accept(new LocalDateTimeSerde(serdeConfiguration));
         consumer.accept(new OffsetDateTimeSerde(serdeConfiguration));
         consumer.accept(new SqlDateSerde(localDateSerde, instantSerde));
+        consumer.accept(new SqlTimeSerde());
         consumer.accept(new SqlTimestampSerde(instantSerde));
+        consumer.accept(new MonthSerde());
         consumer.accept(new YearSerde());
+        consumer.accept(new YearMonthSerde(serdeConfiguration));
+        consumer.accept(new MonthDaySerde(serdeConfiguration));
         consumer.accept(new ZonedDateTimeSerde(serdeConfiguration));
         consumer.accept(new EnumSerde<>(introspections));
         consumer.accept(new InetAddressSerde(serdeConfiguration));

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/SqlTimeSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/SqlTimeSerde.java
@@ -20,7 +20,6 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Encoder;
 import io.micronaut.serde.support.SerdeRegistrar;
-import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.sql.Time;
@@ -40,14 +39,6 @@ final class SqlTimeSerde implements SerdeRegistrar<Time> {
     @Override
     public Time deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super Time> type) throws IOException {
         return Time.valueOf(decoder.decodeString());
-    }
-
-    @Override
-    public @Nullable Time deserializeNullable(Decoder decoder, DecoderContext context, Argument<? super Time> type) throws IOException {
-        if (decoder.decodeNull()) {
-            return null;
-        }
-        return deserialize(decoder, context, type);
     }
 
     @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/SqlTimeSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/SqlTimeSerde.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.support.SerdeRegistrar;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.sql.Time;
+
+/**
+ * Serde mapping for {@link Time}.
+ */
+@Internal
+final class SqlTimeSerde implements SerdeRegistrar<Time> {
+    private static final Argument<Time> ARGUMENT = Argument.of(Time.class);
+
+    @Override
+    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends Time> type, Time value) throws IOException {
+        encoder.encodeString(value.toString());
+    }
+
+    @Override
+    public Time deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super Time> type) throws IOException {
+        return Time.valueOf(decoder.decodeString());
+    }
+
+    @Override
+    public @Nullable Time deserializeNullable(Decoder decoder, DecoderContext context, Argument<? super Time> type) throws IOException {
+        if (decoder.decodeNull()) {
+            return null;
+        }
+        return deserialize(decoder, context, type);
+    }
+
+    @Override
+    public Argument<Time> getType() {
+        return ARGUMENT;
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/YearMonthSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/YearMonthSerde.java
@@ -27,7 +27,6 @@ import io.micronaut.serde.config.SerdeConfiguration;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.SerdeRegistrar;
 import io.micronaut.serde.support.util.SerdeFeatures;
-import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.time.YearMonth;
@@ -109,14 +108,6 @@ final class YearMonthSerde implements FormattedSerde<YearMonth>, SerdeRegistrar<
             }
         }
         return YearMonth.parse(decoder.decodeString(), formatter);
-    }
-
-    @Override
-    public @Nullable YearMonth deserializeNullable(Decoder decoder, DecoderContext context, Argument<? super YearMonth> type) throws IOException {
-        if (decoder.decodeNull()) {
-            return null;
-        }
-        return deserialize(decoder, context, type);
     }
 
     @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/YearMonthSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/YearMonthSerde.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serdes;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.FormatConfiguration;
+import io.micronaut.serde.FormattedSerde;
+import io.micronaut.serde.Serializer;
+import io.micronaut.serde.config.SerdeConfiguration;
+import io.micronaut.serde.exceptions.SerdeException;
+import io.micronaut.serde.support.SerdeRegistrar;
+import io.micronaut.serde.support.util.SerdeFeatures;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Serde mapping for {@link YearMonth}.
+ */
+@Internal
+final class YearMonthSerde implements FormattedSerde<YearMonth>, SerdeRegistrar<YearMonth> {
+    private static final Argument<YearMonth> ARGUMENT = Argument.of(YearMonth.class);
+    private static final DateTimeFormatter DEFAULT_FORMATTER = DateTimeFormatter.ofPattern("u-MM");
+
+    private final DateTimeFormatter formatter;
+    private final boolean arrayShape;
+
+    YearMonthSerde(SerdeConfiguration configuration) {
+        this(
+            DefaultFormattedTemporalSerde.createFormatter(configuration).orElse(DEFAULT_FORMATTER),
+            configuration.getTimeWriteShape() != SerdeConfiguration.TimeShape.STRING
+        );
+    }
+
+    private YearMonthSerde(DateTimeFormatter formatter, boolean arrayShape) {
+        this.formatter = formatter;
+        this.arrayShape = arrayShape;
+    }
+
+    @Override
+    public Serializer<YearMonth> createSpecific(EncoderContext context, Argument<? extends YearMonth> type) {
+        context = SerdeFeatures.withFeatures(context, type.getAnnotationMetadata());
+        FormatConfiguration format = FormatConfiguration.from(type.getAnnotationMetadata());
+        return format == null ? this : createSpecific(context, type, format);
+    }
+
+    @Override
+    public Serializer<YearMonth> createSpecific(EncoderContext context,
+                                                Argument<? extends YearMonth> type,
+                                                FormatConfiguration format) {
+        return new YearMonthSerde(formatter(format), useArrayShape(format));
+    }
+
+    @Override
+    public Deserializer<YearMonth> createSpecific(DecoderContext context, Argument<? super YearMonth> type)
+        throws SerdeException {
+        context = SerdeFeatures.withFeatures(context, type.getAnnotationMetadata());
+        FormatConfiguration format = FormatConfiguration.from(type.getAnnotationMetadata());
+        return format == null ? this : createSpecific(context, type, format);
+    }
+
+    @Override
+    public Deserializer<YearMonth> createSpecific(DecoderContext context,
+                                                  Argument<? super YearMonth> type,
+                                                  FormatConfiguration format) throws SerdeException {
+        return new YearMonthSerde(formatter(format), useArrayShape(format));
+    }
+
+    @Override
+    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends YearMonth> type, YearMonth value) throws IOException {
+        if (arrayShape) {
+            try (Encoder arrayEncoder = encoder.encodeArray(type)) {
+                arrayEncoder.encodeInt(value.getYear());
+                arrayEncoder.encodeInt(value.getMonthValue());
+            }
+            return;
+        }
+        encoder.encodeString(formatter.format(value));
+    }
+
+    @Override
+    public YearMonth deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super YearMonth> type) throws IOException {
+        if (arrayShape) {
+            try (Decoder arrayDecoder = decoder.decodeArray(Argument.INT)) {
+                YearMonth value = YearMonth.of(arrayDecoder.decodeInt(), arrayDecoder.decodeInt());
+                if (arrayDecoder.hasNextArrayValue()) {
+                    throw decoder.createDeserializationException("Expected YearMonth array with year and month", null);
+                }
+                return value;
+            }
+        }
+        return YearMonth.parse(decoder.decodeString(), formatter);
+    }
+
+    @Override
+    public @Nullable YearMonth deserializeNullable(Decoder decoder, DecoderContext context, Argument<? super YearMonth> type) throws IOException {
+        if (decoder.decodeNull()) {
+            return null;
+        }
+        return deserialize(decoder, context, type);
+    }
+
+    @Override
+    public Argument<YearMonth> getType() {
+        return ARGUMENT;
+    }
+
+    private DateTimeFormatter formatter(FormatConfiguration format) {
+        return format.createDateTimeFormatter().orElse(formatter);
+    }
+
+    private boolean useArrayShape(FormatConfiguration format) {
+        if (format.shape() == FormatConfiguration.Shape.STRING) {
+            return false;
+        }
+        if (TemporalArrayShapeSupport.isNumericOrArrayShape(format)) {
+            return true;
+        }
+        return format.pattern() == null && arrayShape;
+    }
+
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/ZoneOffsetSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/ZoneOffsetSerde.java
@@ -20,7 +20,6 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Encoder;
 import io.micronaut.serde.support.SerdeRegistrar;
-import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
 import java.time.ZoneOffset;
@@ -40,14 +39,6 @@ final class ZoneOffsetSerde implements SerdeRegistrar<ZoneOffset> {
     @Override
     public ZoneOffset deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super ZoneOffset> type) throws IOException {
         return ZoneOffset.of(decoder.decodeString());
-    }
-
-    @Override
-    public @Nullable ZoneOffset deserializeNullable(Decoder decoder, DecoderContext context, Argument<? super ZoneOffset> type) throws IOException {
-        if (decoder.decodeNull()) {
-            return null;
-        }
-        return deserialize(decoder, context, type);
     }
 
     @Override


### PR DESCRIPTION
Implemented Jackson parity for additional date/time types in Micronaut Serialization.

Added support/registration for:
- `java.time.YearMonth`
- `java.time.MonthDay`
- `java.time.Month`
- `java.sql.Time`

Extended existing behavior/tests for:
- `OffsetTime`
- `ZoneOffset`
- `TimeZone`
- `Calendar`
- `GregorianCalendar`

Main behavior updates:
- `@JsonFormat` shape handling now covers the missing temporal types.
- Array/numeric temporal forms mirror Jackson where applicable.
- Deserialization now mirrors serialization shape selection directly, using array/scalar decoders instead of `decodeArbitrary`.
- `java.sql.Time` is tested for scalar shapes only because Jackson does not treat `ARRAY` as a normal temporal array for it.
