### PR TITLE
Implement JsonMerge update support

### DIFF
--- a/doc-examples/example-java/src/main/java/example/ReleaseConfiguration.java
+++ b/doc-examples/example-java/src/main/java/example/ReleaseConfiguration.java
@@ -1,0 +1,71 @@
+package example;
+
+import com.fasterxml.jackson.annotation.JsonMerge;
+import io.micronaut.serde.annotation.Serdeable;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Serdeable
+public class ReleaseConfiguration {
+    private String service = "";
+    private String owner = "";
+    @JsonMerge
+    private DeploymentWindow deploymentWindow = new DeploymentWindow();
+    @JsonMerge
+    private Map<String, String> labels = new LinkedHashMap<>();
+
+    public String getService() {
+        return service;
+    }
+
+    public void setService(String service) {
+        this.service = service;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    public DeploymentWindow getDeploymentWindow() {
+        return deploymentWindow;
+    }
+
+    public void setDeploymentWindow(DeploymentWindow deploymentWindow) {
+        this.deploymentWindow = deploymentWindow;
+    }
+
+    public Map<String, String> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(Map<String, String> labels) {
+        this.labels = labels;
+    }
+
+    @Serdeable
+    public static class DeploymentWindow {
+        private String day = "";
+        private String timeZone = "";
+
+        public String getDay() {
+            return day;
+        }
+
+        public void setDay(String day) {
+            this.day = day;
+        }
+
+        public String getTimeZone() {
+            return timeZone;
+        }
+
+        public void setTimeZone(String timeZone) {
+            this.timeZone = timeZone;
+        }
+    }
+}

--- a/doc-examples/example-java/src/test/java/example/JsonMergeExampleTest.java
+++ b/doc-examples/example-java/src/test/java/example/JsonMergeExampleTest.java
@@ -1,0 +1,73 @@
+package example;
+
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.ObjectMapper;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+@MicronautTest
+public class JsonMergeExampleTest {
+
+    @Test
+    void testMergeNestedReleaseConfiguration(ObjectMapper objectMapper) throws IOException {
+        ReleaseConfiguration release = new ReleaseConfiguration();
+        release.setService("checkout");
+        release.setOwner("platform");
+
+        ReleaseConfiguration.DeploymentWindow window = new ReleaseConfiguration.DeploymentWindow();
+        window.setDay("Friday");
+        window.setTimeZone("UTC");
+        release.setDeploymentWindow(window);
+
+        objectMapper.updateValue(
+            release,
+            Argument.of(ReleaseConfiguration.class),
+            """
+            {
+              "owner": "growth",
+              "deploymentWindow": {
+                "day": "Tuesday"
+              }
+            }
+            """.getBytes(StandardCharsets.UTF_8)
+        );
+
+        assertEquals("growth", release.getOwner());
+        assertSame(window, release.getDeploymentWindow());
+        assertEquals("Tuesday", release.getDeploymentWindow().getDay());
+        assertEquals("UTC", release.getDeploymentWindow().getTimeZone());
+    }
+
+    @Test
+    void testMergeReleaseLabels(ObjectMapper objectMapper) throws IOException {
+        ReleaseConfiguration release = new ReleaseConfiguration();
+        release.setLabels(new java.util.LinkedHashMap<>(Map.of(
+            "environment", "production",
+            "region", "us-east"
+        )));
+
+        objectMapper.updateValue(
+            release,
+            Argument.of(ReleaseConfiguration.class),
+            """
+            {
+              "labels": {
+                "version": "2026.06",
+                "region": "eu-west"
+              }
+            }
+            """.getBytes(StandardCharsets.UTF_8)
+        );
+
+        assertEquals("production", release.getLabels().get("environment"));
+        assertEquals("eu-west", release.getLabels().get("region"));
+        assertEquals("2026.06", release.getLabels().get("version"));
+    }
+}

--- a/serde-api/src/main/java/io/micronaut/serde/ObjectMapper.java
+++ b/serde-api/src/main/java/io/micronaut/serde/ObjectMapper.java
@@ -15,15 +15,19 @@
  */
 package io.micronaut.serde;
 
+import io.micronaut.core.annotation.Experimental;
+import io.micronaut.core.io.buffer.ByteBuffer;
+import io.micronaut.core.type.Argument;
 import io.micronaut.json.JsonFeatures;
 import io.micronaut.json.JsonMapper;
+import io.micronaut.json.tree.JsonNode;
 import io.micronaut.serde.config.DeserializationConfiguration;
 import io.micronaut.serde.config.SerdeConfiguration;
 import io.micronaut.serde.config.SerializationConfiguration;
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import java.io.InputStream;
 import java.util.Map;
 import java.util.Objects;
 
@@ -34,11 +38,117 @@ import java.util.Objects;
  */
 public interface ObjectMapper extends JsonMapper {
 
-    // Delete when this is merged and core is released in RC2 https://github.com/micronaut-projects/micronaut-core/pull/9453
-    @Override
-    default String writeValueAsString(@Nullable Object object) throws IOException {
-        Objects.requireNonNull(object, "Object cannot be null");
-        return new String(writeValueAsBytes(object), StandardCharsets.UTF_8);
+    /**
+     * Update an existing mutable value from the supplied override value.
+     *
+     * <p>The override value is converted to a JSON tree and applied through
+     * {@link #updateValueFromTree(Object, JsonNode)}. Supported update semantics are implementation-specific;
+     * immutable, creator-only, and builder-only values may be rejected.</p>
+     *
+     * @param valueToUpdate The existing value to update
+     * @param overrides The override value containing fields to apply
+     * @param <T> The value type
+     * @return The updated {@code valueToUpdate}
+     * @throws IOException If an I/O or decoding error occurs
+     * @since 3.1
+     */
+    @Experimental
+    @SuppressWarnings("unchecked")
+    default <T> T updateValue(T valueToUpdate, @Nullable Object overrides) throws IOException {
+        Objects.requireNonNull(valueToUpdate, "Value to update cannot be null");
+        return updateValue(valueToUpdate, (Argument<T>) Argument.of(valueToUpdate.getClass()), overrides);
+    }
+
+    /**
+     * Update an existing mutable value from the supplied override value.
+     *
+     * <p>The override value is converted to a JSON tree and applied through
+     * {@link #updateValueFromTree(Object, JsonNode)}. Supported update semantics are implementation-specific;
+     * immutable, creator-only, and builder-only values may be rejected.</p>
+     *
+     * @param valueToUpdate The existing value to update
+     * @param type The type of the value to update
+     * @param overrides The override value containing fields to apply
+     * @param <T> The value type
+     * @return The updated {@code valueToUpdate}
+     * @throws IOException If an I/O or decoding error occurs
+     * @since 3.1
+     */
+    @Experimental
+    default <T> T updateValue(T valueToUpdate, Argument<T> type, @Nullable Object overrides) throws IOException {
+        Objects.requireNonNull(valueToUpdate, "Value to update cannot be null");
+        Objects.requireNonNull(type, "Type cannot be null");
+        if (overrides == null) {
+            return valueToUpdate;
+        }
+        JsonNode tree = overrides instanceof JsonNode jsonNode ? jsonNode : writeValueToTree(overrides);
+        updateValueFromTree(valueToUpdate, tree);
+        return valueToUpdate;
+    }
+
+    /**
+     * Update an existing mutable value from JSON read from the supplied input stream.
+     *
+     * @param valueToUpdate The existing value to update
+     * @param inputStream The input stream containing JSON fields to apply
+     * @param <T> The value type
+     * @return The updated {@code valueToUpdate}
+     * @throws IOException If an I/O or decoding error occurs
+     * @param type The type of the value to update
+     * @since 3.1
+     */
+    @Experimental
+    default <T> T updateValue(T valueToUpdate, Argument<T> type, InputStream inputStream) throws IOException {
+        Objects.requireNonNull(valueToUpdate, "Value to update cannot be null");
+        Objects.requireNonNull(type, "Type cannot be null");
+        Objects.requireNonNull(inputStream, "Input stream cannot be null");
+        JsonNode tree = readValue(inputStream, JsonNode.class);
+        if (tree != null) {
+            updateValueFromTree(valueToUpdate, tree);
+        }
+        return valueToUpdate;
+    }
+
+    /**
+     * Update an existing mutable value from JSON read from the supplied byte array.
+     *
+     * @param valueToUpdate The existing value to update
+     * @param byteArray The byte array containing JSON fields to apply
+     * @param <T> The value type
+     * @return The updated {@code valueToUpdate}
+     * @throws IOException If an I/O or decoding error occurs
+     * @param type The type of the value to update
+     * @since 3.1
+     */
+    @Experimental
+    default <T> T updateValue(T valueToUpdate, Argument<T> type, byte[] byteArray) throws IOException {
+        Objects.requireNonNull(valueToUpdate, "Value to update cannot be null");
+        Objects.requireNonNull(type, "Type cannot be null");
+        Objects.requireNonNull(byteArray, "Byte array cannot be null");
+        JsonNode tree = readValue(byteArray, JsonNode.class);
+        if (tree != null) {
+            updateValueFromTree(valueToUpdate, tree);
+        }
+        return valueToUpdate;
+    }
+
+    /**
+     * Update an existing mutable value from JSON read from the supplied byte buffer.
+     *
+     * @param valueToUpdate The existing value to update
+     * @param byteBuffer The byte buffer containing JSON fields to apply
+     * @param <T> The value type
+     * @return The updated {@code valueToUpdate}
+     * @throws IOException If an I/O or decoding error occurs
+     * @param type The type of the value to update
+     * @since 3.1
+     */
+    @Experimental
+    default <T> T updateValue(T valueToUpdate, Argument<T> type, ByteBuffer<?> byteBuffer) throws IOException {
+        Objects.requireNonNull(valueToUpdate, "Value to update cannot be null");
+        Objects.requireNonNull(type, "Type cannot be null");
+        Objects.requireNonNull(byteBuffer, "Byte buffer cannot be null");
+        return updateValue(valueToUpdate, type, byteBuffer.toByteArray());
     }
 
     @Override

--- a/serde-api/src/main/java/io/micronaut/serde/ObjectMappers.java
+++ b/serde-api/src/main/java/io/micronaut/serde/ObjectMappers.java
@@ -18,6 +18,7 @@ package io.micronaut.serde;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.context.ApplicationContextBuilder;
 import io.micronaut.context.env.PropertySource;
+import io.micronaut.core.io.buffer.ByteBuffer;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.json.JsonStreamConfig;
@@ -111,6 +112,31 @@ final class ObjectMappers {
                                                        @Nullable DeserializationConfiguration deserializationConfiguration,
                                                        SerdeIntrospections introspections) {
                 return objectMapper.cloneWithConfiguration(configuration, serializationConfiguration, deserializationConfiguration, introspections);
+            }
+
+            @Override
+            public <T> T updateValue(T valueToUpdate, @Nullable Object overrides) throws IOException {
+                return objectMapper.updateValue(valueToUpdate, overrides);
+            }
+
+            @Override
+            public <T> T updateValue(T valueToUpdate, Argument<T> type, @Nullable Object overrides) throws IOException {
+                return objectMapper.updateValue(valueToUpdate, type, overrides);
+            }
+
+            @Override
+            public <T> T updateValue(T valueToUpdate, Argument<T> type, InputStream inputStream) throws IOException {
+                return objectMapper.updateValue(valueToUpdate, type, inputStream);
+            }
+
+            @Override
+            public <T> T updateValue(T valueToUpdate, Argument<T> type, byte[] byteArray) throws IOException {
+                return objectMapper.updateValue(valueToUpdate, type, byteArray);
+            }
+
+            @Override
+            public <T> T updateValue(T valueToUpdate, Argument<T> type, ByteBuffer<?> byteBuffer) throws IOException {
+                return objectMapper.updateValue(valueToUpdate, type, byteBuffer);
             }
 
             @Override

--- a/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
@@ -98,6 +98,11 @@ public @interface SerdeConfig {
     String INCLUDE_CONTENT = "includeContent";
 
     /**
+     * Whether an existing value should be updated instead of replaced.
+     */
+    String MERGE = "merge";
+
+    /**
      * Property filter name.
      */
     String FILTER = "filter";

--- a/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonMergeSpec.groovy
+++ b/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonMergeSpec.groovy
@@ -1,0 +1,812 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.jackson
+
+import io.micronaut.core.io.buffer.ByteArrayBufferFactory
+import io.micronaut.core.type.Argument
+import io.micronaut.json.tree.JsonNode
+import io.micronaut.serde.ObjectMapper
+import spock.lang.IgnoreIf
+
+import java.nio.charset.StandardCharsets
+
+abstract class JsonMergeSpec extends JsonCompileSpec {
+
+    protected boolean expectsRecordLikeUpdateUnsupported() {
+        true
+    }
+
+    protected boolean appliesJsonPropertyDefaultValueOnRead() {
+        true
+    }
+
+    protected boolean failsOnMissingRequiredPropertyOnRead() {
+        true
+    }
+
+    protected boolean preservesAbsentUnwrappedValueOnUpdate() {
+        true
+    }
+
+    void "@JsonMerge nested bean updates existing value"() {
+        given:
+        def context = buildContext("test.MergeRoot", nestedBeanSource("MergeRoot", "@JsonMerge"))
+        def root = newInstance(context, "test.MergeRoot", [:])
+        def child = newInstance(context, "test.MergeRoot\$Child", [left: "keep", right: "old"])
+        def patchChild = newInstance(context, "test.MergeRoot\$Child", [right: "new"])
+        def patch = newInstance(context, "test.MergeRoot\$Patch", [child: patchChild])
+        root.child = child
+
+        when:
+        def result = update(root, argumentOf(context, "test.MergeRoot"), patch)
+
+        then:
+        result.is(root)
+        root.child.is(child)
+        root.child.left == "keep"
+        root.child.right == "new"
+
+        cleanup:
+        context.close()
+    }
+
+    void "nested bean without @JsonMerge replaces value"() {
+        given:
+        def context = buildContext("test.ReplaceRoot", nestedBeanSource("ReplaceRoot", ""))
+        def root = newInstance(context, "test.ReplaceRoot", [:])
+        def child = newInstance(context, "test.ReplaceRoot\$Child", [left: "old-left", right: "old-right"])
+        root.child = child
+
+        when:
+        updateBytes(root, argumentOf(context, "test.ReplaceRoot"), '{"child":{"right":"new"}}')
+
+        then:
+        !root.child.is(child)
+        root.child.left == null
+        root.child.right == "new"
+
+        cleanup:
+        context.close()
+    }
+
+    void "@JsonMerge false keeps replacement behavior"() {
+        given:
+        def context = buildContext("test.MergeFalseRoot", nestedBeanSource("MergeFalseRoot", "@JsonMerge(OptBoolean.FALSE)"))
+        def root = newInstance(context, "test.MergeFalseRoot", [:])
+        def child = newInstance(context, "test.MergeFalseRoot\$Child", [left: "old-left", right: "old-right"])
+        root.child = child
+
+        when:
+        updateStream(root, argumentOf(context, "test.MergeFalseRoot"), '{"child":{"right":"new"}}')
+
+        then:
+        !root.child.is(child)
+        root.child.left == null
+        root.child.right == "new"
+
+        cleanup:
+        context.close()
+    }
+
+    void "nested release window without @JsonMerge is replaced"() {
+        given:
+        def context = buildContext("test.ReleasePlanWithoutMerge", releasePlanSource("ReleasePlanWithoutMerge", ""))
+        def releasePlan = newInstance(context, "test.ReleasePlanWithoutMerge", [
+                service: "checkout",
+                owner: "platform",
+                rolloutWindow: newInstance(context, "test.ReleasePlanWithoutMerge\$RolloutWindow", [day: "Friday", timeZone: "UTC"])
+        ])
+        def rolloutWindow = releasePlan.rolloutWindow
+
+        when:
+        def result = updateBytes(releasePlan, argumentOf(context, "test.ReleasePlanWithoutMerge"),
+                '{"owner":"growth","rolloutWindow":{"day":"Tuesday"}}')
+
+        then:
+        result.is(releasePlan)
+        releasePlan.service == "checkout"
+        releasePlan.owner == "growth"
+        !releasePlan.rolloutWindow.is(rolloutWindow)
+        releasePlan.rolloutWindow.day == "Tuesday"
+        releasePlan.rolloutWindow.timeZone == null
+
+        cleanup:
+        context.close()
+    }
+
+    void "nested release window with @JsonMerge preserves absent fields"() {
+        given:
+        def context = buildContext("test.ReleasePlanWithMerge", releasePlanSource("ReleasePlanWithMerge", "@JsonMerge"))
+        def releasePlan = newInstance(context, "test.ReleasePlanWithMerge", [
+                service: "checkout",
+                owner: "platform",
+                rolloutWindow: newInstance(context, "test.ReleasePlanWithMerge\$RolloutWindow", [day: "Friday", timeZone: "UTC"])
+        ])
+        def rolloutWindow = releasePlan.rolloutWindow
+
+        when:
+        def result = updateStream(releasePlan, argumentOf(context, "test.ReleasePlanWithMerge"),
+                '{"owner":"growth","rolloutWindow":{"day":"Tuesday"}}')
+
+        then:
+        result.is(releasePlan)
+        releasePlan.service == "checkout"
+        releasePlan.owner == "growth"
+        releasePlan.rolloutWindow.is(rolloutWindow)
+        releasePlan.rolloutWindow.day == "Tuesday"
+        releasePlan.rolloutWindow.timeZone == "UTC"
+
+        cleanup:
+        context.close()
+    }
+
+    void "@JsonMerge map updates existing keys and adds new keys"() {
+        given:
+        def context = buildContext("test.MergeMapRoot", """
+package test;
+
+import com.fasterxml.jackson.annotation.JsonMerge;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Serdeable
+public class MergeMapRoot {
+    @JsonMerge
+    private Map<String, Child> children = new LinkedHashMap<>();
+
+    public Map<String, Child> getChildren() {
+        return children;
+    }
+
+    public void setChildren(Map<String, Child> children) {
+        this.children = children;
+    }
+
+    @Serdeable
+    public static class Child {
+        private String left;
+        private String right;
+
+        public String getLeft() {
+            return left;
+        }
+
+        public void setLeft(String left) {
+            this.left = left;
+        }
+
+        public String getRight() {
+            return right;
+        }
+
+        public void setRight(String right) {
+            this.right = right;
+        }
+    }
+}
+""")
+        def root = newInstance(context, "test.MergeMapRoot", [:])
+        def children = root.children
+        def existing = newInstance(context, "test.MergeMapRoot\$Child", [left: "keep", right: "old"])
+        children.one = existing
+
+        when:
+        update(root, argumentOf(context, "test.MergeMapRoot"), [children: [one: [right: "new"], two: [left: "added"]]])
+
+        then:
+        root.children.is(children)
+        root.children.one.is(existing)
+        root.children.one.left == "keep"
+        root.children.one.right == "new"
+        root.children.two.left == "added"
+
+        cleanup:
+        context.close()
+    }
+
+    void "@JsonMerge labels map keeps existing entries"() {
+        given:
+        def context = buildContext("test.MergeLabelsRoot", """
+package test;
+
+import com.fasterxml.jackson.annotation.JsonMerge;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Serdeable
+public class MergeLabelsRoot {
+    private String service;
+
+    @JsonMerge
+    private Map<String, String> labels = new LinkedHashMap<>();
+
+    public String getService() {
+        return service;
+    }
+
+    public void setService(String service) {
+        this.service = service;
+    }
+
+    public Map<String, String> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(Map<String, String> labels) {
+        this.labels = labels;
+    }
+}
+""")
+        def root = newInstance(context, "test.MergeLabelsRoot", [service: "checkout"])
+        def labels = root.labels
+        labels.environment = "production"
+
+        when:
+        def result = updateBuffer(root, argumentOf(context, "test.MergeLabelsRoot"),
+                '{"labels":{"version":"2026.06","region":"eu-west"}}')
+
+        then:
+        result.is(root)
+        root.service == "checkout"
+        root.labels.is(labels)
+        root.labels == [environment: "production", version: "2026.06", region: "eu-west"]
+
+        cleanup:
+        context.close()
+    }
+
+    void "@JsonMerge collection appends incoming values"() {
+        given:
+        def context = buildContext("test.MergeListRoot", """
+package test;
+
+import com.fasterxml.jackson.annotation.JsonMerge;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.ArrayList;
+import java.util.List;
+
+@Serdeable
+public class MergeListRoot {
+    @JsonMerge
+    private List<String> values = new ArrayList<>();
+
+    public List<String> getValues() {
+        return values;
+    }
+
+    public void setValues(List<String> values) {
+        this.values = values;
+    }
+}
+""")
+        def root = newInstance(context, "test.MergeListRoot", [:])
+        def values = root.values
+        values.add("a")
+
+        when:
+        updateBuffer(root, argumentOf(context, "test.MergeListRoot"), '{"values":["b","c"]}')
+
+        then:
+        root.values.is(values)
+        root.values == ["a", "b", "c"]
+
+        cleanup:
+        context.close()
+    }
+
+    void "@JsonMerge array appends incoming array values"() {
+        given:
+        def context = buildContext("test.MergeArrayRoot", """
+package test;
+
+import com.fasterxml.jackson.annotation.JsonMerge;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public class MergeArrayRoot {
+    @JsonMerge
+    private String[] values;
+
+    public String[] getValues() {
+        return values;
+    }
+
+    public void setValues(String[] values) {
+        this.values = values;
+    }
+}
+""")
+        def root = newInstance(context, "test.MergeArrayRoot", [values: ["a"] as String[]])
+        def values = root.values
+
+        when:
+        update(root, argumentOf(context, "test.MergeArrayRoot"), [values: ["b", "c"]])
+
+        then:
+        !root.values.is(values)
+        root.values as List == ["a", "b", "c"]
+
+        cleanup:
+        context.close()
+    }
+
+    void "updateValueFromTree mutable bean updates present fields only"() {
+        given:
+        def context = buildContext("test.GeneratedUpdateRoot", """
+package test;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public class GeneratedUpdateRoot {
+    private String changed;
+    private String unchanged;
+
+    public String getChanged() {
+        return changed;
+    }
+
+    public void setChanged(String changed) {
+        this.changed = changed;
+    }
+
+    public String getUnchanged() {
+        return unchanged;
+    }
+
+    public void setUnchanged(String unchanged) {
+        this.unchanged = unchanged;
+    }
+}
+""")
+        def root = newInstance(context, "test.GeneratedUpdateRoot", [changed: "old", unchanged: "keep"])
+
+        when:
+        jsonMapper.updateValueFromTree(root, JsonNode.from([changed: "new"]))
+
+        then:
+        root.changed == "new"
+        root.unchanged == "keep"
+
+        cleanup:
+        context.close()
+    }
+
+    @IgnoreIf({ !instance.appliesJsonPropertyDefaultValueOnRead() })
+    void "readValue still applies property defaults for new simple beans"() {
+        given:
+        def context = buildContext("test.UpdateDefaultsRoot", updateDefaultsRootSource())
+
+        when:
+        def root = jsonMapper.readValue('{"required":"present"}', argumentOf(context, "test.UpdateDefaultsRoot"))
+
+        then:
+        root.defaulted == "from-default"
+        root.defaultedPrimitive == 33
+        root.required == "present"
+
+        cleanup:
+        context.close()
+    }
+
+    @IgnoreIf({ !instance.failsOnMissingRequiredPropertyOnRead() })
+    void "readValue still applies required checks for new simple beans"() {
+        given:
+        def context = buildContext("test.UpdateDefaultsRoot", updateDefaultsRootSource())
+
+        when:
+        jsonMapper.readValue('{}', argumentOf(context, "test.UpdateDefaultsRoot"))
+
+        then:
+        def e = thrown(Exception)
+        e.message.contains("Required property") || e.message.contains("required")
+
+        cleanup:
+        context.close()
+    }
+
+    void "updateValue skips applyDefaults for absent simple bean properties with #mode input"() {
+        given:
+        def context = buildContext("test.UpdateDefaultsRoot", updateDefaultsRootSource())
+        def root = newInstance(context, "test.UpdateDefaultsRoot", [
+                changed: "old",
+                defaulted: "keep-default",
+                required: "keep-required",
+                defaultedPrimitive: 9
+        ])
+
+        when:
+        def result = updateByMode(mode, root, argumentOf(context, "test.UpdateDefaultsRoot"), '{"changed":"new"}')
+
+        then:
+        result.is(root)
+        root.changed == "new"
+        root.defaulted == "keep-default"
+        root.required == "keep-required"
+        root.defaultedPrimitive == 9
+
+        cleanup:
+        context.close()
+
+        where:
+        mode << ["object", "bytes", "stream", "buffer", "tree"]
+    }
+
+    @IgnoreIf({ !instance.appliesJsonPropertyDefaultValueOnRead() })
+    void "readValue still applies unwrapped defaults for new specific beans"() {
+        given:
+        def context = buildContext("test.UpdateUnwrappedDefaultsRoot", updateUnwrappedDefaultsRootSource())
+
+        when:
+        def root = jsonMapper.readValue('{}', argumentOf(context, "test.UpdateUnwrappedDefaultsRoot"))
+
+        then:
+        root.name != null
+        root.name.first == "from-unwrapped-default"
+        root.name.last == "from-unwrapped-last"
+
+        cleanup:
+        context.close()
+    }
+
+    @IgnoreIf({ !instance.preservesAbsentUnwrappedValueOnUpdate() })
+    void "updateValue skips applyDefaults for absent unwrapped properties with #mode input"() {
+        given:
+        def context = buildContext("test.UpdateUnwrappedDefaultsRoot", updateUnwrappedDefaultsRootSource())
+        def name = newInstance(context, "test.UpdateUnwrappedDefaultsRoot\$Name", [
+                first: "keep-first",
+                last: "keep-last"
+        ])
+        def root = newInstance(context, "test.UpdateUnwrappedDefaultsRoot", [
+                changed: "old",
+                name: name
+        ])
+
+        when:
+        def result = updateByMode(mode, root, argumentOf(context, "test.UpdateUnwrappedDefaultsRoot"), '{"changed":"new"}')
+
+        then:
+        result.is(root)
+        root.changed == "new"
+        root.name.is(name)
+        root.name.first == "keep-first"
+        root.name.last == "keep-last"
+
+        cleanup:
+        context.close()
+
+        where:
+        mode << ["object", "bytes", "stream", "buffer", "tree"]
+    }
+
+    @IgnoreIf({ !instance.expectsRecordLikeUpdateUnsupported() })
+    void "record-like update is unsupported"() {
+        given:
+        def context = buildContext("test.ImmutableRoot", """
+package test;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public record ImmutableRoot(String name) {
+}
+""")
+        def root = newInstance(context, "test.ImmutableRoot", ["old"] as Object[])
+
+        when:
+        update(root, argumentOf(context, "test.ImmutableRoot"), [name: "new"])
+
+        then:
+        def e = thrown(Exception)
+        e.message.contains("Unsupported") || e.message.contains("Cannot update")
+
+        cleanup:
+        context.close()
+    }
+
+    protected Object update(Object value, Argument type, Object overrides) {
+        if (jsonMapper instanceof ObjectMapper) {
+            return ((ObjectMapper) jsonMapper).updateValue(value, type, overrides)
+        }
+        JsonNode tree = overrides instanceof JsonNode ? (JsonNode) overrides : jsonMapper.writeValueToTree(overrides)
+        jsonMapper.updateValueFromTree(value, tree)
+        return value
+    }
+
+    protected Object updateBytes(Object value, Argument type, String json) {
+        byte[] bytes = json.getBytes(StandardCharsets.UTF_8)
+        if (jsonMapper instanceof ObjectMapper) {
+            return ((ObjectMapper) jsonMapper).updateValue(value, type, bytes)
+        }
+        jsonMapper.updateValueFromTree(value, jsonMapper.readValue(bytes, JsonNode))
+        return value
+    }
+
+    protected Object updateStream(Object value, Argument type, String json) {
+        byte[] bytes = json.getBytes(StandardCharsets.UTF_8)
+        if (jsonMapper instanceof ObjectMapper) {
+            return ((ObjectMapper) jsonMapper).updateValue(value, type, new ByteArrayInputStream(bytes))
+        }
+        jsonMapper.updateValueFromTree(value, jsonMapper.readValue(bytes, JsonNode))
+        return value
+    }
+
+    protected Object updateBuffer(Object value, Argument type, String json) {
+        byte[] bytes = json.getBytes(StandardCharsets.UTF_8)
+        if (jsonMapper instanceof ObjectMapper) {
+            return ((ObjectMapper) jsonMapper).updateValue(value, type, ByteArrayBufferFactory.INSTANCE.wrap(bytes))
+        }
+        jsonMapper.updateValueFromTree(value, jsonMapper.readValue(bytes, JsonNode))
+        return value
+    }
+
+    private Object updateByMode(String mode, Object value, Argument type, String json) {
+        switch (mode) {
+            case "object":
+                return update(value, type, jsonMapper.readValue(json, Map))
+            case "bytes":
+                return updateBytes(value, type, json)
+            case "stream":
+                return updateStream(value, type, json)
+            case "buffer":
+                return updateBuffer(value, type, json)
+            case "tree":
+                jsonMapper.updateValueFromTree(value, jsonMapper.readValue(json, JsonNode))
+                return value
+            default:
+                throw new IllegalArgumentException("Unknown update mode: " + mode)
+        }
+    }
+
+    private static String releasePlanSource(String rootName, String mergeAnnotation) {
+        """
+package test;
+
+import com.fasterxml.jackson.annotation.JsonMerge;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public class ${rootName} {
+    private String service;
+    private String owner;
+
+    ${mergeAnnotation}
+    private RolloutWindow rolloutWindow;
+
+    public String getService() {
+        return service;
+    }
+
+    public void setService(String service) {
+        this.service = service;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public void setOwner(String owner) {
+        this.owner = owner;
+    }
+
+    public RolloutWindow getRolloutWindow() {
+        return rolloutWindow;
+    }
+
+    public void setRolloutWindow(RolloutWindow rolloutWindow) {
+        this.rolloutWindow = rolloutWindow;
+    }
+
+    @Serdeable
+    public static class RolloutWindow {
+        private String day;
+        private String timeZone;
+
+        public String getDay() {
+            return day;
+        }
+
+        public void setDay(String day) {
+            this.day = day;
+        }
+
+        public String getTimeZone() {
+            return timeZone;
+        }
+
+        public void setTimeZone(String timeZone) {
+            this.timeZone = timeZone;
+        }
+    }
+}
+"""
+    }
+
+    private static String nestedBeanSource(String rootName, String mergeAnnotation) {
+        """
+package test;
+
+import com.fasterxml.jackson.annotation.JsonMerge;
+import com.fasterxml.jackson.annotation.OptBoolean;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public class ${rootName} {
+    ${mergeAnnotation}
+    private Child child;
+
+    public Child getChild() {
+        return child;
+    }
+
+    public void setChild(Child child) {
+        this.child = child;
+    }
+
+    @Serdeable
+    public static class Patch {
+        private Child child;
+
+        public Child getChild() {
+            return child;
+        }
+
+        public void setChild(Child child) {
+            this.child = child;
+        }
+    }
+
+    @Serdeable
+    public static class Child {
+        private String left;
+        private String right;
+
+        public String getLeft() {
+            return left;
+        }
+
+        public void setLeft(String left) {
+            this.left = left;
+        }
+
+        public String getRight() {
+            return right;
+        }
+
+        public void setRight(String right) {
+            this.right = right;
+        }
+    }
+}
+"""
+    }
+
+    private static String updateDefaultsRootSource() {
+        """
+package test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public class UpdateDefaultsRoot {
+    private String changed;
+
+    @JsonProperty(defaultValue = "from-default")
+    private String defaulted;
+
+    @JsonProperty(required = true)
+    private String required;
+
+    @JsonProperty(defaultValue = "33")
+    private int defaultedPrimitive;
+
+    public String getChanged() {
+        return changed;
+    }
+
+    public void setChanged(String changed) {
+        this.changed = changed;
+    }
+
+    public String getDefaulted() {
+        return defaulted;
+    }
+
+    public void setDefaulted(String defaulted) {
+        this.defaulted = defaulted;
+    }
+
+    public String getRequired() {
+        return required;
+    }
+
+    public void setRequired(String required) {
+        this.required = required;
+    }
+
+    public int getDefaultedPrimitive() {
+        return defaultedPrimitive;
+    }
+
+    public void setDefaultedPrimitive(int defaultedPrimitive) {
+        this.defaultedPrimitive = defaultedPrimitive;
+    }
+}
+"""
+    }
+
+    private static String updateUnwrappedDefaultsRootSource() {
+        """
+package test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public class UpdateUnwrappedDefaultsRoot {
+    private String changed;
+
+    @JsonUnwrapped
+    private Name name;
+
+    public String getChanged() {
+        return changed;
+    }
+
+    public void setChanged(String changed) {
+        this.changed = changed;
+    }
+
+    public Name getName() {
+        return name;
+    }
+
+    public void setName(Name name) {
+        this.name = name;
+    }
+
+    @Serdeable
+    public static class Name {
+        @JsonProperty(defaultValue = "from-unwrapped-default")
+        private String first;
+
+        @JsonProperty(defaultValue = "from-unwrapped-last")
+        private String last;
+
+        public String getFirst() {
+            return first;
+        }
+
+        public void setFirst(String first) {
+            this.first = first;
+        }
+
+        public String getLast() {
+            return last;
+        }
+
+        public void setLast(String last) {
+            this.last = last;
+        }
+    }
+}
+"""
+    }
+}

--- a/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonJsonMapper.java
+++ b/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonJsonMapper.java
@@ -404,39 +404,121 @@ public final class JacksonJsonMapper implements JacksonObjectMapper {
     @Override
     public void updateValueFromTree(Object value, JsonNode tree) throws IOException {
         if (tree != null && value != null) {
-            Argument<Object> type = (Argument<Object>) Argument.of(value.getClass());
-            Deserializer deserializer;
-            if (isSpecificType(type)) {
-                deserializer = Objects.requireNonNull(specificDeserializer);
-            } else {
-                deserializer = decoderContext.findDeserializer(type).createSpecific(decoderContext, (Argument) type);
-            }
-            if (deserializer instanceof UpdatingDeserializer) {
-
-                try (JsonParser parser = treeCodec.treeAsTokens(tree, ObjectReadContext.empty())) {
-                    if (!parser.hasCurrentToken()) {
-                        parser.nextToken();
-                    }
-                    // for jackson compat we need to support deserializing null, but most deserializers don't support it.
-                    if (parser.currentToken() != JsonToken.VALUE_NULL) {
-                        final Decoder decoder = JacksonDecoder.create(parser, streamLimits);
-                        ((UpdatingDeserializer<Object>) deserializer).deserializeInto(
-                            decoder,
-                            decoderContext,
-                            type,
-                            value
-                        );
-                    }
-                }
+            try (JsonParser parser = treeCodec.treeAsTokens(tree, ObjectReadContext.empty())) {
+                updateValue(parser, value, (Argument<Object>) Argument.of(value.getClass()));
             }
         }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T updateValue(T valueToUpdate, @Nullable Object overrides) throws IOException {
+        Objects.requireNonNull(valueToUpdate, "Value to update cannot be null");
+        return updateValue(valueToUpdate, (Argument<T>) Argument.of(valueToUpdate.getClass()), overrides);
+    }
+
+    @Override
+    public <T> T updateValue(T valueToUpdate, Argument<T> type, @Nullable Object overrides) throws IOException {
+        Objects.requireNonNull(valueToUpdate, "Value to update cannot be null");
+        Objects.requireNonNull(type, "Type cannot be null");
+        if (overrides == null) {
+            return valueToUpdate;
+        }
+        if (overrides instanceof JsonNode jsonNode) {
+            try (JsonParser parser = treeCodec.treeAsTokens(jsonNode, ObjectReadContext.empty())) {
+                return updateValue(parser, valueToUpdate, type);
+            }
+        }
+        BufferRecycler bufferRecycler = jsonFactory._getBufferRecycler();
+        try (ByteArrayBuilder bb = new ByteArrayBuilder(bufferRecycler)) {
+            try (JsonGenerator generator = createGenerator(bb)) {
+                writeValue0(generator, overrides);
+            }
+            try (JsonParser parser = jsonFactory.createParser(bb.getClearAndRelease())) {
+                updateValue(parser, valueToUpdate, type);
+            }
+        } finally {
+            bufferRecycler.releaseToPool();
+        }
+        return valueToUpdate;
+    }
+
+    @Override
+    public <T> T updateValue(T valueToUpdate, Argument<T> type, InputStream inputStream) throws IOException {
+        Objects.requireNonNull(valueToUpdate, "Value to update cannot be null");
+        Objects.requireNonNull(type, "Type cannot be null");
+        Objects.requireNonNull(inputStream, "Input stream cannot be null");
+        try (JsonParser parser = jsonFactory.createParser(inputStream)) {
+            return updateValue(parser, valueToUpdate, type);
+        } catch (StreamReadException pe) {
+            throw new JsonSyntaxException(pe);
+        }
+    }
+
+    @Override
+    public <T> T updateValue(T valueToUpdate, Argument<T> type, byte[] byteArray) throws IOException {
+        Objects.requireNonNull(valueToUpdate, "Value to update cannot be null");
+        Objects.requireNonNull(type, "Type cannot be null");
+        Objects.requireNonNull(byteArray, "Byte array cannot be null");
+        try (JsonParser parser = jsonFactory.createParser(byteArray)) {
+            return updateValue(parser, valueToUpdate, type);
+        } catch (StreamReadException pe) {
+            throw new JsonSyntaxException(pe);
+        }
+    }
+
+    @Override
+    public <T> T updateValue(T valueToUpdate, Argument<T> type, ByteBuffer<?> byteBuffer) throws IOException {
+        Objects.requireNonNull(valueToUpdate, "Value to update cannot be null");
+        Objects.requireNonNull(type, "Type cannot be null");
+        Objects.requireNonNull(byteBuffer, "Byte buffer cannot be null");
+        try (JsonParser parser = JacksonCoreParserFactory.createJsonParser(jsonFactory, byteBuffer)) {
+            return updateValue(parser, valueToUpdate, type);
+        } catch (StreamReadException pe) {
+            throw new JsonSyntaxException(pe);
+        }
+    }
+
+    private <T> T updateValue(JsonParser parser, T value, Argument<T> type) throws IOException {
+        Deserializer<T> deserializer;
+        Deserializer.DecoderContext decoderContext = this.decoderContext;
+        if (isSpecificType(type)) {
+            deserializer = (Deserializer<T>) Objects.requireNonNull(specificDeserializer);
+        } else {
+            @Nullable Class<?> viewClass = JsonViewUtil.extractView(serdeConfiguration, type, view);
+            if (viewClass != view) {
+                decoderContext = registry.newDecoderContext(viewClass);
+            }
+            deserializer = decoderContext.findDeserializer(type).createSpecific(decoderContext, (Argument) type);
+        }
+        if (!(deserializer instanceof UpdatingDeserializer<T>)) {
+            deserializer = decoderContext.findDeserializer(Argument.OBJECT_ARGUMENT)
+                .createSpecific(decoderContext, (Argument) type);
+        }
+        if (!(deserializer instanceof UpdatingDeserializer<T> updatingDeserializer)) {
+            throw new UnsupportedOperationException("Updating existing value of type [" + type + "] is not supported");
+        }
+        if (!parser.hasCurrentToken()) {
+            parser.nextToken();
+        }
+        // for jackson compat we need to support deserializing null, but most deserializers don't support it.
+        if (parser.currentToken() != JsonToken.VALUE_NULL) {
+            final Decoder decoder = JacksonDecoder.create(parser, streamLimits);
+            updatingDeserializer.deserializeInto(
+                decoder,
+                decoderContext,
+                type,
+                value
+            );
+        }
+        return value;
     }
 
     private boolean isSpecificType(Argument<?> type) {
         return type == specificType || type.equalsType(specificType);
     }
 
-    private JsonGenerator createGenerator(OutputStream outputStream) throws IOException {
+    private JsonGenerator createGenerator(OutputStream outputStream) {
         if (jacksonConfiguration.isPrettyPrint()) {
             return jsonFactory.createGenerator(new PrettyPrintWriteContext(), outputStream);
         }

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeJsonMergeSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeJsonMergeSpec.groovy
@@ -1,0 +1,6 @@
+package io.micronaut.serde.jackson.annotation
+
+import io.micronaut.serde.jackson.JsonMergeSpec
+
+class SerdeJsonMergeSpec extends JsonMergeSpec {
+}

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/SerdeAnnotationVisitor.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/SerdeAnnotationVisitor.java
@@ -113,7 +113,6 @@ public class SerdeAnnotationVisitor implements TypeElementVisitor<SerdeConfig, S
     private Set<String> getUnsupportedJacksonAnnotations() {
         return CollectionUtils.setOf(
                 "com.fasterxml.jackson.annotation.JsonAutoDetect",
-                "com.fasterxml.jackson.annotation.JsonMerge",
                 "com.fasterxml.jackson.annotation.JsonIdentityInfo",
                 "com.fasterxml.jackson.annotation.JsonIdentityReference"
         );

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/jackson/JsonMergeMapper.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/jackson/JsonMergeMapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.processor.jackson;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.annotation.NamedAnnotationMapper;
+import io.micronaut.inject.visitor.VisitorContext;
+import io.micronaut.serde.config.annotation.SerdeConfig;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Support for JsonMerge.
+ */
+public final class JsonMergeMapper implements NamedAnnotationMapper {
+    @Override
+    public String getName() {
+        return "com.fasterxml.jackson.annotation.JsonMerge";
+    }
+
+    @Override
+    public List<AnnotationValue<?>> map(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        String value = annotation.stringValue().orElse("TRUE");
+        return Collections.singletonList(
+            AnnotationValue.builder(SerdeConfig.class)
+                .member(SerdeConfig.MERGE, "TRUE".equals(value))
+                .build()
+        );
+    }
+}

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/SimpleSerdeShapeAnalyzer.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/SimpleSerdeShapeAnalyzer.java
@@ -802,6 +802,7 @@ public final class SimpleSerdeShapeAnalyzer {
             || element.booleanValue(SerdeConfig.class, SerdeConfig.REQUIRED).orElse(false)
             || element.booleanValue(SerdeConfig.class, SerdeConfig.READ_ONLY).orElse(false)
             || element.booleanValue(SerdeConfig.class, SerdeConfig.WRITE_ONLY).orElse(false)
+            || element.booleanValue(SerdeConfig.class, SerdeConfig.MERGE).orElse(false)
             || FormatConfiguration.from(element.getAnnotationMetadata()) != null
             || hasFeatureOverrides(element.getAnnotationMetadata())
             || hasSerializeAsOverride(element)
@@ -819,6 +820,7 @@ public final class SimpleSerdeShapeAnalyzer {
             || annotationMetadata.booleanValue(SerdeConfig.class, SerdeConfig.REQUIRED).orElse(false)
             || annotationMetadata.booleanValue(SerdeConfig.class, SerdeConfig.READ_ONLY).orElse(false)
             || annotationMetadata.booleanValue(SerdeConfig.class, SerdeConfig.WRITE_ONLY).orElse(false)
+            || annotationMetadata.booleanValue(SerdeConfig.class, SerdeConfig.MERGE).orElse(false)
             || FormatConfiguration.from(annotationMetadata) != null
             || hasFeatureOverrides(annotationMetadata)
             || hasSerializeAsOverride(annotationMetadata)

--- a/serde-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
+++ b/serde-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
@@ -23,6 +23,7 @@ io.micronaut.serde.processor.jackson.JsonEnumDefaultValueMapper
 io.micronaut.serde.processor.jackson.JsonKeyMapper
 io.micronaut.serde.processor.jackson.JsonValueMapper
 io.micronaut.serde.processor.jackson.JsonTypeInfoMapper
+io.micronaut.serde.processor.jackson.JsonMergeMapper
 io.micronaut.serde.processor.jackson.JsonSetterMapper
 io.micronaut.serde.processor.jackson.JsonAnyGetterMapper
 io.micronaut.serde.processor.jackson.JsonTypeNameMapper

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBean.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBean.java
@@ -22,6 +22,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.beans.BeanIntrospection;
 import io.micronaut.core.beans.BeanMethod;
 import io.micronaut.core.beans.BeanProperty;
+import io.micronaut.core.beans.BeanReadProperty;
 import io.micronaut.core.beans.BeanWriteProperty;
 import io.micronaut.core.beans.UnsafeBeanWriteProperty;
 import io.micronaut.core.bind.annotation.Bindable;
@@ -37,6 +38,7 @@ import io.micronaut.serde.Deserializer;
 import io.micronaut.serde.FormatConfiguration;
 import io.micronaut.serde.FormattedDeserializer;
 import io.micronaut.serde.Keys;
+import io.micronaut.serde.UpdatingDeserializer;
 import io.micronaut.serde.config.DeserializationConfiguration;
 import io.micronaut.serde.config.SerdeConfiguration;
 import io.micronaut.serde.config.annotation.SerdeConfig;
@@ -56,6 +58,7 @@ import io.micronaut.serde.util.GeneratedSerdeExceptionUtil;
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -563,7 +566,7 @@ final class DeserBean<T> {
                 return false;
             }
             for (DerProperty<T, Object> property : injectProperties.getProperties()) {
-                if (property.unresolvedTypeVariableName != null || property.isAnySetter || property.views != null || property.aliases != null || property.managedRef != null || introspection != property.introspection || property.backRef != null || property.beanProperty == null) {
+                if (property.unresolvedTypeVariableName != null || property.isAnySetter || property.views != null || property.aliases != null || property.managedRef != null || introspection != property.introspection || property.backRef != null || property.beanProperty == null || property.merge) {
                     return false;
                 }
             }
@@ -596,6 +599,17 @@ final class DeserBean<T> {
                 : findDeserializer(propertyContext, property.argument, property.format));
             if (property.format == null && !property.hasFeatureOverrides && property.deserializer instanceof DecoderValueKind.Provider decoderValueKind) {
                 property.decoderValueKind = decoderValueKind.decoderValueKind().code();
+            }
+            if (property.merge
+                && property.beanReadProperty != null
+                && property.format == null
+                && !property.hasFeatureOverrides
+                && !property.argument.getType().isArray()
+                && !(property.deserializer instanceof UpdatingDeserializer)) {
+                UpdatingDeserializer<Object> mergeDeserializer = ObjectShapeSerdeHelper.updatingObjectDeserializer(propertyContext, property.argument);
+                if (mergeDeserializer != null) {
+                    property.mergeDeserializer = unwrapErrorCatching(mergeDeserializer);
+                }
             }
         }
     }
@@ -970,6 +984,8 @@ final class DeserBean<T> {
 
         @Nullable
         public final UnsafeBeanWriteProperty<B, P> beanProperty;
+        @Nullable
+        public final BeanReadProperty<B, P> beanReadProperty;
 
         @Nullable
         public final DeserBean<P> unwrapped;
@@ -987,10 +1003,13 @@ final class DeserBean<T> {
         public final Set<DeserializationConfiguration.Feature> featuresWith;
         public final Set<DeserializationConfiguration.Feature> featuresWithout;
         public final boolean hasFeatureOverrides;
+        public final boolean merge;
 
         // Null when DeserBean not initialized
         @Nullable
         public Deserializer<P> deserializer;
+        @Nullable
+        public Deserializer<P> mergeDeserializer;
         private byte decoderValueKind = DecoderValueKind.NONE_CODE;
 
         DerProperty(ConversionService conversionService,
@@ -1043,6 +1062,7 @@ final class DeserBean<T> {
             this.unresolvedTypeVariableName = unresolvedTypeVariableName;
             AnnotationMetadata annotationMetadata = resolveArgumentMetadata(introspection, argument, argumentMetadata);
             this.argument = annotationMetadata.isEmpty() ? argument : argument.withAnnotationMetadata(annotationMetadata);
+            this.merge = annotationMetadata.booleanValue(SerdeConfig.class, SerdeConfig.MERGE).orElse(false);
             this.failOnNullForPrimitives = failOnNullForPrimitives;
             FormatConfiguration propertyFormat = FormatConfiguration.from(annotationMetadata);
             if (propertyFormat == null) {
@@ -1072,10 +1092,13 @@ final class DeserBean<T> {
 
             if (beanProperty != null) {
                 this.beanProperty = (UnsafeBeanWriteProperty<B, P>) beanProperty;
+                this.beanReadProperty = resolveBeanReadProperty(introspection, property, beanProperty);
             } else if (beanMethod != null) {
                 this.beanProperty = new BeanMethodAsBeanProperty<>(property, beanMethod);
+                this.beanReadProperty = null;
             } else {
                 this.beanProperty = null;
+                this.beanReadProperty = null;
             }
             this.views = SerdeAnnotationUtil.resolveViews(introspection, annotationMetadata);
 
@@ -1103,6 +1126,17 @@ final class DeserBean<T> {
             this.explicitlyRequired = annotationMetadata.booleanValue(SerdeConfig.class, SerdeConfig.REQUIRED)
                 .orElse(false);
             this.explicitlyRequiredForConstructor = explicitlyRequired || deserializationConfiguration.isRequireAllCreatorParameters();
+        }
+
+        @SuppressWarnings("unchecked")
+        @Nullable
+        private static <B, P> BeanReadProperty<B, P> resolveBeanReadProperty(BeanIntrospection<B> introspection,
+                                                                             String property,
+                                                                             BeanWriteProperty<B, P> beanProperty) {
+            if (beanProperty instanceof BeanReadProperty<?, ?> beanReadProperty) {
+                return (BeanReadProperty<B, P>) beanReadProperty;
+            }
+            return (BeanReadProperty<B, P>) introspection.getProperty(property).orElse(null);
         }
 
         @SuppressWarnings("NullAway")
@@ -1174,6 +1208,10 @@ final class DeserBean<T> {
                                                    Decoder objectDecoder,
                                                    Deserializer.DecoderContext decoderContext,
                                                    B beanInstance) throws IOException {
+            if (merge && beanReadProperty != null && decoderValueKind == DecoderValueKind.NONE_CODE) {
+                deserializeAndMergePropertyValue(deserializer, objectDecoder, decoderContext, beanInstance);
+                return;
+            }
             try {
                 P value;
                 if (primitive && !failOnNullForPrimitives) {
@@ -1195,6 +1233,69 @@ final class DeserBean<T> {
             } catch (Exception e) {
                 throw convertException(e, true); // Only convert exceptions from `setUnsafe`
             }
+        }
+
+        @SuppressWarnings({"NullAway"})
+        private void deserializeAndMergePropertyValue(Deserializer<P> deserializer,
+                                                      Decoder objectDecoder,
+                                                      Deserializer.DecoderContext decoderContext,
+                                                      B beanInstance) throws IOException {
+            try {
+                decoderContext = resolveFeatures(decoderContext);
+                if (objectDecoder.decodeNull()) {
+                    setNullPropertyValue(beanInstance);
+                    return;
+                }
+                P currentValue = beanReadProperty.get(beanInstance);
+                if (currentValue == null) {
+                    P value = deserializeValue(deserializer, objectDecoder, decoderContext);
+                    beanProperty.setUnsafe(beanInstance, value);
+                    return;
+                }
+                if (argument.getType().isArray()) {
+                    P incomingValue = deserializeValue(deserializer, objectDecoder, decoderContext);
+                    if (incomingValue == null) {
+                        beanProperty.setUnsafe(beanInstance, null);
+                    } else {
+                        beanProperty.setUnsafe(beanInstance, concatenateArrays(currentValue, incomingValue));
+                    }
+                    return;
+                }
+                Deserializer<P> effectiveDeserializer = mergeDeserializer == null ? deserializer : mergeDeserializer;
+                if (effectiveDeserializer instanceof UpdatingDeserializer<P> updatingDeserializer) {
+                    updatingDeserializer.deserializeInto(objectDecoder, decoderContext, argument, currentValue);
+                } else {
+                    P value = deserializeValue(deserializer, objectDecoder, decoderContext);
+                    beanProperty.setUnsafe(beanInstance, value);
+                }
+            } catch (Exception e) {
+                throw convertException(e, true); // Only convert exceptions from `setUnsafe`
+            }
+        }
+
+        @SuppressWarnings("NullAway")
+        private void setNullPropertyValue(B beanInstance) throws SerdeException {
+            if (explicitlyRequired) {
+                throw new SerdeException("Unable to deserialize type [" + introspection.getBeanType().getName() + "]. Required property [" + argument +
+                    "] is not present or is null in the supplied data");
+            }
+            if (primitive && !failOnNullForPrimitives) {
+                return;
+            }
+            if (rejectsNullValue) {
+                throw GeneratedSerdeExceptionUtil.nullValue(Argument.of(introspection.getBeanType()), argument);
+            }
+            beanProperty.setUnsafe(beanInstance, null);
+        }
+
+        @SuppressWarnings("unchecked")
+        private P concatenateArrays(P currentValue, P incomingValue) {
+            int currentLength = Array.getLength(currentValue);
+            int incomingLength = Array.getLength(incomingValue);
+            Object mergedArray = Array.newInstance(currentValue.getClass().getComponentType(), currentLength + incomingLength);
+            System.arraycopy(currentValue, 0, mergedArray, 0, currentLength);
+            System.arraycopy(incomingValue, 0, mergedArray, currentLength, incomingLength);
+            return (P) mergedArray;
         }
 
         @SuppressWarnings("NullAway")

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SimpleObjectDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SimpleObjectDeserializer.java
@@ -103,7 +103,7 @@ final class SimpleObjectDeserializer implements Deserializer<Object>, UpdatingDe
             throw new SerdeException("Unable to deserialize type [" + beanType + "]: " + e.getMessage(), e);
         }
 
-        deserializeInto(decoder, decoderContext, beanType, obj);
+        deserializeInto(decoder, decoderContext, beanType, obj, true);
 
         return obj;
     }
@@ -111,20 +111,32 @@ final class SimpleObjectDeserializer implements Deserializer<Object>, UpdatingDe
     @Override
     public void deserializeInto(Decoder decoder, DecoderContext decoderContext, Argument<? super Object> beanType, Object beanInstance)
             throws IOException {
+        deserializeInto(decoder, decoderContext, beanType, beanInstance, false);
+    }
+
+    private void deserializeInto(Decoder decoder,
+                                 DecoderContext decoderContext,
+                                 Argument<? super Object> beanType,
+                                 Object beanInstance,
+                                 boolean applyDefaults) throws IOException {
         KeysAwareDecoder objectDecoder = KeysAwareDecoder.of(decoder.decodeObject(beanType));
         DeserBean.DerProperty<Object, Object>[] localProperties = propertiesArray;
         long consumedProperties = ~propertiesMask;
         while (true) {
             final int keyIndex = objectDecoder.decodeKey(propertyKeys);
             if (keyIndex == KeysAwareDecoder.MATCH_END_OBJECT) {
-                setDefaultPropertyValues(decoderContext, beanInstance, localProperties, consumedProperties);
+                if (applyDefaults) {
+                    setDefaultPropertyValues(decoderContext, beanInstance, localProperties, consumedProperties);
+                }
                 objectDecoder.finishStructure();
                 return;
             }
             if (keyIndex == KeysAwareDecoder.MATCH_UNKNOWN_NAME) {
                 String propertyName = objectDecoder.decodeKey();
                 if (propertyName == null) {
-                    setDefaultPropertyValues(decoderContext, beanInstance, localProperties, consumedProperties);
+                    if (applyDefaults) {
+                        setDefaultPropertyValues(decoderContext, beanInstance, localProperties, consumedProperties);
+                    }
                     objectDecoder.finishStructure();
                     return;
                 }
@@ -171,7 +183,7 @@ final class SimpleObjectDeserializer implements Deserializer<Object>, UpdatingDe
         return serdeException;
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({"unchecked"})
     private static DeserBean.DerProperty<Object, Object>[] emptyProperties() {
         return new DeserBean.DerProperty[0];
     }

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SpecificObjectDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SpecificObjectDeserializer.java
@@ -70,7 +70,7 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
 
     @Override
     public Object deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super Object> type) throws IOException {
-        BeanDeserializer deserializer = newBeanDeserializer(null, deserBean, conf, false);
+        BeanDeserializer deserializer = newBeanDeserializer(null, deserBean, conf, false, false);
         deserializer.init(decoderContext);
         if (deserBean.externalProperties == null) {
             return requireNonNull(deserialize(decoder, decoderContext, type, deserializer), type);
@@ -81,7 +81,10 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
 
     @Override
     public void deserializeInto(Decoder decoder, DecoderContext decoderContext, Argument<? super Object> type, Object value) throws IOException {
-        BeanDeserializer deserializer = newBeanDeserializer(value, deserBean, conf, false);
+        if (deserBean.hasBuilder || deserBean.creatorParams != null) {
+            throw unsupportedUpdate(type);
+        }
+        BeanDeserializer deserializer = newBeanDeserializer(value, deserBean, conf, false, true);
         deserializer.init(decoderContext);
         if (deserBean.externalProperties == null) {
             deserialize(decoder, decoderContext, type, deserializer);
@@ -95,6 +98,10 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
             throw new SerdeException("Null value encountered during deserialization of type: " + type);
         }
         return value;
+    }
+
+    private static SerdeException unsupportedUpdate(Argument<?> type) {
+        return new SerdeException("Unsupported deserialize into immutable [" + type + "]");
     }
 
     private @Nullable Object deserialize(Decoder decoder, DecoderContext decoderContext, Argument<? super Object> type, BeanDeserializer beanDeserializer) throws IOException {
@@ -344,7 +351,8 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
     private static BeanDeserializer newBeanDeserializer(@Nullable Object instance,
                                                         DeserBean<? super Object> db,
                                                         Conf conf,
-                                                        boolean allowSubtype) {
+                                                        boolean allowSubtype,
+                                                        boolean updateMode) {
         if (db.hasBuilder) {
             return new BuilderDeserializer(db, conf);
         }
@@ -365,7 +373,7 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
         if (db.creatorParams != null) {
             return new ArgsConstructorBeanDeserializer(db, conf);
         }
-        return new NoArgsConstructorDeserializer(instance, db, conf);
+        return new NoArgsConstructorDeserializer(instance, db, conf, updateMode);
     }
 
     private static boolean tryConsumeResolved(BeanDeserializer resolvedBeanDeserializer,
@@ -599,7 +607,7 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
                     decoder.skipValue();
                     return true;
                 }
-                if (property.managedRef == null) {
+                if (property.managedRef == null && !property.merge) {
                     values[property.index] = property.deserializeValue(Objects.requireNonNull(property.deserializer), decoder, decoderContext);
                 } else {
                     buffered[property.index] = decoder.decodeBuffer();
@@ -609,7 +617,10 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
             return false;
         }
 
-        void injectProperties(Argument<? super Object> objectArgument, Object instance, DecoderContext decoderContext) throws IOException {
+        void injectProperties(Argument<? super Object> objectArgument,
+                              Object instance,
+                              DecoderContext decoderContext,
+                              boolean applyDefaults) throws IOException {
             DeserBean.DerProperty<Object, Object>[] propertiesArray = properties.getPropertiesArray();
             for (int i = 0; i < propertiesArray.length; i++) {
                 DeserBean.DerProperty<Object, Object> property = propertiesArray[i];
@@ -634,6 +645,12 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
                     }
                     property.set(decoderContext, instance, value);
                 } else {
+                    if (!propertiesConsumer.isConsumed(i)) {
+                        if (applyDefaults) {
+                            property.setDefaultPropertyValue(decoderContext, instance);
+                        }
+                        continue;
+                    }
                     Decoder bufferedDecoder = buffered[i];
                     if (bufferedDecoder != null) {
                         deserializeAndSetPropertyValue(decoderContext, bufferedDecoder, property, objectArgument, instance);
@@ -645,6 +662,9 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
             if (unwrappedProperties != null) {
                 for (UnwrappedPropertyDeserializer unwrappedProperty : unwrappedProperties) {
                     DeserBean.DerProperty<Object, Object> wrappedProperty = unwrappedProperty.wrappedProperty;
+                    if (!propertiesConsumer.isConsumed(wrappedProperty.index) && !applyDefaults) {
+                        continue;
+                    }
                     if (wrappedProperty.views != null && !decoderContext.hasView(wrappedProperty.views)) {
                         continue;
                     }
@@ -796,8 +816,11 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
             return false;
         }
 
-        void finalizeProperties(DecoderContext decoderContext, Argument<? super Object> objectArgument, Object instance) throws IOException {
-            if (unwrappedProperties != null) {
+        void finalizeProperties(DecoderContext decoderContext,
+                                Argument<? super Object> objectArgument,
+                                Object instance,
+                                boolean applyDefaults) throws IOException {
+            if (applyDefaults && unwrappedProperties != null) {
                 for (UnwrappedPropertyDeserializer unwrappedProperty : unwrappedProperties) {
                     DeserBean.DerProperty<Object, Object> wrappedProperty = unwrappedProperty.wrappedProperty;
                     if (propertiesConsumer.isConsumed(wrappedProperty.index)) {
@@ -822,7 +845,9 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
                 if (property.unwrapped != null) {
                     continue;
                 }
-                property.setDefaultPropertyValue(decoderContext, instance);
+                if (applyDefaults) {
+                    property.setDefaultPropertyValue(decoderContext, instance);
+                }
             }
 
         }
@@ -1049,7 +1074,7 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
                                               Conf conf) {
             this.wrappedProperty = unwrappedProperty;
             DeserBean<?> unwrappedBean = Objects.requireNonNull(unwrappedProperty.unwrapped);
-            this.beanDeserializer = newBeanDeserializer(null, (DeserBean<? super Object>) unwrappedBean, conf, true);
+            this.beanDeserializer = newBeanDeserializer(null, (DeserBean<? super Object>) unwrappedBean, conf, true, false);
             this.keyIndexes = new int[parentDeserBean.propertyKeyCount()];
             for (int i = 0; i < keyIndexes.length; i++) {
                 if (!parentDeserBean.isKnownPropertyKey(i) && !parentDeserBean.isIgnoredPropertyKey(i)) {
@@ -1169,7 +1194,7 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
                 throw new SerdeException(PREFIX_UNABLE_TO_DESERIALIZE_TYPE + introspection.getBeanType() + "]: " + e.getMessage(), e);
             }
             if (propertiesConsumer != null) {
-                propertiesConsumer.injectProperties(objectArgument, instance, decoderContext);
+                propertiesConsumer.injectProperties(objectArgument, instance, decoderContext, true);
             }
             if (anyValuesDeserializer != null && !anyValuesDeserializer.anySetter.constructorArgument) {
                 anyValuesDeserializer.bind(instance);
@@ -1202,11 +1227,16 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
         private final AnyValuesDeserializer anyValuesDeserializer;
         @Nullable
         private Object instance;
+        private final boolean updateMode;
 
-        NoArgsConstructorDeserializer(@Nullable Object instance, DeserBean<? super Object> db, Conf conf) {
+        NoArgsConstructorDeserializer(@Nullable Object instance,
+                                      DeserBean<? super Object> db,
+                                      Conf conf,
+                                      boolean updateMode) {
             this.instance = instance;
             this.introspection = db.introspection;
             this.conf = conf;
+            this.updateMode = updateMode;
             if (db.injectProperties != null) {
                 this.propertiesConsumer = new PropertiesValuesDeserializer(db, conf);
             } else {
@@ -1258,7 +1288,7 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
         @Override
         public Object provideInstance(Argument<? super Object> objectArgument, DecoderContext decoderContext) throws IOException {
             if (propertiesConsumer != null) {
-                propertiesConsumer.finalizeProperties(decoderContext, objectArgument, Objects.requireNonNull(instance));
+                propertiesConsumer.finalizeProperties(decoderContext, objectArgument, Objects.requireNonNull(instance), !updateMode);
             }
             if (anyValuesDeserializer != null) {
                 anyValuesDeserializer.bind(Objects.requireNonNull(instance));
@@ -1375,7 +1405,8 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
                 null,
                 (DeserBean<? super Object>) deserBean,
                 conf,
-                true);
+                true,
+                false);
             beanDeserializer = resolvedBeanDeserializer;
             resolvedDeserBean = deserBean;
             resolvedKeyIndexes = targetKeyIndexes(deserBean, this.deserBean);
@@ -1525,6 +1556,7 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
                 null,
                 (DeserBean<? super Object>) deserBean,
                 conf,
+                false,
                 false);
             beanDeserializer = resolvedBeanDeserializer;
             resolvedDeserBean = deserBean;

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/CollectionDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/CollectionDeserializer.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.UpdatingDeserializer;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.exceptions.path.ReferencePath;
 
@@ -33,7 +34,7 @@ import java.util.Collection;
  * @author Denis Stepanov
  */
 @Internal
-abstract sealed class CollectionDeserializer<E, C extends Collection<E>> implements Deserializer<C>
+abstract sealed class CollectionDeserializer<E, C extends Collection<E>> implements Deserializer<C>, UpdatingDeserializer<C>
     permits ArrayDequeDeserializer, ArrayListDeserializer, HashSetDeserializer, LinkedHashSetDeserializer, LinkedListDeserializer, TreeSetDeserializer {
 
     private final Deserializer<? extends E> valueDeser;
@@ -65,6 +66,14 @@ abstract sealed class CollectionDeserializer<E, C extends Collection<E>> impleme
             e.getPath().add(ReferencePath.ofCollection(collection.getClass(), collectionArgument, index));
             throw e;
         }
+    }
+
+    @Override
+    public void deserializeInto(Decoder decoder,
+                                DecoderContext decoderContext,
+                                Argument<? super C> collectionArgument,
+                                C value) throws IOException {
+        doDeserialize(decoder, decoderContext, value, collectionArgument);
     }
 
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/CoreCollectionsDeserializers.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/CoreCollectionsDeserializers.java
@@ -109,7 +109,9 @@ public final class CoreCollectionsDeserializers {
         consumer.accept(new SpecificOnlyMapDeserializer<Object, Object, HashMap<Object, Object>>(HashMap.class) {
 
             @Override
-            protected Deserializer<HashMap<Object, Object>> createSpecific(Argument<Object> keyType, Argument<Object> valueType, @Nullable Deserializer<?> valueDeser) {
+            protected Deserializer<HashMap<Object, Object>> createSpecific(Argument<Object> keyType,
+                                                                           Argument<Object> valueType,
+                                                                           @Nullable Deserializer<?> valueDeser) {
                 return new HashMapDeserializer<>(valueDeser, keyType, valueType);
             }
 
@@ -117,7 +119,9 @@ public final class CoreCollectionsDeserializers {
         consumer.accept(new SpecificOnlyMapDeserializer<Object, Object, LinkedHashMap<Object, Object>>(LinkedHashMap.class) {
 
             @Override
-            protected Deserializer<LinkedHashMap<Object, Object>> createSpecific(Argument<Object> keyType, Argument<Object> valueType, @Nullable Deserializer<?> valueDeser) {
+            protected Deserializer<LinkedHashMap<Object, Object>> createSpecific(Argument<Object> keyType,
+                                                                                 Argument<Object> valueType,
+                                                                                 @Nullable Deserializer<?> valueDeser) {
                 return new LinkedHashMapDeserializer<>(valueDeser, keyType, valueType);
             }
 
@@ -130,7 +134,9 @@ public final class CoreCollectionsDeserializers {
         consumer.accept(new SpecificOnlyMapDeserializer<Object, Object, TreeMap<Object, Object>>(TreeMap.class) {
 
             @Override
-            protected Deserializer<TreeMap<Object, Object>> createSpecific(Argument<Object> keyType, Argument<Object> valueType, @Nullable Deserializer<?> valueDeser) {
+            protected Deserializer<TreeMap<Object, Object>> createSpecific(Argument<Object> keyType,
+                                                                           Argument<Object> valueType,
+                                                                           @Nullable Deserializer<?> valueDeser) {
                 return new TreeMapDeserializer<>(valueDeser, keyType, valueType);
             }
 

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/MapDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/MapDeserializer.java
@@ -21,8 +21,10 @@ import io.micronaut.core.convert.exceptions.ConversionErrorException;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.UpdatingDeserializer;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.exceptions.path.ReferencePath;
+import io.micronaut.serde.support.util.ObjectShapeSerdeHelper;
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
@@ -37,14 +39,16 @@ import java.util.Map;
  * @author Denis Stepanov
  */
 @Internal
-abstract class MapDeserializer<K, V, M extends Map<K, V>> implements Deserializer<M> {
+abstract class MapDeserializer<K, V, M extends Map<K, @Nullable V>> implements Deserializer<M>, UpdatingDeserializer<M> {
 
     @Nullable
     private final Deserializer<? extends V> valueDeser;
     private final Argument<K> keyArgument;
     private final Argument<V> valueArgument;
 
-    MapDeserializer(@Nullable Deserializer<? extends V> valueDeser, Argument<K> keyArgument, Argument<V> valueArgument) {
+    MapDeserializer(@Nullable Deserializer<? extends V> valueDeser,
+                    Argument<K> keyArgument,
+                    Argument<V> valueArgument) {
         this.valueDeser = valueDeser;
         this.keyArgument = keyArgument;
         this.valueArgument = valueArgument;
@@ -53,10 +57,20 @@ abstract class MapDeserializer<K, V, M extends Map<K, V>> implements Deserialize
     protected final void doDeserialize(Decoder decoder,
                                        DecoderContext decoderContext,
                                        Argument<? super M> mapType,
-                                       Map<K, V> map) throws IOException {
+                                       Map<K, @Nullable V> map) throws IOException {
+        doDeserialize(decoder, decoderContext, mapType, map, false);
+    }
+
+    protected final void doDeserialize(Decoder decoder,
+                                       DecoderContext decoderContext,
+                                       Argument<? super M> mapType,
+                                       Map<K, @Nullable V> map,
+                                       boolean merge) throws IOException {
         final Decoder objectDecoder = decoder.decodeObject(mapType);
         String key = objectDecoder.decodeKey();
         ConversionService conversionService = decoderContext.getConversionService();
+        @Nullable UpdatingDeserializer<V> valueUpdatingDeser = null;
+        boolean valueUpdatingDeserResolved = false;
         try {
             while (key != null) {
                 K k;
@@ -71,6 +85,16 @@ abstract class MapDeserializer<K, V, M extends Map<K, V>> implements Deserialize
                 }
                 if (valueDeser == null) {
                     map.put(k, (V) objectDecoder.decodeArbitrary());
+                } else if (merge && map.containsKey(k)) {
+                    if (!valueUpdatingDeserResolved) {
+                        valueUpdatingDeserResolved = true;
+                        valueUpdatingDeser = resolveUpdatingValueDeserializer(decoderContext);
+                    }
+                    if (valueUpdatingDeser == null) {
+                        map.put(k, valueDeser.deserializeNullable(objectDecoder, decoderContext, valueArgument));
+                    } else {
+                        mergeValue(objectDecoder, decoderContext, map, k, valueDeser, valueUpdatingDeser);
+                    }
                 } else {
                     map.put(k, valueDeser.deserializeNullable(objectDecoder, decoderContext, valueArgument));
                 }
@@ -81,6 +105,43 @@ abstract class MapDeserializer<K, V, M extends Map<K, V>> implements Deserialize
             throw e;
         }
         objectDecoder.finishStructure();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Nullable
+    private UpdatingDeserializer<V> resolveUpdatingValueDeserializer(DecoderContext context) throws SerdeException {
+        if (valueDeser instanceof UpdatingDeserializer<?> updatingDeserializer) {
+            return (UpdatingDeserializer<V>) updatingDeserializer;
+        } else if (valueDeser != null) {
+            // Generated value deserializers may be replace-only; map merge needs the runtime object path
+            // to recursively update existing structured values in place.
+            return ObjectShapeSerdeHelper.updatingObjectDeserializer(context, valueArgument);
+        }
+        return null;
+    }
+
+    private void mergeValue(Decoder objectDecoder,
+                            DecoderContext decoderContext,
+                            Map<K, @Nullable V> map,
+                            K key,
+                            Deserializer<? extends V> valueDeserializer,
+                            UpdatingDeserializer<V> updatingDeserializer) throws IOException {
+        V existingValue = map.get(key);
+        if (existingValue == null) {
+            map.put(key, valueDeserializer.deserializeNullable(objectDecoder, decoderContext, valueArgument));
+        } else if (objectDecoder.decodeNull()) {
+            map.put(key, null);
+        } else {
+            updatingDeserializer.deserializeInto(objectDecoder, decoderContext, valueArgument, existingValue);
+        }
+    }
+
+    @Override
+    public void deserializeInto(Decoder decoder,
+                                DecoderContext decoderContext,
+                                Argument<? super M> mapType,
+                                M value) throws IOException {
+        doDeserialize(decoder, decoderContext, mapType, value, true);
     }
 
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/StringListDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/collect/StringListDeserializer.java
@@ -21,6 +21,7 @@ import io.micronaut.serde.Decoder;
 import io.micronaut.serde.Deserializer;
 import io.micronaut.serde.FormattedDeserializer;
 import io.micronaut.serde.FormatConfiguration;
+import io.micronaut.serde.UpdatingDeserializer;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.exceptions.path.ReferencePath;
 import io.micronaut.serde.support.DeserializerRegistrar;
@@ -36,25 +37,33 @@ import java.util.ArrayList;
  * @author Denis Stepanov
  */
 @Internal
-final class StringListDeserializer implements FormattedDeserializer<ArrayList<String>>, DeserializerRegistrar<ArrayList<String>> {
+final class StringListDeserializer implements FormattedDeserializer<ArrayList<String>>, UpdatingDeserializer<ArrayList<String>>, DeserializerRegistrar<ArrayList<String>> {
     private static final int INITIAL_CAPACITY = 16;
 
     @Override
     public ArrayList<String> deserialize(Decoder decoder, DecoderContext context, Argument<? super ArrayList<String>> type) throws IOException {
-        final Decoder arrayDecoder = decoder.decodeArray();
         ArrayList<String> collection = new ArrayList<>(INITIAL_CAPACITY);
+        deserializeInto(decoder, context, type, collection);
+        return collection;
+    }
+
+    @Override
+    public void deserializeInto(Decoder decoder,
+                                DecoderContext context,
+                                Argument<? super ArrayList<String>> type,
+                                ArrayList<String> value) throws IOException {
+        final Decoder arrayDecoder = decoder.decodeArray();
         int index = 0;
         try {
             while (arrayDecoder.hasNextArrayValue()) {
-                collection.add(arrayDecoder.decodeStringNullable());
+                value.add(arrayDecoder.decodeStringNullable());
                 index++;
             }
         } catch (SerdeException e) {
-            e.getPath().add(ReferencePath.ofCollection(collection.getClass(), type, index));
+            e.getPath().add(ReferencePath.ofCollection(value.getClass(), type, index));
             throw e;
         }
         arrayDecoder.finishStructure();
-        return collection;
     }
 
     @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/SingleElementArraySerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/SingleElementArraySerde.java
@@ -23,6 +23,7 @@ import io.micronaut.serde.Deserializer;
 import io.micronaut.serde.Encoder;
 import io.micronaut.serde.LimitingStream;
 import io.micronaut.serde.Serializer;
+import io.micronaut.serde.UpdatingDeserializer;
 import io.micronaut.serde.config.DeserializationConfiguration;
 import io.micronaut.serde.config.SerializationConfiguration;
 import io.micronaut.serde.exceptions.SerdeException;
@@ -68,9 +69,13 @@ public final class SingleElementArraySerde {
      * @param <T> The deserialized type
      * @return The deserializer, wrapped when needed
      */
+    @SuppressWarnings("unchecked")
     public static <T> Deserializer<T> acceptSingleValueAsArray(Deserializer<T> deserializer,
                                                                Deserializer.DecoderContext context) {
         if (context.getFeatures().contains(DeserializationConfiguration.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)) {
+            if (deserializer instanceof UpdatingDeserializer<?> updatingDeserializer) {
+                return new SingleValueAsArrayUpdatingDeserializer<>((UpdatingDeserializer<T>) updatingDeserializer, deserializer, context);
+            }
             return new SingleValueAsArrayDeserializer<>(deserializer, context);
         }
         return deserializer;
@@ -159,6 +164,51 @@ public final class SingleElementArraySerde {
         public @Nullable T getDefaultValue(DecoderContext context,
                                            Argument<? super T> type) {
             return delegate.getDefaultValue(context, type);
+        }
+    }
+
+    private static final class SingleValueAsArrayUpdatingDeserializer<T> implements Deserializer<T>, UpdatingDeserializer<T> {
+        private final UpdatingDeserializer<T> updatingDelegate;
+        private final Deserializer<T> delegate;
+        private final LimitingStream.RemainingLimits remainingLimits;
+
+        private SingleValueAsArrayUpdatingDeserializer(UpdatingDeserializer<T> updatingDelegate,
+                                                       Deserializer<T> delegate,
+                                                       Deserializer.DecoderContext context) {
+            this.updatingDelegate = updatingDelegate;
+            this.delegate = delegate;
+            this.remainingLimits = decoderLimits(context);
+        }
+
+        @Override
+        public T deserialize(Decoder decoder,
+                             DecoderContext context,
+                             Argument<? super T> type) throws IOException {
+            JsonNode node = arrayNode(decoder);
+            return delegate.deserialize(JsonNodeDecoder.create(node, remainingLimits), context, type);
+        }
+
+        @Override
+        public void deserializeInto(Decoder decoder,
+                                    DecoderContext context,
+                                    Argument<? super T> type,
+                                    T value) throws IOException {
+            JsonNode node = arrayNode(decoder);
+            updatingDelegate.deserializeInto(JsonNodeDecoder.create(node, remainingLimits), context, type, value);
+        }
+
+        @Override
+        public @Nullable T getDefaultValue(DecoderContext context,
+                                           Argument<? super T> type) {
+            return delegate.getDefaultValue(context, type);
+        }
+
+        private JsonNode arrayNode(Decoder decoder) throws IOException {
+            JsonNode node = decoder.decodeNode();
+            if (!node.isArray()) {
+                node = JsonNode.createArrayNode(List.of(node));
+            }
+            return node;
         }
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/util/ObjectShapeSerdeHelper.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/util/ObjectShapeSerdeHelper.java
@@ -16,10 +16,13 @@
 package io.micronaut.serde.support.util;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.beans.exceptions.IntrospectionException;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Deserializer;
 import io.micronaut.serde.Serializer;
+import io.micronaut.serde.UpdatingDeserializer;
 import io.micronaut.serde.exceptions.SerdeException;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Common helpers for POJO-like shape handling.
@@ -61,5 +64,27 @@ public final class ObjectShapeSerdeHelper {
                                                          Argument<? super T> type) throws SerdeException {
         Deserializer<T> objectDeserializer = (Deserializer<T>) context.findDeserializer((Argument) Argument.OBJECT_ARGUMENT);
         return objectDeserializer.createSpecific(context, type);
+    }
+
+    /**
+     * Select the generic object deserializer only when it supports updating this type.
+     *
+     * <p>This is used as a merge fallback for generated deserializers that are replace-only. If the type is not
+     * object-shaped, the generic object deserializer may not be able to create a specific deserializer. In that case
+     * there is no updating fallback and callers should keep replacement semantics.</p>
+     *
+     * @param context The decoder context
+     * @param type The type
+     * @param <T> The deserialized type
+     * @return The updating object deserializer, or {@code null} if the type cannot be updated through the object path
+     */
+    public static <T> @Nullable UpdatingDeserializer<T> updatingObjectDeserializer(Deserializer.DecoderContext context,
+                                                                                   Argument<? super T> type) throws SerdeException {
+        try {
+            Deserializer<T> deserializer = objectDeserializer(context, type);
+            return deserializer instanceof UpdatingDeserializer<?> ? (UpdatingDeserializer<T>) deserializer : null;
+        } catch (IntrospectionException e) {
+            return null;
+        }
     }
 }

--- a/src/main/docs/guide/jacksonAnnotations.adoc
+++ b/src/main/docs/guide/jacksonAnnotations.adoc
@@ -92,8 +92,8 @@ NOTE: If an unsupported annotation or member is used, a compilation error will r
 |
 
 |link:{jacksonAnnotationJavadoc}/JsonMerge.html[@JsonMerge]
-|❌
-|
+|✅
+|Supported for explicit property-level merge during `ObjectMapper.updateValue` and `updateValueFromTree`; no public `readerForUpdating` API is provided.
 
 |link:{jacksonAnnotationJavadoc}/JsonProperty.html[@JsonProperty]
 |✅
@@ -147,6 +147,30 @@ NOTE: If an unsupported annotation or member is used, a compilation error will r
 |✅
 |
 |===
+
+=== `@JsonMerge`
+
+The link:{jacksonAnnotationJavadoc}/JsonMerge.html[@JsonMerge] annotation enables merge behavior when updating an existing mutable object with api:serde.ObjectMapper[].
+
+Without `@JsonMerge`, an incoming nested object replaces the current property value. With `@JsonMerge`, Micronaut Serialization updates the existing nested value when possible: JSON fields present in the update replace matching fields, and fields absent from the update keep their current values.
+
+For example, this release configuration uses `@JsonMerge` on a nested deployment window and a labels map:
+
+snippet::example.ReleaseConfiguration[project-base="doc-examples/example", source="main"]
+
+The update JSON can then include only the values that should change:
+
+snippet::example.JsonMergeExampleTest[project-base="doc-examples/example"]
+
+In the nested object case, the update changes the deployment day but keeps the existing time zone.
+If the `deploymentWindow` property is not annotated with `@JsonMerge`, the incoming object replaces the current one and the absent time zone value is lost.
+In the map case, incoming labels update matching keys and add new keys while keys absent from the update remain in the map.
+
+`@JsonMerge` is explicit and property-scoped.
+It is supported for mutable readable bean properties, mutable maps, mutable collections, and array properties.
+Immutable, creator-only, builder-only, and record-like values cannot be updated in place.
+Explicit JSON `null` values follow the normal null handling rules instead of attempting a merge.
+Micronaut Serialization does not provide a public Jackson-style `readerForUpdating` API; use `ObjectMapper.updateValue(...)` or `updateValueFromTree(...)` to update existing values.
 
 In addition, limited support for 3 `jackson-databind` annotations is included to allow portability for cases where both support for `jackson-databind` and Micronaut Serialization is required:
 

--- a/test-suite-tck-jackson-databind/src/test/groovy/io/micronaut/serde/tck/jackson/databind/DatabindJsonMergeSpec.groovy
+++ b/test-suite-tck-jackson-databind/src/test/groovy/io/micronaut/serde/tck/jackson/databind/DatabindJsonMergeSpec.groovy
@@ -1,0 +1,50 @@
+package io.micronaut.serde.tck.jackson.databind
+
+import io.micronaut.core.type.Argument
+import io.micronaut.jackson.databind.JacksonDatabindMapper
+import io.micronaut.serde.jackson.JsonMergeSpec
+
+import java.nio.charset.StandardCharsets
+
+class DatabindJsonMergeSpec extends JsonMergeSpec {
+    @Override
+    protected boolean expectsRecordLikeUpdateUnsupported() {
+        false
+    }
+
+    @Override
+    protected boolean appliesJsonPropertyDefaultValueOnRead() {
+        false
+    }
+
+    @Override
+    protected boolean failsOnMissingRequiredPropertyOnRead() {
+        false
+    }
+
+    @Override
+    protected boolean preservesAbsentUnwrappedValueOnUpdate() {
+        false
+    }
+
+    @Override
+    protected Object update(Object value, Argument type, Object overrides) {
+        ((JacksonDatabindMapper) jsonMapper).objectMapper.updateValue(value, overrides)
+    }
+
+    @Override
+    protected Object updateBytes(Object value, Argument type, String json) {
+        ((JacksonDatabindMapper) jsonMapper).objectMapper.readerForUpdating(value).readValue(json.getBytes(StandardCharsets.UTF_8))
+    }
+
+    @Override
+    protected Object updateStream(Object value, Argument type, String json) {
+        ((JacksonDatabindMapper) jsonMapper).objectMapper.readerForUpdating(value)
+                .readValue(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)))
+    }
+
+    @Override
+    protected Object updateBuffer(Object value, Argument type, String json) {
+        updateBytes(value, type, json)
+    }
+}


### PR DESCRIPTION
Add experimental ObjectMapper updateValue overloads and stream-based JacksonJsonMapper update handling.

Support property-level @JsonMerge for mutable beans, maps, collections, and arrays through UpdatingDeserializer paths.

Add shared Serde/Jackson Databind TCK coverage plus tested documentation examples for JsonMerge.