### PR TITLE
Add Jackson JsonKey serialization support

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
@@ -427,6 +427,13 @@ public @interface SerdeConfig {
     }
 
     /**
+     * Meta-annotation used to model the value used during map key serialization.
+     */
+    @Internal
+    @interface SerKey {
+    }
+
+    /**
      * Meta-annotation used to model the enum constant to use for unknown values.
      *
      * @since 3.0

--- a/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonKeySpec.groovy
+++ b/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonKeySpec.groovy
@@ -1,0 +1,380 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.jackson
+
+class JsonKeySpec extends JsonCompileSpec {
+
+    void "JsonKey method is used only for map keys"() {
+        given:
+            def context = buildContext('''
+package example;
+
+import com.fasterxml.jackson.annotation.JsonKey;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.Map;
+
+@Serdeable
+class Basket {
+    private Map<Fruit, Integer> fruits;
+
+    public Map<Fruit, Integer> getFruits() {
+        return fruits;
+    }
+
+    public void setFruits(Map<Fruit, Integer> fruits) {
+        this.fruits = fruits;
+    }
+}
+
+@Serdeable
+class Fruit {
+    private final String name;
+    private final String variety;
+
+    Fruit(String name, String variety) {
+        this.name = name;
+        this.variety = variety;
+    }
+
+    @JsonKey
+    public String getName() {
+        return name;
+    }
+
+    @JsonValue
+    public String getFullName() {
+        return variety + " " + name;
+    }
+}
+''')
+            def fruit = newInstance(context, 'example.Fruit', 'Mango', 'Alphonso')
+            def basket = newInstance(context, 'example.Basket')
+            basket.fruits = new LinkedHashMap()
+            basket.fruits.put(fruit, 1)
+
+        expect:
+            writeJson(jsonMapper, fruit) == '"Alphonso Mango"'
+            writeJson(jsonMapper, basket) == '{"fruits":{"Mango":1}}'
+
+        cleanup:
+            context.close()
+    }
+
+    void "JsonKey field is used for map keys without changing value serialization"() {
+        given:
+            def context = buildContext('''
+package example;
+
+import com.fasterxml.jackson.annotation.JsonKey;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.Map;
+
+@Serdeable
+@Introspected(accessKind = Introspected.AccessKind.FIELD)
+class Catalog {
+    public Map<Product, Integer> products;
+    public Product selected;
+}
+
+@Serdeable
+@Introspected(accessKind = Introspected.AccessKind.FIELD)
+class Product {
+    @JsonKey
+    public String sku;
+    public String name;
+
+    Product(String sku, String name) {
+        this.sku = sku;
+        this.name = name;
+    }
+}
+''')
+            def product = newInstance(context, 'example.Product', 'SKU-1', 'Widget')
+            def catalog = newInstance(context, 'example.Catalog')
+            catalog.products = new LinkedHashMap()
+            catalog.products.put(product, 2)
+            catalog.selected = product
+
+        expect:
+            validateJsonWithoutOrder(
+                jsonMapper,
+                '{"products":{"SKU-1":2},"selected":{"sku":"SKU-1","name":"Widget"}}',
+                writeJson(jsonMapper, catalog)
+            )
+
+        cleanup:
+            context.close()
+    }
+
+    void "JsonKey field is used for runtime map key serialization"() {
+        given:
+            def context = buildContext(
+                'example.RuntimeCatalog',
+                '''
+package example;
+
+import com.fasterxml.jackson.annotation.JsonKey;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Serdeable
+@Introspected(accessKind = Introspected.AccessKind.FIELD)
+class RuntimeCatalog {
+    public Map<RuntimeProduct, Integer> products = new LinkedHashMap<>();
+    public RuntimeProduct selected;
+}
+
+@Serdeable
+@Introspected(accessKind = Introspected.AccessKind.FIELD)
+class RuntimeProduct {
+    @JsonKey
+    public String sku;
+    public String name;
+
+    RuntimeProduct(String sku, String name) {
+        this.sku = sku;
+        this.name = name;
+    }
+}
+''',
+                true,
+                ['micronaut.serde.serialization.disable-generated-serializer': true]
+            )
+            def product = newInstance(context, 'example.RuntimeProduct', 'SKU-1', 'Widget')
+            def catalog = newInstance(context, 'example.RuntimeCatalog')
+            catalog.products.put(product, 2)
+            catalog.selected = product
+
+        expect:
+            validateJsonWithoutOrder(
+                jsonMapper,
+                '{"products":{"SKU-1":2},"selected":{"sku":"SKU-1","name":"Widget"}}',
+                writeJson(jsonMapper, catalog)
+            )
+
+        cleanup:
+            context.close()
+    }
+
+    void "JsonKey false is ignored"() {
+        given:
+            def context = buildContext('''
+package example;
+
+import com.fasterxml.jackson.annotation.JsonKey;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.Map;
+
+@Serdeable
+class Basket {
+    private Map<Fruit, Integer> fruits;
+
+    public Map<Fruit, Integer> getFruits() {
+        return fruits;
+    }
+
+    public void setFruits(Map<Fruit, Integer> fruits) {
+        this.fruits = fruits;
+    }
+}
+
+@Serdeable
+class Fruit {
+    private final String name;
+    private final String variety;
+
+    Fruit(String name, String variety) {
+        this.name = name;
+        this.variety = variety;
+    }
+
+    @JsonKey(false)
+    public String getName() {
+        return name;
+    }
+
+    @JsonValue
+    public String getFullName() {
+        return variety + " " + name;
+    }
+}
+''')
+            def fruit = newInstance(context, 'example.Fruit', 'Mango', 'Alphonso')
+            def basket = newInstance(context, 'example.Basket')
+            basket.fruits = new LinkedHashMap()
+            basket.fruits.put(fruit, 1)
+
+        expect:
+            writeJson(jsonMapper, basket) == '{"fruits":{"Alphonso Mango":1}}'
+
+        cleanup:
+            context.close()
+    }
+
+    void "JsonKey method is used for enum map keys"() {
+        given:
+            def context = buildContext('''
+package example;
+
+import com.fasterxml.jackson.annotation.JsonKey;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.Map;
+
+@Serdeable
+class StatusHolder {
+    private Map<Status, Integer> statuses;
+    private Status status;
+
+    public Map<Status, Integer> getStatuses() {
+        return statuses;
+    }
+
+    public void setStatuses(Map<Status, Integer> statuses) {
+        this.statuses = statuses;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+}
+
+@Serdeable
+enum Status {
+    OK("ok-key", "ok-value");
+
+    private final String key;
+    private final String value;
+
+    Status(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    @JsonKey
+    public String key() {
+        return key;
+    }
+
+    @JsonValue
+    public String value() {
+        return value;
+    }
+}
+''')
+            def status = getEnum(context, 'example.Status.OK')
+            def holder = newInstance(context, 'example.StatusHolder')
+            holder.statuses = new LinkedHashMap()
+            holder.statuses.put(status, 3)
+            holder.status = status
+
+        expect:
+            validateJsonWithoutOrder(
+                jsonMapper,
+                '{"statuses":{"ok-key":3},"status":"ok-value"}',
+                writeJson(jsonMapper, holder)
+            )
+
+        cleanup:
+            context.close()
+    }
+
+    void "JsonKey composes with JsonValue for nested map key serialization"() {
+        given:
+            def context = buildContext('''
+package example;
+
+import com.fasterxml.jackson.annotation.JsonKey;
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Serdeable
+@Introspected(accessKind = Introspected.AccessKind.FIELD)
+class Catalog {
+    public Map<CatalogEntry, String> entriesByKey = new LinkedHashMap<>();
+    public Map<String, CatalogEntry> entriesByName = new LinkedHashMap<>();
+    public Map<String, ValueOnlyCatalogEntry> valueOnlyEntries = new LinkedHashMap<>();
+}
+
+@Serdeable
+@Introspected(accessKind = Introspected.AccessKind.FIELD)
+class CatalogLabel {
+    @JsonKey
+    String key;
+
+    @JsonValue
+    String value;
+
+    CatalogLabel(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+}
+
+@Serdeable
+@Introspected(accessKind = Introspected.AccessKind.FIELD)
+class CatalogEntry {
+    @JsonKey
+    @JsonValue
+    CatalogLabel label;
+
+    CatalogEntry(CatalogLabel label) {
+        this.label = label;
+    }
+}
+
+@Serdeable
+@Introspected(accessKind = Introspected.AccessKind.FIELD)
+class ValueOnlyCatalogEntry {
+    @JsonValue
+    CatalogLabel label;
+
+    ValueOnlyCatalogEntry(CatalogLabel label) {
+        this.label = label;
+    }
+}
+''')
+            def label = newInstance(context, 'example.CatalogLabel', 'display-key', 'display-value')
+            def entry = newInstance(context, 'example.CatalogEntry', label)
+            def valueOnlyEntry = newInstance(context, 'example.ValueOnlyCatalogEntry', label)
+            def catalog = newInstance(context, 'example.Catalog')
+            catalog.entriesByKey.put(entry, 'value')
+            catalog.entriesByName.put('key', entry)
+            catalog.valueOnlyEntries.put('key', valueOnlyEntry)
+
+        expect:
+            validateJsonWithoutOrder(
+                jsonMapper,
+                '{"entriesByKey":{"display-key":"value"},"entriesByName":{"key":"display-value"},"valueOnlyEntries":{"key":"display-value"}}',
+                writeJson(jsonMapper, catalog)
+            )
+
+        cleanup:
+            context.close()
+    }
+}

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeJsonKeySpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeJsonKeySpec.groovy
@@ -1,0 +1,6 @@
+package io.micronaut.serde.jackson.annotation
+
+import io.micronaut.serde.jackson.JsonKeySpec
+
+class SerdeJsonKeySpec extends JsonKeySpec {
+}

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/SerdeAnnotationVisitor.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/SerdeAnnotationVisitor.java
@@ -90,6 +90,8 @@ public class SerdeAnnotationVisitor implements TypeElementVisitor<SerdeConfig, S
     private @Nullable FieldElement anySetterField;
     private @Nullable MethodElement jsonValueMethod;
     private @Nullable FieldElement jsonValueField;
+    private @Nullable MethodElement jsonKeyMethod;
+    private @Nullable FieldElement jsonKeyField;
     private final Set<MethodElement> readMethods = new HashSet<>(20);
     private final Set<MethodElement> writeMethods = new HashSet<>(20);
     private final Set<String> elementVisitedAsSubtype = new HashSet<>(10);
@@ -110,7 +112,6 @@ public class SerdeAnnotationVisitor implements TypeElementVisitor<SerdeConfig, S
 
     private Set<String> getUnsupportedJacksonAnnotations() {
         return CollectionUtils.setOf(
-                "com.fasterxml.jackson.annotation.JsonKey",
                 "com.fasterxml.jackson.annotation.JsonAutoDetect",
                 "com.fasterxml.jackson.annotation.JsonMerge",
                 "com.fasterxml.jackson.annotation.JsonIdentityInfo",
@@ -167,6 +168,15 @@ public class SerdeAnnotationVisitor implements TypeElementVisitor<SerdeConfig, S
                 throw new ProcessingException(element, "A JsonValue method is already defined: " + jsonValueMethod);
             } else {
                 this.jsonValueField = element;
+            }
+        }
+        if (element.hasDeclaredAnnotation(SerdeConfig.SerKey.class)) {
+            if (jsonKeyField != null) {
+                throw new ProcessingException(element, "A JsonKey field is already defined: " + jsonKeyField);
+            } else if (jsonKeyMethod != null) {
+                throw new ProcessingException(element, "A JsonKey method is already defined: " + jsonKeyMethod);
+            } else {
+                this.jsonKeyField = element;
             }
         }
     }
@@ -260,6 +270,21 @@ public class SerdeAnnotationVisitor implements TypeElementVisitor<SerdeConfig, S
                 throw new ProcessingException(element, "A JsonValue method is already defined: " + jsonValueMethod);
             } else {
                 this.jsonValueMethod = element;
+            }
+        }
+        if (methodMetadata.hasDeclaredAnnotation(SerdeConfig.SerKey.class)) {
+            if (element.isStatic()) {
+                throw new ProcessingException(element, "A JsonKey method cannot be static");
+            } else if (element.getReturnType().getName().equals("void")) {
+                throw new ProcessingException(element, "A JsonKey method cannot return void");
+            } else if (element.hasParameters()) {
+                throw new ProcessingException(element, "A JsonKey method cannot define arguments");
+            } else if (jsonKeyField != null) {
+                throw new ProcessingException(element, "A JsonKey field is already defined: " + jsonKeyField);
+            } else if (jsonKeyMethod != null) {
+                throw new ProcessingException(element, "A JsonKey method is already defined: " + jsonKeyMethod);
+            } else {
+                this.jsonKeyMethod = element;
             }
         }
     }
@@ -1415,6 +1440,8 @@ public class SerdeAnnotationVisitor implements TypeElementVisitor<SerdeConfig, S
         this.anySetterField = null;
         this.jsonValueField = null;
         this.jsonValueMethod = null;
+        this.jsonKeyField = null;
+        this.jsonKeyMethod = null;
         this.readMethods.clear();
         this.writeMethods.clear();
     }

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/jackson/JsonKeyMapper.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/jackson/JsonKeyMapper.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.processor.jackson;
+
+import io.micronaut.context.annotation.Executable;
+import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.visitor.VisitorContext;
+import io.micronaut.serde.config.annotation.SerdeConfig;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Support for JsonKey.
+ */
+public class JsonKeyMapper extends ValidatingAnnotationMapper {
+    @Override
+    protected List<AnnotationValue<?>> mapValid(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        if (!annotation.booleanValue().orElse(true)) {
+            return List.of();
+        }
+        return List.of(
+            AnnotationValue.builder(Executable.class).build(),
+            AnnotationValue.builder(SerdeConfig.SerKey.class).build()
+        );
+    }
+
+    @Override
+    protected Set<String> getSupportedMemberNames() {
+        return Set.of(AnnotationMetadata.VALUE_MEMBER);
+    }
+
+    @Override
+    public String getName() {
+        return "com.fasterxml.jackson.annotation.JsonKey";
+    }
+}

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/SimpleSerdeShapeAnalyzer.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/SimpleSerdeShapeAnalyzer.java
@@ -162,6 +162,13 @@ public final class SimpleSerdeShapeAnalyzer {
             && failBoth(serializerReasons, deserializerReasons, SimpleSerdeShapeDecision.FallbackReason.UNSUPPORTED_SHAPE)) {
             return decision(shapeKind, serializerReasons, deserializerReasons);
         }
+        if (serializerReasons.isEmpty()
+            && hasAnnotation(element, SerdeConfig.SerKey.class)) {
+            failSerializer(serializerReasons, SimpleSerdeShapeDecision.FallbackReason.UNSUPPORTED_SHAPE);
+            if (isBothFailed(serializerReasons, deserializerReasons)) {
+                return decision(shapeKind, serializerReasons, deserializerReasons);
+            }
+        }
         if (!element.isEnum()
             && !isBothFailed(serializerReasons, deserializerReasons)
             && hasSerValueInPropertyTypes(element)

--- a/serde-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
+++ b/serde-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
@@ -20,6 +20,7 @@ io.micronaut.serde.processor.jackson.JsonAliasMapper
 io.micronaut.serde.processor.bson.BsonRepresentationMapper
 io.micronaut.serde.processor.jackson.JsonPropertyOrderMapper
 io.micronaut.serde.processor.jackson.JsonEnumDefaultValueMapper
+io.micronaut.serde.processor.jackson.JsonKeyMapper
 io.micronaut.serde.processor.jackson.JsonValueMapper
 io.micronaut.serde.processor.jackson.JsonTypeInfoMapper
 io.micronaut.serde.processor.jackson.JsonSetterMapper

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/EnumSerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/EnumSerde.java
@@ -15,6 +15,7 @@
  */
 package io.micronaut.serde.support.serdes;
 
+import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Creator;
 import io.micronaut.core.beans.BeanIntrospection;
 import io.micronaut.core.beans.BeanMethod;
@@ -56,6 +57,7 @@ import java.util.stream.Collectors;
  * @since 1.0.0
  */
 final class EnumSerde<E extends Enum<E>> implements CustomizableDeserializer<E>, FormattedSerde<E>, SerdeRegistrar<E> {
+    private static final String JACKSON_KEY = "com.fasterxml.jackson.annotation.JsonKey";
 
     private final SerdeIntrospections introspections;
 
@@ -186,8 +188,25 @@ final class EnumSerde<E extends Enum<E>> implements CustomizableDeserializer<E>,
     @Override
     public Serializer<E> createSpecific(EncoderContext context,
                                         Argument<? extends E> type) throws SerdeException {
+        boolean keySerialization = type.getAnnotationMetadata().hasAnnotation(SerdeConfig.SerKey.class);
         try {
             BeanIntrospection<E> si = introspections.getSerializableIntrospection((Argument<E>) type);
+            if (keySerialization) {
+                for (BeanMethod<? extends E, Object> beanMethod : si.getBeanMethods()) {
+                    if (isJsonKey(beanMethod.getAnnotationMetadata())) {
+                        Argument<Object> valueType = beanMethod.getReturnType().asArgument();
+                        Serializer<? super Object> valueSerializer = context.findSerializer(valueType);
+                        return new EnumJsonValueSerializer<>(valueType, valueSerializer, beanMethod, null);
+                    }
+                }
+                for (BeanProperty<? extends E, Object> beanProperty : si.getBeanProperties()) {
+                    if (isJsonKey(beanProperty.getAnnotationMetadata())) {
+                        Argument<Object> valueType = beanProperty.asArgument();
+                        Serializer<? super Object> valueSerializer = context.findSerializer(valueType);
+                        return new EnumJsonValueSerializer<>(valueType, valueSerializer, null, beanProperty);
+                    }
+                }
+            }
             for (BeanMethod<? extends E, Object> beanMethod : si.getBeanMethods()) {
                 if (beanMethod.getAnnotationMetadata().hasDeclaredAnnotation(SerdeConfig.SerValue.class)) {
                     Argument<Object> valueType = beanMethod.getReturnType().asArgument();
@@ -218,6 +237,11 @@ final class EnumSerde<E extends Enum<E>> implements CustomizableDeserializer<E>,
             // ignore
         }
         return new EnumNameSerializer<>();
+    }
+
+    private static boolean isJsonKey(AnnotationMetadata annotationMetadata) {
+        return annotationMetadata.hasAnnotation(SerdeConfig.SerKey.class)
+            || (annotationMetadata.hasAnnotation(JACKSON_KEY) && annotationMetadata.booleanValue(JACKSON_KEY).orElse(true));
     }
 
     @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/AbstractMapObjectSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/AbstractMapObjectSerializer.java
@@ -70,7 +70,7 @@ abstract sealed class AbstractMapObjectSerializer<K, V> implements ObjectSeriali
     }
 
     @SuppressWarnings("unchecked")
-    private static int compareKeys(Object left, Object right) {
+    private static int compareKeys(@Nullable Object left, @Nullable Object right) {
         if (left == right) {
             return 0;
         }
@@ -104,7 +104,7 @@ abstract sealed class AbstractMapObjectSerializer<K, V> implements ObjectSeriali
                 .sorted(AbstractMapObjectSerializer::compareEntriesByKey)
                 .toList();
         }
-        for (Map.Entry<K, V> entry : entries) {
+        for (Map.Entry<@Nullable K, @Nullable V> entry : entries) {
             K k = entry.getKey();
             try {
                 V v = entry.getValue();

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/ObjectSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/ObjectSerializer.java
@@ -93,6 +93,7 @@ public final class ObjectSerializer implements CustomizableSerializer<Object> {
 
     private io.micronaut.serde.Serializer<Object> createSpecificInternal(EncoderContext encoderContext,
                                                                          Argument<?> type) throws SerdeException {
+        boolean keySerialization = type.getAnnotationMetadata().hasAnnotation(SerdeConfig.SerKey.class);
         SerBean<Object> serBean;
         try {
             serBean = (SerBean<Object>) getSerializableBean(type, encoderContext);
@@ -102,17 +103,25 @@ public final class ObjectSerializer implements CustomizableSerializer<Object> {
         }
 
         io.micronaut.serde.Serializer<Object> serializer;
-        if (serBean.simpleBean) {
+        SerBean.SerProperty<Object, Object> jsonKey = serBean.jsonKey;
+        boolean jsonKeySerialization;
+        if (keySerialization && jsonKey != null) {
+            serializer = new JsonValueSerializer<>(jsonKey);
+            jsonKeySerialization = true;
+        } else if (serBean.simpleBean) {
             serializer = new SimpleObjectSerializer<>(serBean);
+            jsonKeySerialization = false;
         } else if (serBean.jsonValue != null) {
             serializer = new JsonValueSerializer<>(serBean.jsonValue);
+            jsonKeySerialization = false;
         } else {
             serializer = new CustomizedObjectSerializer<>(serBean);
+            jsonKeySerialization = false;
         }
-        boolean subtyped = serBean.subtyped;
+        boolean subtyped = !jsonKeySerialization && serBean.subtyped;
         if (subtyped) {
             serializer = new RuntimeTypeSerializer(encoderContext, serializer, type);
-        } else {
+        } else if (!jsonKeySerialization) {
             if (serBean.wrapperProperty != null) {
                 serializer = new WrappedObjectSerializer<>(serializer, serBean.wrapperProperty);
             } else if (serBean.arrayWrapperProperty != null) {

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/RuntimeMapSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/RuntimeMapSerializer.java
@@ -15,14 +15,18 @@
  */
 package io.micronaut.serde.support.serializers;
 
+import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.beans.exceptions.IntrospectionException;
 import io.micronaut.core.convert.exceptions.ConversionErrorException;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.ArrayUtils;
+import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
+import io.micronaut.inject.annotation.MutableAnnotationMetadata;
 import io.micronaut.json.tree.JsonNode;
 import io.micronaut.serde.Encoder;
 import io.micronaut.serde.Serializer;
+import io.micronaut.serde.config.annotation.SerdeConfig;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.util.JsonNodeEncoder;
 
@@ -39,6 +43,7 @@ import java.util.Objects;
  */
 @Internal
 final class RuntimeMapSerializer<K, V> extends AbstractMapObjectSerializer<K, V> {
+    private static final AnnotationMetadata MAP_KEY_SERIALIZATION_METADATA = mapKeySerializationMetadata();
 
     private final boolean isStringKey;
     private final Argument<K> keyGeneric;
@@ -49,10 +54,10 @@ final class RuntimeMapSerializer<K, V> extends AbstractMapObjectSerializer<K, V>
         final Argument<?>[] generics = type.getTypeParameters();
         final boolean hasGenerics = ArrayUtils.isNotEmpty(generics) && generics.length == 2;
         if (hasGenerics) {
-            keyGeneric = (Argument<K>) generics[0];
+            keyGeneric = asMapKeyArgument((Argument<K>) generics[0]);
             isStringKey = keyGeneric.getType() == String.class || CharSequence.class.isAssignableFrom(keyGeneric.getType());
         } else {
-            keyGeneric = (Argument<K>) Argument.OBJECT_ARGUMENT;
+            keyGeneric = asMapKeyArgument((Argument<K>) Argument.OBJECT_ARGUMENT);
             isStringKey = false;
         }
         keySerializer = findKeySerializer(context, keyGeneric);
@@ -60,13 +65,28 @@ final class RuntimeMapSerializer<K, V> extends AbstractMapObjectSerializer<K, V>
 
     @Override
     protected void encodeKey(Encoder encoder, EncoderContext context, K k) throws IOException {
-        if (k == null) {
-            encoder.encodeNull();
-        } else if (isStringKey || k instanceof CharSequence) {
+        if (isStringKey || k instanceof CharSequence) {
             encoder.encodeKey(k.toString());
         } else {
             encodeMapKey(context, encoder, keyGeneric, keySerializer, k);
         }
+    }
+
+    private static AnnotationMetadata mapKeySerializationMetadata() {
+        MutableAnnotationMetadata metadata = new MutableAnnotationMetadata();
+        metadata.addDeclaredAnnotation(SerdeConfig.SerKey.class.getName(), Map.of());
+        return metadata;
+    }
+
+    private static <K> Argument<K> asMapKeyArgument(Argument<K> keyGeneric) {
+        AnnotationMetadata annotationMetadata = keyGeneric.getAnnotationMetadata();
+        if (annotationMetadata.hasAnnotation(SerdeConfig.SerKey.class)) {
+            return keyGeneric;
+        }
+        AnnotationMetadata keyAnnotationMetadata = annotationMetadata.isEmpty()
+            ? MAP_KEY_SERIALIZATION_METADATA
+            : new AnnotationMetadataHierarchy(annotationMetadata, MAP_KEY_SERIALIZATION_METADATA);
+        return keyGeneric.withAnnotationMetadata(keyAnnotationMetadata);
     }
 
     private static <K> Serializer<K> findKeySerializer(EncoderContext context, Argument<K> keyGeneric) throws
@@ -110,14 +130,11 @@ final class RuntimeMapSerializer<K, V> extends AbstractMapObjectSerializer<K, V>
         }
     }
 
-    private static void convertMapKeyToStringAndEncode(EncoderContext context, Encoder
-        encoder, Object keyValue) throws IOException {
+    private static void convertMapKeyToStringAndEncode(EncoderContext context, Encoder encoder, Object keyValue) throws IOException {
         try {
-            final String result = context.getConversionService().convertRequired(keyValue, Argument.STRING);
-            if (result == null) {
-                throw new SerdeException("Null key for a Map not allowed in JSON");
-            }
-            encoder.encodeKey(result);
+            encoder.encodeKey(
+                context.getConversionService().convertRequired(keyValue, Argument.STRING)
+            );
         } catch (ConversionErrorException ce) {
             throw new SerdeException("Error converting Map key [" + keyValue + "] to String: " + ce.getMessage(), ce);
         }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBean.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBean.java
@@ -32,6 +32,7 @@ import io.micronaut.core.order.Ordered;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.inject.annotation.AnnotationMetadataHierarchy;
+import io.micronaut.inject.annotation.MutableAnnotationMetadata;
 import io.micronaut.inject.qualifiers.Qualifiers;
 import io.micronaut.serde.FormatConfiguration;
 import io.micronaut.serde.FormattedSerializer;
@@ -87,6 +88,7 @@ final class SerBean<T> {
     );
     private static final String JK_PROP = "com.fasterxml.jackson.annotation.JsonProperty";
     private static final String JACKSON_VALUE = "com.fasterxml.jackson.annotation.JsonValue";
+    private static final String JACKSON_KEY = "com.fasterxml.jackson.annotation.JsonKey";
 
     // CHECKSTYLE:OFF
     public final BeanIntrospection<T> introspection;
@@ -98,6 +100,8 @@ final class SerBean<T> {
     public final String arrayWrapperProperty;
     @Nullable
     public SerProperty<T, Object> jsonValue;
+    @Nullable
+    public SerProperty<T, Object> jsonKey;
     public final SerializationConfiguration configuration;
     public final boolean simpleBean;
     public final boolean subtyped;
@@ -149,12 +153,13 @@ final class SerBean<T> {
         final Map.Entry<BeanReadProperty<T, Object>, AnnotationMetadata> serPropEntry = properties.stream()
                 .filter(bp -> bp.getValue().hasAnnotation(SerdeConfig.SerValue.class) || bp.getValue().hasAnnotation(JACKSON_VALUE))
                 .findFirst().orElse(null);
+        jsonKey = resolveJsonKey(properties, resolvedInitializers, serdeArgumentConf);
         if (serPropEntry != null) {
             wrapperProperty = null;
             arrayWrapperProperty = null;
             BeanReadProperty<T, Object> beanProperty = serPropEntry.getKey();
             final Argument<Object> serType = beanProperty.asArgument();
-            AnnotationMetadata propertyAnnotationMetadata = serPropEntry.getValue();
+            AnnotationMetadata propertyAnnotationMetadata = withoutJsonKey(serPropEntry.getValue());
             SerProperty<T, Object> resolvedJsonValue = new PropSerProperty<>(
                 SerBean.this,
                 beanProperty.getName(),
@@ -179,7 +184,7 @@ final class SerBean<T> {
                     serMethod.getName(),
                     serMethod.getName(),
                     serMethod.getReturnType().asArgument(),
-                    serMethod.getAnnotationMetadata(),
+                    withoutJsonKey(serMethod.getAnnotationMetadata()),
                     serMethod
                 );
                 jsonValue = resolvedJsonValue;
@@ -226,7 +231,62 @@ final class SerBean<T> {
 
         simpleBean = isSimpleBean();
         boolean isAbstractIntrospection = Modifier.isAbstract(introspection.getBeanType().getModifiers());
-        subtyped = isAbstractIntrospection || resolvedSubtypeInfo != null && !resolvedSubtypeInfo.subtypes().isEmpty() && !resolvedSubtypeInfo.subtypes().containsKey(type.getType()) || introspection.getAnnotationMetadata().hasDeclaredAnnotation(SerdeConfig.SerSubtyped.class);
+        subtyped = isAbstractIntrospection
+            || (resolvedSubtypeInfo != null && !resolvedSubtypeInfo.subtypes().isEmpty() && !resolvedSubtypeInfo.subtypes().containsKey(type.getType()))
+            || introspection.getAnnotationMetadata().hasDeclaredAnnotation(SerdeConfig.SerSubtyped.class);
+    }
+
+    @Nullable
+    private SerProperty<T, Object> resolveJsonKey(Collection<Map.Entry<BeanReadProperty<T, Object>, AnnotationMetadata>> properties,
+                                                  List<Initializer> resolvedInitializers,
+                                                  @Nullable SerdeArgumentConf serdeArgumentConf) {
+        final Map.Entry<BeanReadProperty<T, Object>, AnnotationMetadata> serKeyPropEntry = properties.stream()
+            .filter(bp -> isJsonKey(bp.getValue()))
+            .findFirst().orElse(null);
+        if (serKeyPropEntry != null) {
+            BeanReadProperty<T, Object> beanProperty = serKeyPropEntry.getKey();
+            SerProperty<T, Object> resolvedJsonKey = new PropSerProperty<>(
+                SerBean.this,
+                beanProperty.getName(),
+                beanProperty.getName(),
+                beanProperty.asArgument(),
+                serKeyPropEntry.getValue(),
+                beanProperty
+            );
+            resolvedInitializers.add(ctx -> initProperty(resolvedJsonKey, ctx, serdeArgumentConf));
+            return resolvedJsonKey;
+        }
+        final BeanMethod<T, Object> serKeyMethod = introspection.getBeanMethods().stream()
+            .filter(m -> isJsonKey(m.getAnnotationMetadata()))
+            .findFirst().orElse(null);
+        if (serKeyMethod != null) {
+            SerProperty<T, Object> resolvedJsonKey = new MethodSerProperty<>(
+                SerBean.this,
+                serKeyMethod.getName(),
+                serKeyMethod.getName(),
+                serKeyMethod.getReturnType().asArgument(),
+                serKeyMethod.getAnnotationMetadata(),
+                serKeyMethod
+            );
+            resolvedInitializers.add(ctx -> initProperty(resolvedJsonKey, ctx, serdeArgumentConf));
+            return resolvedJsonKey;
+        }
+        return null;
+    }
+
+    private static boolean isJsonKey(AnnotationMetadata annotationMetadata) {
+        return annotationMetadata.hasAnnotation(SerdeConfig.SerKey.class)
+            || (annotationMetadata.hasAnnotation(JACKSON_KEY) && annotationMetadata.booleanValue(JACKSON_KEY).orElse(true));
+    }
+
+    private static AnnotationMetadata withoutJsonKey(AnnotationMetadata annotationMetadata) {
+        if (!annotationMetadata.hasAnnotation(SerdeConfig.SerKey.class) && !annotationMetadata.hasAnnotation(JACKSON_KEY)) {
+            return annotationMetadata;
+        }
+        MutableAnnotationMetadata mutableAnnotationMetadata = MutableAnnotationMetadata.of(annotationMetadata);
+        mutableAnnotationMetadata.removeAnnotation(SerdeConfig.SerKey.class.getName());
+        mutableAnnotationMetadata.removeAnnotation(JACKSON_KEY);
+        return mutableAnnotationMetadata;
     }
 
     private static <T> void sortPropertiesIfNeeded(@Nullable SerdeArgumentConf serdeArgumentConf,

--- a/src/main/docs/guide/jacksonAnnotations.adoc
+++ b/src/main/docs/guide/jacksonAnnotations.adoc
@@ -84,7 +84,7 @@ NOTE: If an unsupported annotation or member is used, a compilation error will r
 |unsupported members: `contentFilter`, `valueFilter`
 
 |link:{jacksonAnnotationJavadoc}/JsonKey.html[@JsonKey]
-|❌
+|✅
 |
 
 |link:{jacksonAnnotationJavadoc}/JsonManagedReference.html[@JsonManagedReference]

--- a/test-suite-tck-jackson-databind/src/test/groovy/io/micronaut/serde/tck/jackson/databind/DatabindJsonKeySpec.groovy
+++ b/test-suite-tck-jackson-databind/src/test/groovy/io/micronaut/serde/tck/jackson/databind/DatabindJsonKeySpec.groovy
@@ -1,0 +1,6 @@
+package io.micronaut.serde.tck.jackson.databind
+
+import io.micronaut.serde.jackson.JsonKeySpec
+
+class DatabindJsonKeySpec extends JsonKeySpec {
+}


### PR DESCRIPTION
Map Jackson @JsonKey to serde key metadata, apply key-mode serialization for objects and enums, and cover serde and Databind TCK behavior including runtime map serialization and JsonValue composition.