### PR TITLE
Publish Jakarta JSON TCK results to GitHub Pages

### DIFF
--- a/.github/workflows/json-tck.yml
+++ b/.github/workflows/json-tck.yml
@@ -12,6 +12,8 @@ jobs:
   json-tck:
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: "📥 Checkout repository"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -69,3 +71,112 @@ jobs:
         run: |
           test "${JSONP_OUTCOME}" = "success"
           test "${JSONB_OUTCOME}" = "success"
+
+  publish-results:
+    name: Publish Jakarta JSON TCK results
+    needs: json-tck
+    if: success() && github.event_name == 'push' && github.repository == 'micronaut-projects/micronaut-serialization'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+    steps:
+      - name: "📥 Download Jakarta JSON TCK evidence"
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: jakarta-json-tck-evidence
+          path: downloaded-tck-results
+
+      - name: "📑 Build Jakarta JSON TCK results index"
+        run: |
+          set -euo pipefail
+
+          run_results_dir="pages-tck-results/${GITHUB_RUN_ID}"
+          mkdir -p "${run_results_dir}"
+          cp -R downloaded-tck-results/. "${run_results_dir}/"
+
+          if [ ! -f "${run_results_dir}/jsonp/index.html" ]; then
+            echo "Missing Jakarta JSON-P TCK evidence." >&2
+            exit 1
+          fi
+          if [ ! -f "${run_results_dir}/jsonb/index.html" ]; then
+            echo "Missing Jakarta JSON-B TCK evidence." >&2
+            exit 1
+          fi
+
+          cat > "${run_results_dir}/index.html" <<EOF
+          <!doctype html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <title>Micronaut Serialization Jakarta JSON TCK Results</title>
+            <style>
+              body { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height: 1.5; max-width: 960px; margin: 2rem auto; padding: 0 1rem; color: #1f2933; }
+              code { background: #f5f7fa; border-radius: 4px; padding: 0.1rem 0.25rem; }
+            </style>
+          </head>
+          <body>
+            <h1>Micronaut Serialization Jakarta JSON TCK Results</h1>
+            <p>Workflow run: <a href="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}">${GITHUB_RUN_ID}</a></p>
+            <p>Commit: <a href="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/commit/${GITHUB_SHA}"><code>${GITHUB_SHA}</code></a></p>
+            <ul>
+              <li><a href="./jsonp/">Jakarta JSON Processing (JSON-P) TCK evidence</a></li>
+              <li><a href="./jsonb/">Jakarta JSON Binding (JSON-B) TCK evidence</a></li>
+            </ul>
+          </body>
+          </html>
+          EOF
+
+      - name: "📑 Publish Jakarta JSON TCK results to Github Pages"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+
+          docs_branch="gh-pages"
+          docs_dir="$(mktemp -d)"
+          repository_url="https://github.com/${GITHUB_REPOSITORY}.git"
+          target_dir="${docs_dir}/tck-results/${GITHUB_RUN_ID}"
+          latest_dir="${docs_dir}/tck-results/latest"
+          askpass="$(mktemp)"
+
+          cat > "${askpass}" <<'EOF'
+          #!/usr/bin/env sh
+          case "$1" in
+            *Username*) printf '%s\n' 'x-access-token' ;;
+            *Password*) printf '%s\n' "${GH_TOKEN}" ;;
+            *) printf '\n' ;;
+          esac
+          EOF
+          chmod 700 "${askpass}"
+          trap 'rm -f "${askpass}"' EXIT
+
+          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config --global user.name "${GITHUB_ACTOR}"
+
+          if GIT_ASKPASS="${askpass}" GIT_TERMINAL_PROMPT=0 git ls-remote --exit-code --heads "${repository_url}" "${docs_branch}" > /dev/null 2>&1; then
+            GIT_ASKPASS="${askpass}" GIT_TERMINAL_PROMPT=0 git clone --depth 1 --branch "${docs_branch}" "${repository_url}" "${docs_dir}"
+          else
+            git init "${docs_dir}"
+            git -C "${docs_dir}" checkout -b "${docs_branch}"
+            git -C "${docs_dir}" remote add origin "${repository_url}"
+          fi
+
+          rm -rf "${target_dir}"
+          mkdir -p "${target_dir}"
+          cp -R "pages-tck-results/${GITHUB_RUN_ID}/." "${target_dir}/"
+
+          rm -rf "${latest_dir}"
+          mkdir -p "${latest_dir}"
+          cp -R "pages-tck-results/${GITHUB_RUN_ID}/." "${latest_dir}/"
+
+          touch "${docs_dir}/.nojekyll"
+
+          git -C "${docs_dir}" add -A
+          if git -C "${docs_dir}" diff --cached --quiet; then
+            echo "No Jakarta JSON TCK result changes to publish."
+          else
+            git -C "${docs_dir}" commit -m "Deploy Jakarta JSON TCK results for ${GITHUB_RUN_ID}"
+            GIT_ASKPASS="${askpass}" GIT_TERMINAL_PROMPT=0 git -C "${docs_dir}" push origin "${docs_branch}"
+          fi

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ See the [Documentation](https://micronaut-projects.github.io/micronaut-serializa
 
 See the [Snapshot Documentation](https://micronaut-projects.github.io/micronaut-serialization/snapshot/guide/) for the current development docs.
 
+## Specification Compliance
+
+Micronaut Serialization verifies its Jakarta JSON provider support with the official standalone Jakarta TCKs:
+
+* [Jakarta JSON Processing (JSON-P)](https://jakarta.ee/specifications/jsonp/2.1/) 2.1, using `jakarta.json-api` 2.1.3 and `jakarta.json-tck-tests` 2.1.1.
+* [Jakarta JSON Binding (JSON-B)](https://jakarta.ee/specifications/jsonb/3.0/) 3.0, using `jakarta.json.bind-api` 3.0.2 and `jakarta.json.bind-tck` 3.0.0.
+
+The latest published TCK results are available from the fixed [Jakarta JSON TCK results page](https://micronaut-projects.github.io/micronaut-serialization/tck-results/latest/). Each successful push run also publishes immutable results under `tck-results/<workflow-run-id>/` with separate JSON-P and JSON-B summaries, sanitized JUnit XML, and SHA-256 checksums.
+
 ## Snapshots and Releases
 
 Snapshots are automatically published to [Sonatype Snapshots](https://s01.oss.sonatype.org/content/repositories/snapshots/io/micronaut/) using [Github Actions](https://github.com/micronaut-projects/micronaut-serialization/actions).


### PR DESCRIPTION
## Summary
- publish Jakarta JSON TCK evidence to GitHub Pages under tck-results/<workflow-run-id>/ and tck-results/latest/
- add an index page linking JSON-P and JSON-B evidence
- document the fixed TCK results URL in README

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/json-tck.yml"); puts "yaml ok"'
- git diff --check