### PR TITLE
Support Jackson JsonTypeId annotation

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/annotation/SerdeConfig.java
@@ -434,6 +434,13 @@ public @interface SerdeConfig {
     }
 
     /**
+     * Meta-annotation used to model the property that provides the type id during serialization.
+     */
+    @Internal
+    @interface SerTypeId {
+    }
+
+    /**
      * Meta-annotation used to model the enum constant to use for unknown values.
      *
      * @since 3.0

--- a/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonTypeInfoSpec.groovy
+++ b/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonTypeInfoSpec.groovy
@@ -272,7 +272,8 @@ abstract class Base {
 class Person extends Base {
     private final int age;
 
-    Person(int age) {
+    @JsonCreator
+    Person(@JsonProperty("age") int age) {
         this.age = age;
     }
 
@@ -302,6 +303,13 @@ class Person extends Base {
         then:
             result.class.name == 'example.Person'
             result.age == 19
+
+        when:
+            def databindResult = new ObjectMapper().readValue('{"age":19,"name":"bob"}', baseClass)
+
+        then:
+            databindResult.class.name == 'example.Person'
+            databindResult.age == 19
 
         cleanup:
             compiled.close()

--- a/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonTypeInfoSpec.groovy
+++ b/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonTypeInfoSpec.groovy
@@ -85,6 +85,262 @@ class B extends Base {
             compiled.close()
     }
 
+    def 'test @JsonTypeId with property type info'() {
+        given:
+            def compiled = buildContext('example.Base', '''
+package example;
+
+import com.fasterxml.jackson.annotation.*;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+@Introspected(accessKind = Introspected.AccessKind.FIELD)
+@JsonSubTypes(@JsonSubTypes.Type(value = Book.class, name = "book"))
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
+class Base {
+}
+
+@Introspected(accessKind = Introspected.AccessKind.FIELD)
+class Book extends Base {
+    @JsonTypeId
+    public String code;
+    public String title;
+}
+''', true)
+            def jsonMapper = compiled.getBean(JsonMapper)
+
+        when:
+            def book = newInstance(compiled, 'example.Book')
+            book.code = 'book'
+            book.title = 'Micronaut'
+            String json = serializeToString(jsonMapper, book)
+
+        then:
+            JSONAssert.assertEquals('{"kind":"book","title":"Micronaut"}', json, JSONCompareMode.STRICT)
+
+        cleanup:
+            compiled.close()
+    }
+
+    void 'test @JsonTypeId with wrapper #include type info'(String include, String expected) {
+        given:
+            def compiled = buildContext('example.Base', """
+package example;
+
+import com.fasterxml.jackson.annotation.*;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+@Introspected(accessKind = Introspected.AccessKind.FIELD)
+@JsonSubTypes(@JsonSubTypes.Type(value = Book.class, name = "book"))
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.${include})
+class Base {
+}
+
+@Introspected(accessKind = Introspected.AccessKind.FIELD)
+class Book extends Base {
+    @JsonTypeId
+    public String code;
+    public String title;
+}
+""", true)
+            def jsonMapper = compiled.getBean(JsonMapper)
+
+        when:
+            def book = newInstance(compiled, 'example.Book')
+            book.code = 'custom-book'
+            book.title = 'Micronaut'
+
+        then:
+            serializeToString(jsonMapper, book) == expected
+
+        cleanup:
+            compiled.close()
+
+        where:
+            include          | expected
+            'WRAPPER_OBJECT' | '{"custom-book":{"title":"Micronaut"}}'
+            'WRAPPER_ARRAY'  | '["custom-book",{"title":"Micronaut"}]'
+    }
+
+    def 'test @JsonTypeId on method with wrapper object type info'() {
+        given:
+            def compiled = buildContext('example.Base', '''
+package example;
+
+import com.fasterxml.jackson.annotation.*;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+@JsonSubTypes(@JsonSubTypes.Type(value = Book.class, name = "book"))
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.WRAPPER_OBJECT)
+class Base {
+}
+
+@Serdeable
+class Book extends Base {
+    private final String title;
+
+    Book(String title) {
+        this.title = title;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    @JsonTypeId
+    public String getCode() {
+        return "custom-book";
+    }
+}
+''', true)
+            def jsonMapper = compiled.getBean(JsonMapper)
+
+        when:
+            def book = newInstance(compiled, 'example.Book', 'Micronaut')
+
+        then:
+            serializeToString(jsonMapper, book) == '{"custom-book":{"title":"Micronaut"}}'
+
+        cleanup:
+            compiled.close()
+    }
+
+    def 'test @JsonTypeId with external property type info'() {
+        given:
+            def compiled = buildContext('example.Wrapper', '''
+package example;
+
+import com.fasterxml.jackson.annotation.*;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+@Introspected(accessKind = Introspected.AccessKind.FIELD)
+class Wrapper {
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXTERNAL_PROPERTY, property = "kind")
+    public Book book;
+}
+
+@Serdeable
+@Introspected(accessKind = Introspected.AccessKind.FIELD)
+class Book {
+    @JsonTypeId
+    public String kind;
+    public String title;
+}
+''', true)
+            def jsonMapper = compiled.getBean(JsonMapper)
+
+        when:
+            def book = newInstance(compiled, 'example.Book')
+            book.kind = 'custom-book'
+            book.title = 'Micronaut'
+            def wrapper = newInstance(compiled, 'example.Wrapper')
+            wrapper.book = book
+            String json = serializeToString(jsonMapper, wrapper)
+
+        then:
+            JSONAssert.assertEquals('{"book":{"title":"Micronaut"},"kind":"custom-book"}', json, JSONCompareMode.NON_EXTENSIBLE)
+
+        cleanup:
+            compiled.close()
+    }
+
+    def 'test @JsonTypeId on abstract base getter'() {
+        given:
+            def compiled = buildContext('example.Base', '''
+package example;
+
+import com.fasterxml.jackson.annotation.*;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "name")
+@JsonSubTypes(@JsonSubTypes.Type(value = Person.class))
+abstract class Base {
+    @JsonTypeId
+    public abstract String getName();
+}
+
+@Serdeable
+@JsonPropertyOrder({"age", "name"})
+@JsonTypeName("bob")
+class Person extends Base {
+    private final int age;
+
+    Person(int age) {
+        this.age = age;
+    }
+
+    @Override
+    public String getName() {
+        return "bob";
+    }
+
+    public int getAge() {
+        return age;
+    }
+}
+''', true)
+            def jsonMapper = compiled.getBean(JsonMapper)
+            def baseClass = compiled.classLoader.loadClass('example.Base')
+
+        when:
+            def person = newInstance(compiled, 'example.Person', 41)
+            String json = serializeToString(jsonMapper, person)
+
+        then:
+            JSONAssert.assertEquals('{"name":"bob","age":41}', json, JSONCompareMode.NON_EXTENSIBLE)
+
+        when:
+            def result = deserializeFromString(jsonMapper, baseClass, '{"age":19,"name":"bob"}')
+
+        then:
+            result.class.name == 'example.Person'
+            result.age == 19
+
+        cleanup:
+            compiled.close()
+    }
+
+    def 'test multiple @JsonTypeId properties fail'() {
+        given:
+            def compiled = buildContext('example.MultipleIds', '''
+package example;
+
+import com.fasterxml.jackson.annotation.*;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+@Introspected(accessKind = Introspected.AccessKind.FIELD)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+class MultipleIds {
+    @JsonTypeId
+    public String type1 = "type1";
+
+    @JsonTypeId
+    public String type2 = "type2";
+}
+''', true)
+            def jsonMapper = compiled.getBean(JsonMapper)
+            def bean = newInstance(compiled, 'example.MultipleIds')
+
+        when:
+            serializeToString(jsonMapper, bean)
+
+        then:
+            def e = thrown(Exception)
+            e.message.contains('Multiple type ids')
+
+        cleanup:
+            compiled.close()
+    }
+
     def 'test JsonTypeInfo with record deduction with some name'() {
         given:
             def compiled = buildContext('example.ReadResourceResult', '''

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/SerdeAnnotationVisitor.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/SerdeAnnotationVisitor.java
@@ -1544,7 +1544,6 @@ public class SerdeAnnotationVisitor implements TypeElementVisitor<SerdeConfig, S
                         "com.fasterxml.jackson.annotation.JsonTypeInfo",
                         "com.fasterxml.jackson.annotation.JsonRootName",
                         "com.fasterxml.jackson.annotation.JsonTypeName",
-                        "com.fasterxml.jackson.annotation.JsonTypeId",
                         "com.fasterxml.jackson.annotation.JsonAutoDetect",
                         "com.fasterxml.jackson.annotation.JsonIgnoreProperties",
                         "com.fasterxml.jackson.annotation.JsonIncludeProperties"

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/jackson/JsonTypeIdMapper.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/jackson/JsonTypeIdMapper.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.processor.jackson;
+
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.inject.visitor.VisitorContext;
+import io.micronaut.serde.config.annotation.SerdeConfig;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+
+/**
+ * Support for Jackson's JsonTypeId.
+ */
+public class JsonTypeIdMapper extends ValidatingAnnotationMapper {
+    @Override
+    protected List<AnnotationValue<?>> mapValid(AnnotationValue<Annotation> annotation, VisitorContext visitorContext) {
+        return List.of(AnnotationValue.builder(SerdeConfig.SerTypeId.class).build());
+    }
+
+    @Override
+    public String getName() {
+        return "com.fasterxml.jackson.annotation.JsonTypeId";
+    }
+}

--- a/serde-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
+++ b/serde-processor/src/main/resources/META-INF/services/io.micronaut.inject.annotation.AnnotationMapper
@@ -22,6 +22,7 @@ io.micronaut.serde.processor.jackson.JsonPropertyOrderMapper
 io.micronaut.serde.processor.jackson.JsonEnumDefaultValueMapper
 io.micronaut.serde.processor.jackson.JsonKeyMapper
 io.micronaut.serde.processor.jackson.JsonValueMapper
+io.micronaut.serde.processor.jackson.JsonTypeIdMapper
 io.micronaut.serde.processor.jackson.JsonTypeInfoMapper
 io.micronaut.serde.processor.jackson.JsonSetterMapper
 io.micronaut.serde.processor.jackson.JsonAnyGetterMapper

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/DynamicWrappedArraySerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/DynamicWrappedArraySerializer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serializers;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.Serializer;
+import io.micronaut.serde.support.serializers.SerBean.SerProperty;
+
+import java.io.IOException;
+
+/**
+ * A wrapped array serializer that resolves the wrapper value from the serialized value.
+ *
+ * @param <T> The type
+ */
+@Internal
+final class DynamicWrappedArraySerializer<T> implements Serializer<T> {
+
+    private final Serializer<T> serializer;
+    private final SerProperty<T, Object> wrapperProperty;
+
+    DynamicWrappedArraySerializer(Serializer<T> serializer, SerProperty<T, Object> wrapperProperty) {
+        this.serializer = serializer;
+        this.wrapperProperty = wrapperProperty;
+    }
+
+    @Override
+    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends T> type, T value) throws IOException {
+        try (Encoder wrapperEncoder = encoder.encodeArray(Argument.OBJECT_ARGUMENT)) {
+            wrapperEncoder.encodeString(wrapperProperty.getRequiredString(value));
+            serializer.serialize(wrapperEncoder, context, type, value);
+        }
+    }
+
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/DynamicWrappedObjectSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/DynamicWrappedObjectSerializer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.support.serializers;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.Keys;
+import io.micronaut.serde.KeysAwareEncoder;
+import io.micronaut.serde.ObjectSerializer;
+import io.micronaut.serde.Serializer;
+import io.micronaut.serde.support.serializers.SerBean.SerProperty;
+
+import java.io.IOException;
+
+/**
+ * A wrapped object serializer that resolves the wrapper key from the value.
+ *
+ * @param <T> The type
+ */
+@Internal
+final class DynamicWrappedObjectSerializer<T> implements ObjectSerializer<T> {
+
+    private final Serializer<T> serializer;
+    private final SerProperty<T, Object> wrapperProperty;
+
+    DynamicWrappedObjectSerializer(Serializer<T> serializer, SerProperty<T, Object> wrapperProperty) {
+        this.serializer = serializer;
+        this.wrapperProperty = wrapperProperty;
+    }
+
+    @Override
+    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends T> type, T value) throws IOException {
+        try (KeysAwareEncoder wrapperEncoder = KeysAwareEncoder.of(encoder.encodeObject(Argument.OBJECT_ARGUMENT))) {
+            wrapperEncoder.encodeKey(Keys.create(wrapperProperty.getRequiredString(value)), 0);
+            serializer.serialize(wrapperEncoder, context, type, value);
+        }
+    }
+
+    @Override
+    public void serializeInto(Encoder encoder, EncoderContext context, Argument<? extends T> type, T value) throws IOException {
+        KeysAwareEncoder keysAwareEncoder = KeysAwareEncoder.of(encoder);
+        keysAwareEncoder.encodeKey(Keys.create(wrapperProperty.getRequiredString(value)), 0);
+        serializer.serialize(keysAwareEncoder, context, type, value);
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/DynamicWrappedObjectSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/DynamicWrappedObjectSerializer.java
@@ -18,8 +18,6 @@ package io.micronaut.serde.support.serializers;
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.serde.Encoder;
-import io.micronaut.serde.Keys;
-import io.micronaut.serde.KeysAwareEncoder;
 import io.micronaut.serde.ObjectSerializer;
 import io.micronaut.serde.Serializer;
 import io.micronaut.serde.support.serializers.SerBean.SerProperty;
@@ -44,16 +42,15 @@ final class DynamicWrappedObjectSerializer<T> implements ObjectSerializer<T> {
 
     @Override
     public void serialize(Encoder encoder, EncoderContext context, Argument<? extends T> type, T value) throws IOException {
-        try (KeysAwareEncoder wrapperEncoder = KeysAwareEncoder.of(encoder.encodeObject(Argument.OBJECT_ARGUMENT))) {
-            wrapperEncoder.encodeKey(Keys.create(wrapperProperty.getRequiredString(value)), 0);
+        try (Encoder wrapperEncoder = encoder.encodeObject(Argument.OBJECT_ARGUMENT)) {
+            wrapperEncoder.encodeKey(wrapperProperty.getRequiredString(value));
             serializer.serialize(wrapperEncoder, context, type, value);
         }
     }
 
     @Override
     public void serializeInto(Encoder encoder, EncoderContext context, Argument<? extends T> type, T value) throws IOException {
-        KeysAwareEncoder keysAwareEncoder = KeysAwareEncoder.of(encoder);
-        keysAwareEncoder.encodeKey(Keys.create(wrapperProperty.getRequiredString(value)), 0);
-        serializer.serialize(keysAwareEncoder, context, type, value);
+        encoder.encodeKey(wrapperProperty.getRequiredString(value));
+        serializer.serialize(encoder, context, type, value);
     }
 }

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/ObjectSerializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/ObjectSerializer.java
@@ -18,7 +18,6 @@ package io.micronaut.serde.support.serializers;
 import io.micronaut.context.BeanContext;
 import io.micronaut.core.annotation.AnnotationMetadata;
 import io.micronaut.core.annotation.Internal;
-import org.jspecify.annotations.Nullable;
 import io.micronaut.core.beans.exceptions.IntrospectionException;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.type.GenericPlaceholder;
@@ -32,6 +31,7 @@ import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.support.util.SerdeArgumentConf;
 import io.micronaut.serde.support.util.SubtypeInfo;
 import io.micronaut.serde.util.CustomizableSerializer;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -122,7 +122,11 @@ public final class ObjectSerializer implements CustomizableSerializer<Object> {
         if (subtyped) {
             serializer = new RuntimeTypeSerializer(encoderContext, serializer, type);
         } else if (!jsonKeySerialization) {
-            if (serBean.wrapperProperty != null) {
+            if (serBean.dynamicWrapperProperty != null) {
+                serializer = new DynamicWrappedObjectSerializer<>(serializer, serBean.dynamicWrapperProperty);
+            } else if (serBean.dynamicArrayWrapperProperty != null) {
+                serializer = new DynamicWrappedArraySerializer<>(serializer, serBean.dynamicArrayWrapperProperty);
+            } else if (serBean.wrapperProperty != null) {
                 serializer = new WrappedObjectSerializer<>(serializer, serBean.wrapperProperty);
             } else if (serBean.arrayWrapperProperty != null) {
                 serializer = new WrappedArraySerializer<>(serializer, serBean.arrayWrapperProperty);

--- a/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBean.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serializers/SerBean.java
@@ -66,6 +66,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -98,6 +99,12 @@ final class SerBean<T> {
     public final String wrapperProperty;
     @Nullable
     public final String arrayWrapperProperty;
+    @Nullable
+    public final SerProperty<T, Object> typeIdProperty;
+    @Nullable
+    public final SerProperty<T, Object> dynamicWrapperProperty;
+    @Nullable
+    public final SerProperty<T, Object> dynamicArrayWrapperProperty;
     @Nullable
     public SerProperty<T, Object> jsonValue;
     @Nullable
@@ -150,6 +157,8 @@ final class SerBean<T> {
                     ));
                 })
                 .toList();
+        SerProperty<T, Object> resolvedTypeIdProperty = findTypeIdProperty(this, properties);
+        this.typeIdProperty = resolvedTypeIdProperty;
         final Map.Entry<BeanReadProperty<T, Object>, AnnotationMetadata> serPropEntry = properties.stream()
                 .filter(bp -> bp.getValue().hasAnnotation(SerdeConfig.SerValue.class) || bp.getValue().hasAnnotation(JACKSON_VALUE))
                 .findFirst().orElse(null);
@@ -157,6 +166,8 @@ final class SerBean<T> {
         if (serPropEntry != null) {
             wrapperProperty = null;
             arrayWrapperProperty = null;
+            dynamicWrapperProperty = null;
+            dynamicArrayWrapperProperty = null;
             BeanReadProperty<T, Object> beanProperty = serPropEntry.getKey();
             final Argument<Object> serType = beanProperty.asArgument();
             AnnotationMetadata propertyAnnotationMetadata = withoutJsonKey(serPropEntry.getValue());
@@ -179,6 +190,8 @@ final class SerBean<T> {
             if (serMethod != null) {
                 wrapperProperty = null;
                 arrayWrapperProperty = null;
+                dynamicWrapperProperty = null;
+                dynamicArrayWrapperProperty = null;
                 SerProperty<T, Object> resolvedJsonValue = new MethodSerProperty<>(
                     SerBean.this,
                     serMethod.getName(),
@@ -200,11 +213,23 @@ final class SerBean<T> {
                     resolvedSubtypeInfo,
                     introspections,
                     introspection,
-                    resolvedInitializers
+                    resolvedInitializers,
+                    resolvedTypeIdProperty
                 );
 
                 String arrayWrapperProperty = introspection.stringValue(SerdeConfig.class, SerdeConfig.ARRAY_WRAPPER_PROPERTY).orElse(null);
                 String wrapperProperty = introspection.stringValue(SerdeConfig.class, SerdeConfig.WRAPPER_PROPERTY).orElse(null);
+                SerProperty<T, Object> dynamicWrapperProperty = null;
+                SerProperty<T, Object> dynamicArrayWrapperProperty = null;
+                if (resolvedTypeIdProperty != null) {
+                    if (wrapperProperty != null) {
+                        wrapperProperty = null;
+                        dynamicWrapperProperty = resolvedTypeIdProperty;
+                    } else if (arrayWrapperProperty != null) {
+                        arrayWrapperProperty = null;
+                        dynamicArrayWrapperProperty = resolvedTypeIdProperty;
+                    }
+                }
                 if (subtypeInfo != null) {
                     String[] names = introspection.getAnnotationMetadata().stringValues(SerdeConfig.class, SerdeConfig.TYPE_NAMES);
                     if (names.length == 0) {
@@ -215,15 +240,31 @@ final class SerBean<T> {
                     }
                     if (names != null && names.length > 0) {
                         if (subtypeInfo.discriminatorType() == SerdeConfig.SerSubtyped.DiscriminatorType.WRAPPER_OBJECT) {
-                            wrapperProperty = names[0];
+                            if (resolvedTypeIdProperty != null) {
+                                dynamicWrapperProperty = resolvedTypeIdProperty;
+                            } else {
+                                wrapperProperty = names[0];
+                            }
                         } else if (subtypeInfo.discriminatorType() == SerdeConfig.SerSubtyped.DiscriminatorType.WRAPPER_ARRAY) {
-                            arrayWrapperProperty = names[0];
+                            if (resolvedTypeIdProperty != null) {
+                                dynamicArrayWrapperProperty = resolvedTypeIdProperty;
+                            } else {
+                                arrayWrapperProperty = names[0];
+                            }
+                        }
+                    } else if (resolvedTypeIdProperty != null) {
+                        if (subtypeInfo.discriminatorType() == SerdeConfig.SerSubtyped.DiscriminatorType.WRAPPER_OBJECT) {
+                            dynamicWrapperProperty = resolvedTypeIdProperty;
+                        } else if (subtypeInfo.discriminatorType() == SerdeConfig.SerSubtyped.DiscriminatorType.WRAPPER_ARRAY) {
+                            dynamicArrayWrapperProperty = resolvedTypeIdProperty;
                         }
                     }
                 }
 
                 this.wrapperProperty = wrapperProperty;
                 this.arrayWrapperProperty = arrayWrapperProperty;
+                this.dynamicWrapperProperty = dynamicWrapperProperty;
+                this.dynamicArrayWrapperProperty = dynamicArrayWrapperProperty;
             }
         }
         sortPropertiesIfNeeded(serdeArgumentConf, introspection.getAnnotationMetadata(), serializationConfiguration, writeProperties);
@@ -289,6 +330,67 @@ final class SerBean<T> {
         return mutableAnnotationMetadata;
     }
 
+    @Nullable
+    private static <T> SerProperty<T, Object> findTypeIdProperty(SerBean<T> serBean,
+                                                                 Collection<Map.Entry<BeanReadProperty<T, Object>, AnnotationMetadata>> properties) throws SerdeException {
+        SerProperty<T, Object> typeIdProperty = null;
+        for (Map.Entry<BeanReadProperty<T, Object>, AnnotationMetadata> prop : properties) {
+            if (prop.getValue().hasAnnotation(SerdeConfig.SerTypeId.class)) {
+                if (typeIdProperty != null) {
+                    throw new SerdeException("Multiple type ids defined for type [" + serBean.introspection.getBeanType().getName() + "]");
+                }
+                BeanReadProperty<T, Object> property = prop.getKey();
+                typeIdProperty = new PropSerProperty<>(
+                    serBean,
+                    property.getName(),
+                    property.getName(),
+                    property.asArgument(),
+                    prop.getValue(),
+                    property
+                );
+            }
+        }
+        return typeIdProperty;
+    }
+
+    private static <T> boolean isTypeIdPropertyUsed(@Nullable SerProperty<T, Object> typeIdProperty,
+                                                    @Nullable SubtypeInfo subtypeInfo,
+                                                    List<PropertySubtypeDescriptor> propertySubtypeDescriptors,
+                                                    BeanIntrospection<T> introspection) {
+        if (typeIdProperty == null) {
+            return false;
+        }
+        if (!propertySubtypeDescriptors.isEmpty()) {
+            return true;
+        }
+        if (subtypeInfo != null) {
+            return subtypeInfo.discriminatorType() == SerdeConfig.SerSubtyped.DiscriminatorType.WRAPPER_OBJECT
+                || subtypeInfo.discriminatorType() == SerdeConfig.SerSubtyped.DiscriminatorType.WRAPPER_ARRAY
+                || subtypeInfo.discriminatorType() == SerdeConfig.SerSubtyped.DiscriminatorType.EXTERNAL_PROPERTY;
+        }
+        return introspection.stringValue(SerdeConfig.class, SerdeConfig.WRAPPER_PROPERTY).isPresent()
+            || introspection.stringValue(SerdeConfig.class, SerdeConfig.ARRAY_WRAPPER_PROPERTY).isPresent();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <B, P> UnsafeBeanReadProperty<B, P> optimizedReadProperty(BeanReadProperty<B, P> beanProperty) {
+        UnsafeBeanReadProperty<B, P> unsafeBeanProperty = (UnsafeBeanReadProperty<B, P>) beanProperty;
+        for (BeanProperty<B, Object> property : beanProperty.getDeclaringBean().getBeanProperties()) {
+            if (!property.isWriteOnly()
+                && property instanceof UnsafeBeanReadProperty
+                && property.getName().equals(beanProperty.getName())
+                && property.getType().equals(beanProperty.getType())) {
+                return (UnsafeBeanReadProperty<B, P>) property;
+            }
+        }
+        return unsafeBeanProperty;
+    }
+
+    private static boolean isSameProperty(BeanReadProperty<?, Object> property, SerProperty<?, Object> typeIdProperty) {
+        return property.getName().equals(typeIdProperty.originalName)
+            && property.getType().equals(typeIdProperty.argument.getType());
+    }
+
     private static <T> void sortPropertiesIfNeeded(@Nullable SerdeArgumentConf serdeArgumentConf,
                                                    AnnotationMetadata annotationMetadata,
                                                    SerializationConfiguration serializationConfiguration,
@@ -327,7 +429,7 @@ final class SerBean<T> {
     }
 
     private static boolean isInjectedSubtypeProperty(SerProperty<?, Object> property) {
-        return property instanceof CustomSerProperty<?, ?> || property instanceof InjectedSerProperty<?, ?>;
+        return property instanceof CustomSerProperty<?, ?> || property instanceof InjectedSerProperty<?, ?> || property instanceof TypeIdSerProperty<?, ?>;
     }
 
     private static int propertyOrderIndex(String[] explicitOrder,
@@ -376,7 +478,8 @@ final class SerBean<T> {
                                                                                @Nullable SubtypeInfo subtypeInfo,
                                                                                SerdeIntrospections introspections,
                                                                                BeanIntrospection<T> introspection,
-                                                                               List<Initializer> initializers) throws SerdeException {
+                                                                               List<Initializer> initializers,
+                                                                               @Nullable SerProperty<T, Object> typeIdProperty) throws SerdeException {
 
         final List<BeanMethod<T, Object>> jsonGetters = new ArrayList<>(introspection.getBeanMethods().size());
         for (BeanMethod<T, Object> beanMethod : introspection.getBeanMethods()) {
@@ -387,6 +490,7 @@ final class SerBean<T> {
         }
 
         List<PropertySubtypeDescriptor> propertySubtypeDescriptors = findDescriptors(subtypeInfo, type, introspection);
+        boolean typeIdPropertyUsed = isTypeIdPropertyUsed(typeIdProperty, subtypeInfo, propertySubtypeDescriptors, introspection);
 
         if (properties.isEmpty() && jsonGetters.isEmpty() && propertySubtypeDescriptors.isEmpty()) {
             return List.of();
@@ -399,17 +503,25 @@ final class SerBean<T> {
         final @Nullable PropertyNamingStrategy entityPropertyNamingStrategy = getPropertyNamingStrategy(introspection, encoderContext, defaultPropertyNamingStrategy);
         final List<SerProperty<T, Object>> writeProperties = new ArrayList<>(properties.size() + jsonGetters.size());
         for (PropertySubtypeDescriptor propertySubtypeDescriptor : propertySubtypeDescriptors) {
-            addSubtypeProperty(serBean, serdeArgumentConf, introspection, initializers, writeProperties, propertySubtypeDescriptor);
+            if (typeIdProperty == null) {
+                addSubtypeProperty(serBean, serdeArgumentConf, introspection, initializers, writeProperties, propertySubtypeDescriptor);
+            } else {
+                addTypeIdProperty(serBean, serdeArgumentConf, introspection, initializers, writeProperties, propertySubtypeDescriptor.propertyName(), typeIdProperty);
+            }
         }
         final Set<String> addedProperties = CollectionUtils.newHashSet(properties.size());
         for (Map.Entry<BeanReadProperty<T, Object>, AnnotationMetadata> propWithAnnotations : properties) {
             final BeanReadProperty<T, Object> property = propWithAnnotations.getKey();
+            if (typeIdPropertyUsed && typeIdProperty != null && isSameProperty(property, typeIdProperty)) {
+                continue;
+            }
             final Argument<Object> argument = property.asArgument();
             final AnnotationMetadata propertyAnnotationMetadata = propWithAnnotations.getValue();
             PropertyNamingStrategy propertyNamingStrategy = getPropertyNamingStrategy(property.getAnnotationMetadata(), encoderContext, entityPropertyNamingStrategy);
 
             SubtypeInfo propSubtypeInfo = SubtypeInfo.createForProperty(propertyAnnotationMetadata);
             if (propSubtypeInfo != null && propSubtypeInfo.discriminatorType() == SerdeConfig.SerSubtyped.DiscriminatorType.EXTERNAL_PROPERTY) {
+                Map<Class<?>, Optional<BeanReadProperty<Object, Object>>> typeIdProperties = new ConcurrentHashMap<>();
                 final CustomSerProperty<T, String> subtypeDiscriminatorProperty = new CustomSerProperty<>(
                     serBean,
                     propSubtypeInfo.discriminatorName(),
@@ -418,6 +530,10 @@ final class SerBean<T> {
                         Object subtypeValue = property.get(bean);
                         if (subtypeValue == null) {
                             return null;
+                        }
+                        String typeId = findExternalTypeId(introspections, typeIdProperties, subtypeValue);
+                        if (typeId != null) {
+                            return typeId;
                         }
                         String[] names = propSubtypeInfo.subtypes().get(subtypeValue.getClass());
                         if (names == null) {
@@ -507,6 +623,68 @@ final class SerBean<T> {
             initializers.add(ctx -> initProperty(prop, ctx, serdeArgumentConf));
         }
         return writeProperties;
+    }
+
+    @Nullable
+    private static String findExternalTypeId(SerdeIntrospections introspections,
+                                             Map<Class<?>, Optional<BeanReadProperty<Object, Object>>> typeIdProperties,
+                                             Object subtypeValue) {
+        Optional<BeanReadProperty<Object, Object>> typeIdProperty = typeIdProperties.computeIfAbsent(
+            subtypeValue.getClass(),
+            subtypeClass -> findExternalTypeIdProperty(introspections, subtypeClass)
+        );
+        if (typeIdProperty.isEmpty()) {
+            return null;
+        }
+        Object typeIdValue = typeIdProperty.get().get(subtypeValue);
+        if (typeIdValue == null) {
+            throw new IllegalStateException("Property [" + typeIdProperty.get().getName() + "] of type ["
+                + subtypeValue.getClass().getName() + "] returned null");
+        }
+        return typeIdValue.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Optional<BeanReadProperty<Object, Object>> findExternalTypeIdProperty(SerdeIntrospections introspections, Class<?> subtypeClass) {
+        try {
+            BeanIntrospection<Object> subtypeIntrospection = introspections.getSerializableIntrospection(
+                Argument.of((Class<Object>) subtypeClass)
+            );
+            BeanReadProperty<Object, Object> typeIdProperty = null;
+            for (BeanReadProperty<Object, Object> property : subtypeIntrospection.getBeanReadProperties()) {
+                if (property.getAnnotationMetadata().hasAnnotation(SerdeConfig.SerTypeId.class)) {
+                    if (typeIdProperty != null) {
+                        throw new IllegalStateException("Multiple type ids defined for type [" + subtypeClass.getName() + "]");
+                    }
+                    typeIdProperty = property;
+                }
+            }
+            return Optional.ofNullable(typeIdProperty);
+        } catch (IntrospectionException e) {
+            return Optional.empty();
+        }
+    }
+
+    private static <T> void addTypeIdProperty(SerBean<T> serBean,
+                                              @Nullable SerdeArgumentConf serdeArgumentConf,
+                                              BeanIntrospection<T> introspection,
+                                              List<Initializer> initializers,
+                                              List<SerProperty<T, Object>> writeProperties,
+                                              String propertyName,
+                                              SerProperty<T, Object> typeIdProperty) {
+        SerProperty<T, Object> prop = new TypeIdSerProperty<>(
+            serBean,
+            propertyName,
+            typeIdProperty
+        );
+        writeProperties.add(prop);
+        initializers.add(context -> {
+            try {
+                initProperty(prop, context, serdeArgumentConf);
+            } catch (SerdeException e) {
+                throw new IntrospectionException("Error configuring subtype binding for type " + introspection.getBeanType() + ": " + e.getMessage());
+            }
+        });
     }
 
     private static <T> void addSubtypeProperty(SerBean<T> serBean,
@@ -655,7 +833,7 @@ final class SerBean<T> {
     }
 
     private boolean isSimpleBean() {
-        if (propertyFilter != null || jsonValue != null) {
+        if (propertyFilter != null || jsonValue != null || dynamicWrapperProperty != null || dynamicArrayWrapperProperty != null) {
             return false;
         }
         for (SerProperty<T, Object> property : writeProperties) {
@@ -742,19 +920,25 @@ final class SerBean<T> {
         public Class<?> getDeclaringType() {
             return beanProperty.getDeclaringType();
         }
+    }
 
-        @SuppressWarnings("unchecked")
-        private static <B, P> UnsafeBeanReadProperty<B, P> optimizedReadProperty(BeanReadProperty<B, P> beanProperty) {
-            UnsafeBeanReadProperty<B, P> unsafeBeanProperty = (UnsafeBeanReadProperty<B, P>) beanProperty;
-            for (BeanProperty<B, Object> property : beanProperty.getDeclaringBean().getBeanProperties()) {
-                if (!property.isWriteOnly()
-                    && property instanceof UnsafeBeanReadProperty
-                    && property.getName().equals(beanProperty.getName())
-                    && property.getType().equals(beanProperty.getType())) {
-                    return (UnsafeBeanReadProperty<B, P>) property;
-                }
-            }
-            return unsafeBeanProperty;
+    static final class TypeIdSerProperty<B, P> extends SerProperty<B, P> {
+
+        private final SerProperty<B, P> typeIdProperty;
+
+        public TypeIdSerProperty(SerBean<B> bean, String name, SerProperty<B, P> typeIdProperty) {
+            super(bean, name, typeIdProperty.originalName, typeIdProperty.argument);
+            this.typeIdProperty = typeIdProperty;
+        }
+
+        @Override
+        public @Nullable P get(B bean) {
+            return typeIdProperty.get(bean);
+        }
+
+        @Override
+        public Class<?> getDeclaringType() {
+            return typeIdProperty.getDeclaringType();
         }
     }
 
@@ -884,6 +1068,14 @@ final class SerBean<T> {
         }
 
         public abstract @Nullable P get(B bean);
+
+        String getRequiredString(B bean) throws SerdeException {
+            P value = get(bean);
+            if (value == null) {
+                throw new SerdeException("Property [" + originalName + "] of type [" + getDeclaringType().getName() + "] returned null");
+            }
+            return value.toString();
+        }
     }
 
     private interface Initializer {

--- a/src/main/docs/guide/jacksonAnnotations.adoc
+++ b/src/main/docs/guide/jacksonAnnotations.adoc
@@ -124,7 +124,7 @@ NOTE: If an unsupported annotation or member is used, a compilation error will r
 |
 
 |link:{jacksonAnnotationJavadoc}/JsonTypeId.html[@JsonTypeId]
-|❌
+|✅
 |
 
 |link:{jacksonAnnotationJavadoc}/JsonTypeInfo.html[@JsonTypeInfo]


### PR DESCRIPTION
Map JsonTypeId to an internal SerTypeId marker and use it for property, wrapper, and external type id serialization. Add dynamic wrapper serializers plus coverage for getter, external-property, abstract-base, and duplicate marker scenarios.