### PR TITLE
fix(serde): allow leaf @BsonDiscriminator types under strict subtypes default

### DIFF
--- a/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonLeafDiscriminatorSpec.groovy
+++ b/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonLeafDiscriminatorSpec.groovy
@@ -1,0 +1,95 @@
+package io.micronaut.serde.bson
+
+import io.micronaut.core.type.Argument
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+import java.nio.charset.StandardCharsets
+
+/**
+ * Reproduces / guards micronaut-projects/micronaut-core#12853:
+ * leaf classes that carry {@code @BsonDiscriminator} (required by the MongoDB POJO
+ * convention so the base can discover them) must still deserialize when the
+ * document is correct under the MN5 default
+ * {@code micronaut.serde.deserialization.subtypes-require-default-impl=true}.
+ *
+ * Unlike {@link BsonMappingSpec}, this suite deliberately does <strong>not</strong>
+ * relax that property — a global bypass is not an acceptable fix.
+ */
+@MicronautTest
+class BsonLeafDiscriminatorSpec extends Specification implements BsonJsonSpec, BsonBinarySpec {
+
+    @Inject
+    BsonBinaryMapper bsonBinaryMapper
+
+    @Inject
+    BsonJsonMapper bsonJsonMapper
+
+    def "leaf @BsonDiscriminator hierarchy round-trips under strict subtypes default"() {
+        given:
+        def privateState = new PrivateRoomState(label: "kickoff", ownerId: "user-42")
+        def publicState = new PublicRoomState(label: "open", inviteCode: "abc")
+        def privateRoom = new Room(name: "demo-private", activeState: privateState)
+        def publicRoom = new Room(name: "demo-public", activeState: publicState)
+
+        when:
+        def privateBytes = bsonBinaryMapper.writeValueAsBytes(privateRoom)
+        def publicBytes = bsonBinaryMapper.writeValueAsBytes(publicRoom)
+        def rereadPrivate = bsonBinaryMapper.readValue(privateBytes, Argument.of(Room))
+        def rereadPublic = bsonBinaryMapper.readValue(publicBytes, Argument.of(Room))
+
+        then:
+        rereadPrivate.name == "demo-private"
+        rereadPrivate.activeState instanceof PrivateRoomState
+        (rereadPrivate.activeState as PrivateRoomState).ownerId == "user-42"
+        rereadPrivate.activeState.label == "kickoff"
+
+        rereadPublic.name == "demo-public"
+        rereadPublic.activeState instanceof PublicRoomState
+        (rereadPublic.activeState as PublicRoomState).inviteCode == "abc"
+        rereadPublic.activeState.label == "open"
+    }
+
+    def "leaf @BsonDiscriminator hierarchy deserializes from bson-json under strict subtypes default"() {
+        given:
+        def privateJson = '''{"name":"demo-private","activeState":{"_t":"private_room_state","label":"kickoff","ownerId":"user-42"}}'''
+        def publicJson = '''{"name":"demo-public","activeState":{"_t":"public_room_state","label":"open","inviteCode":"abc"}}'''
+
+        when:
+        def rereadPrivate = bsonJsonMapper.readValue(privateJson.getBytes(StandardCharsets.UTF_8), Argument.of(Room))
+        def rereadPublic = bsonJsonMapper.readValue(publicJson.getBytes(StandardCharsets.UTF_8), Argument.of(Room))
+
+        then:
+        rereadPrivate.activeState instanceof PrivateRoomState
+        (rereadPrivate.activeState as PrivateRoomState).ownerId == "user-42"
+        rereadPublic.activeState instanceof PublicRoomState
+        (rereadPublic.activeState as PublicRoomState).inviteCode == "abc"
+    }
+
+    def "reading leaf subtype directly still works under strict subtypes default"() {
+        given:
+        def state = new PrivateRoomState(label: "solo", ownerId: "user-7")
+
+        when:
+        def bytes = bsonBinaryMapper.writeValueAsBytes(state)
+        def reread = bsonBinaryMapper.readValue(bytes, Argument.of(PrivateRoomState))
+
+        then:
+        reread instanceof PrivateRoomState
+        reread.ownerId == "user-7"
+        reread.label == "solo"
+    }
+
+    def "unknown discriminator on base type still fails under strict subtypes default"() {
+        given:
+        def json = '''{"name":"broken","activeState":{"_t":"does_not_exist","label":"x"}}'''
+
+        when:
+        bsonJsonMapper.readValue(json.getBytes(StandardCharsets.UTF_8), Argument.of(Room))
+
+        then:
+        def e = thrown(Exception)
+        e.message?.contains("Could not resolve subtype") || e.cause?.message?.contains("Could not resolve subtype")
+    }
+}

--- a/serde-bson/src/test/java/io/micronaut/serde/bson/PrivateRoomState.java
+++ b/serde-bson/src/test/java/io/micronaut/serde/bson/PrivateRoomState.java
@@ -1,0 +1,19 @@
+package io.micronaut.serde.bson;
+
+import io.micronaut.serde.annotation.Serdeable;
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
+
+@Serdeable
+@BsonDiscriminator("private_room_state")
+public class PrivateRoomState extends RoomState {
+
+    private String ownerId;
+
+    public String getOwnerId() {
+        return ownerId;
+    }
+
+    public void setOwnerId(String ownerId) {
+        this.ownerId = ownerId;
+    }
+}

--- a/serde-bson/src/test/java/io/micronaut/serde/bson/PublicRoomState.java
+++ b/serde-bson/src/test/java/io/micronaut/serde/bson/PublicRoomState.java
@@ -1,0 +1,19 @@
+package io.micronaut.serde.bson;
+
+import io.micronaut.serde.annotation.Serdeable;
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
+
+@Serdeable
+@BsonDiscriminator("public_room_state")
+public class PublicRoomState extends RoomState {
+
+    private String inviteCode;
+
+    public String getInviteCode() {
+        return inviteCode;
+    }
+
+    public void setInviteCode(String inviteCode) {
+        this.inviteCode = inviteCode;
+    }
+}

--- a/serde-bson/src/test/java/io/micronaut/serde/bson/Room.java
+++ b/serde-bson/src/test/java/io/micronaut/serde/bson/Room.java
@@ -1,0 +1,26 @@
+package io.micronaut.serde.bson;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public class Room {
+
+    private String name;
+    private RoomState activeState;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public RoomState getActiveState() {
+        return activeState;
+    }
+
+    public void setActiveState(RoomState activeState) {
+        this.activeState = activeState;
+    }
+}

--- a/serde-bson/src/test/java/io/micronaut/serde/bson/RoomState.java
+++ b/serde-bson/src/test/java/io/micronaut/serde/bson/RoomState.java
@@ -1,0 +1,23 @@
+package io.micronaut.serde.bson;
+
+import io.micronaut.serde.annotation.Serdeable;
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
+
+/**
+ * Polymorphic base matching the MongoDB POJO convention of placing
+ * {@link BsonDiscriminator} on the type and all of its subtypes.
+ */
+@Serdeable
+@BsonDiscriminator("room_state")
+public abstract class RoomState {
+
+    private String label;
+
+    public String getLabel() {
+        return label;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+}

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/ObjectDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/ObjectDeserializer.java
@@ -90,10 +90,28 @@ public class ObjectDeserializer implements CustomizableDeserializer<Object>, Des
         }
         DeserializationConfiguration deserializationConfiguration = context.getDeserializationConfiguration().orElse(this.deserializationConfiguration);
         DeserBean<? super Object> deserBean = getDeserializableBean(type, null, context);
-        if (deserBean.subtypeInfo != null) {
+        if (requiresSubtypeResolution(deserBean)) {
             return createSubtypeDeserializer(context, deserializationConfiguration, deserBean, type);
         }
         return findDeserializer(deserializationConfiguration, deserBean, false);
+    }
+
+    /**
+     * Whether the bean should go through polymorphic subtype resolution.
+     * <p>
+     * Types annotated with {@code @BsonDiscriminator} (and similar) are marked
+     * {@link SerdeConfig.SerSubtyped} even when they are leaf classes with no
+     * further subtypes. Re-running subtype resolution for those leaves fails under
+     * {@code micronaut.serde.deserialization.subtypes-require-default-impl=true}
+     * because the subtype map is empty and there is no {@code defaultImpl}. Skip
+     * resolution when there are neither registered subtypes nor a default type.
+     */
+    private static boolean requiresSubtypeResolution(DeserBean<?> deserBean) {
+        DeserBeanSubtypeInfo<?> subtypeInfo = deserBean.subtypeInfo;
+        if (subtypeInfo == null) {
+            return false;
+        }
+        return !subtypeInfo.subtypes().isEmpty() || subtypeInfo.defaultType() != null;
     }
 
     private Deserializer<Object> createSubtypeDeserializer(DecoderContext context,
@@ -115,9 +133,12 @@ public class ObjectDeserializer implements CustomizableDeserializer<Object>, Des
                 hasUnresolved = true;
                 continue;
             }
-            Deserializer<Object> subtypeDeserializer = subtypeDeserBean.subtypeInfo == null
-                ? findDeserializer(deserializationConfiguration, (DeserBean<? super Object>) subtypeDeserBean, disallowUnwrap)
-                : createSubtypeDeserializer(context, deserializationConfiguration, (DeserBean<? super Object>) subtypeDeserBean, (Argument<? super Object>) subtypeDef.type());
+            // Leaf subtypes may still carry SerSubtyped metadata (e.g. @BsonDiscriminator
+            // on every level as required by the MongoDB POJO docs) without registering any
+            // further children. Do not nest another subtype resolution pass for those.
+            Deserializer<Object> subtypeDeserializer = requiresSubtypeResolution(subtypeDeserBean)
+                ? createSubtypeDeserializer(context, deserializationConfiguration, (DeserBean<? super Object>) subtypeDeserBean, (Argument<? super Object>) subtypeDef.type())
+                : findDeserializer(deserializationConfiguration, (DeserBean<? super Object>) subtypeDeserBean, disallowUnwrap);
             subtypeDeserializers.put(
                 e.getKey(),
                 subtypeDeserializer
@@ -164,9 +185,9 @@ public class ObjectDeserializer implements CustomizableDeserializer<Object>, Des
                         argument = defaultType.type();
                     }
                     DeserBean<?> subtypeDeserBean = getDeserializableBean(argument, type.getTypeVariables(), context);
-                    return subtypeDeserBean.subtypeInfo == null
-                        ? ObjectDeserializer.this.findDeserializer(deserializationConfiguration, (DeserBean<Object>) subtypeDeserBean, disallowUnwrap)
-                        : createSubtypeDeserializer(context, deserializationConfiguration, (DeserBean<? super Object>) subtypeDeserBean, (Argument<? super Object>) argument);
+                    return requiresSubtypeResolution(subtypeDeserBean)
+                        ? createSubtypeDeserializer(context, deserializationConfiguration, (DeserBean<? super Object>) subtypeDeserBean, (Argument<? super Object>) argument)
+                        : ObjectDeserializer.this.findDeserializer(deserializationConfiguration, (DeserBean<Object>) subtypeDeserBean, disallowUnwrap);
                 }
             };
         }


### PR DESCRIPTION
## Description

Fixes [micronaut-projects/micronaut-core#12853](https://github.com/micronaut-projects/micronaut-core/issues/12853)

Polymorphic BSON hierarchies that follow the MongoDB POJO convention — `@BsonDiscriminator` on the abstract base **and** on each concrete leaf — failed to deserialize under Micronaut 5's default `micronaut.serde.deserialization.subtypes-require-default-impl=true`, even when the stored `_t` value was correct.

### Root cause

`BsonDiscriminatorTransformer` maps every `@BsonDiscriminator` to `SerdeConfig.SerSubtyped`, including leaf classes. After the base type correctly resolved the discriminator to a leaf, decoding that leaf ran a **second** subtype resolution pass. Leaves have an empty subtype map and no `defaultImpl`, so that second pass always threw:

```
Could not resolve subtype of […PrivateRoomState] missing type id property '_t'
```

Setting `subtypes-require-default-impl=false` avoided the crash globally, but also disabled legitimate unknown-discriminator failures — not a real fix.

### Fix

In `ObjectDeserializer`, only enter polymorphic subtype resolution when the bean has registered subtypes **or** a default type. Leaf types that are marked `SerSubtyped` solely because of `@BsonDiscriminator` (empty map, no default) are deserialized as concrete beans after the base resolution succeeds. Unknown discriminators on the base type still fail.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/micronaut-projects/micronaut-serialization/blob/master/CONTRIBUTING.md) document
- [x] I have added tests related to my changes
- [x] All new and existing tests passed locally
- [x] I have checked that my code does not require documentation updates (or I have added the required documentation)

### Verification

```
./gradlew :micronaut-serde-bson:test
./gradlew :micronaut-serde-jackson:test --tests 'io.micronaut.serde.jackson.annotation.SerdeJsonSubtypesSpec'
```

- `BsonLeafDiscriminatorSpec` 4/4 (strict default, no flag bypass)
- Full `:micronaut-serde-bson:test` 378/378
- `SerdeJsonSubtypesSpec` 10/10

JDK 25.