### PR TITLE
fix(serde): honor global serialization inclusion in generated serializers

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/util/GeneratedSerdeInclusionUtil.java
+++ b/serde-api/src/main/java/io/micronaut/serde/util/GeneratedSerdeInclusionUtil.java
@@ -112,13 +112,21 @@ public final class GeneratedSerdeInclusionUtil {
      * Default-value check for scalar wrappers encoded without a property serializer field.
      * Empty char sequences are treated as default (matches {@code NON_DEFAULT} vs {@code NON_EMPTY}
      * for strings); numeric zero / false / NUL match the corresponding number/boolean serdes.
+     * Only the boxed primitive-wrapper number types (Byte/Short/Integer/Long/Float/Double) treat
+     * zero as default, matching {@link io.micronaut.serde.support.serdes.NumberSerde} subtypes such
+     * as {@code IntegerSerde}/{@code LongSerde}. {@link java.math.BigInteger} and
+     * {@link java.math.BigDecimal} (and any other {@code Number}) don't override
+     * {@link Serializer#isDefault}, so their runtime-serializer default is {@code false} regardless
+     * of value; treating {@code BigInteger.ZERO}/{@code BigDecimal.ZERO} as default here would
+     * incorrectly omit them under {@code NON_DEFAULT} where the runtime path would not.
      */
     private static boolean isDefaultScalar(Object value) {
         if (value instanceof CharSequence charSequence) {
             return charSequence.isEmpty();
         }
-        if (value instanceof Number number) {
-            return number.doubleValue() == 0d;
+        if (value instanceof Byte || value instanceof Short || value instanceof Integer
+            || value instanceof Long || value instanceof Float || value instanceof Double) {
+            return ((Number) value).doubleValue() == 0d;
         }
         if (value instanceof Boolean bool) {
             return !bool;

--- a/serde-api/src/main/java/io/micronaut/serde/util/GeneratedSerdeInclusionUtil.java
+++ b/serde-api/src/main/java/io/micronaut/serde/util/GeneratedSerdeInclusionUtil.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.util;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.UsedByGeneratedCode;
+import io.micronaut.serde.Serializer;
+import io.micronaut.serde.config.SerializationConfiguration;
+import io.micronaut.serde.config.annotation.SerdeConfig;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Inclusion helpers used by generated serializers so global
+ * {@code micronaut.serde.serialization.inclusion} is honored without falling
+ * back to the runtime object serializer for every simple shape.
+ *
+ * @since 3.1.1
+ */
+@Internal
+@UsedByGeneratedCode
+public final class GeneratedSerdeInclusionUtil {
+
+    private GeneratedSerdeInclusionUtil() {
+    }
+
+    /**
+     * Whether a property value should be written using the active global inclusion strategy
+     * and the property serializer's empty/absent/default checks.
+     *
+     * @param context    The encoder context
+     * @param serializer The property serializer
+     * @param value      The property value
+     * @return {@code true} if the property should be serialized
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static boolean shouldSerialize(Serializer.EncoderContext context,
+                                          Serializer serializer,
+                                          @Nullable Object value) {
+        SerdeConfig.SerInclude include = resolveInclusion(context);
+        return switch (include) {
+            case ALWAYS, USE_DEFAULTS -> true;
+            case NON_NULL -> value != null;
+            case NON_ABSENT -> !serializer.isAbsent(context, value);
+            case NON_EMPTY -> !serializer.isEmpty(context, value);
+            case NON_DEFAULT -> !serializer.isEmpty(context, value)
+                && (value == null || !serializer.isDefault(context, value));
+            case NEVER -> false;
+        };
+    }
+
+    /**
+     * Whether a scalar reference property (encoded without a cached property serializer)
+     * should be written using the active global inclusion strategy.
+     *
+     * @param context The encoder context
+     * @param value   The property value
+     * @return {@code true} if the property should be serialized
+     */
+    public static boolean shouldSerializeScalar(Serializer.EncoderContext context,
+                                                @Nullable Object value) {
+        SerdeConfig.SerInclude include = resolveInclusion(context);
+        return switch (include) {
+            case ALWAYS, USE_DEFAULTS -> true;
+            case NEVER -> false;
+            case NON_NULL, NON_ABSENT -> value != null;
+            case NON_EMPTY -> value != null && !isEmptyCharSequence(value);
+            case NON_DEFAULT -> value != null && !isDefaultScalar(value);
+        };
+    }
+
+    /**
+     * Whether a primitive property should be written using the active global inclusion strategy.
+     *
+     * @param context   The encoder context
+     * @param isDefault Whether the primitive value equals the Java language default for its type
+     * @return {@code true} if the property should be serialized
+     */
+    public static boolean shouldSerializePrimitive(Serializer.EncoderContext context,
+                                                   boolean isDefault) {
+        SerdeConfig.SerInclude include = resolveInclusion(context);
+        return switch (include) {
+            case NEVER -> false;
+            case NON_DEFAULT -> !isDefault;
+            default -> true;
+        };
+    }
+
+    private static SerdeConfig.SerInclude resolveInclusion(Serializer.EncoderContext context) {
+        return context.getSerializationConfiguration()
+            .map(SerializationConfiguration::getInclusion)
+            .orElse(SerdeConfig.SerInclude.NON_EMPTY);
+    }
+
+    private static boolean isEmptyCharSequence(Object value) {
+        return value instanceof CharSequence charSequence && charSequence.isEmpty();
+    }
+
+    /**
+     * Default-value check for scalar wrappers encoded without a property serializer field.
+     * Empty char sequences are treated as default (matches {@code NON_DEFAULT} vs {@code NON_EMPTY}
+     * for strings); numeric zero / false / NUL match the corresponding number/boolean serdes.
+     */
+    private static boolean isDefaultScalar(Object value) {
+        if (value instanceof CharSequence charSequence) {
+            return charSequence.isEmpty();
+        }
+        if (value instanceof Number number) {
+            return number.doubleValue() == 0d;
+        }
+        if (value instanceof Boolean bool) {
+            return !bool;
+        }
+        if (value instanceof Character character) {
+            return character == '\0';
+        }
+        return false;
+    }
+}
+

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeJsonSerializeDeserializeSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeJsonSerializeDeserializeSpec.groovy
@@ -33,7 +33,7 @@ class RecursiveView {
         this.view = view;
     }
 }
-""")
+""", true, ['micronaut.serde.serialization.inclusion': 'ALWAYS'])
             def recursiveType = argumentOf(context, 'test.RecursiveView')
             def root = newInstance(context, 'test.RecursiveView', [id: 'root'])
             def child = newInstance(context, 'test.RecursiveView', [id: 'child'])
@@ -63,7 +63,7 @@ import io.micronaut.serde.annotation.Serdeable;
 @Serdeable
 public record RecursiveRecordView(String id, RecursiveRecordView view) {
 }
-""")
+""", true, ['micronaut.serde.serialization.inclusion': 'ALWAYS'])
             def recursiveType = argumentOf(context, 'test.RecursiveRecordView')
             def recursiveClass = recursiveType.type
             def constructor = recursiveClass.getDeclaredConstructor(String, recursiveClass)

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeSourceGenSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeSourceGenSpec.groovy
@@ -454,6 +454,39 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
         context.close()
     }
 
+    void 'test generated serializers honor global inclusion NON_DEFAULT for BigInteger and BigDecimal zero'() {
+        given:
+        def context = ApplicationContext.run([
+            'micronaut.serde.serialization.inclusion': 'NON_DEFAULT'
+        ])
+        jsonMapper = context.getBean(JsonMapper)
+        def registry = context.getBean(SerdeRegistry)
+        Argument beanArgument = Argument.of(SourceGenNonDefaultScalarBean)
+
+        when:
+        def zeroBean = new SourceGenNonDefaultScalarBean()
+        zeroBean.count = 0
+        zeroBean.bigCount = BigInteger.ZERO
+        zeroBean.bigAmount = BigDecimal.ZERO
+        String zeroJson = serializeToString(jsonMapper, zeroBean)
+        def nonZeroBean = new SourceGenNonDefaultScalarBean()
+        nonZeroBean.count = 1
+        nonZeroBean.bigCount = BigInteger.ONE
+        nonZeroBean.bigAmount = BigDecimal.ONE
+        String nonZeroJson = serializeToString(jsonMapper, nonZeroBean)
+
+        then:
+        assertGeneratedSerializer(registry, beanArgument)
+        // Integer/int zero is the language default and is omitted, but BigInteger/BigDecimal
+        // ZERO is not treated as a default value (matches CustomizedObjectSerializer, which
+        // relies on Serializer#isDefault, unset for BigInteger/BigDecimal).
+        validateJsonWithoutOrder(jsonMapper, '{"bigCount":0,"bigAmount":0}', zeroJson)
+        validateJsonWithoutOrder(jsonMapper, '{"count":1,"bigCount":1,"bigAmount":1}', nonZeroJson)
+
+        cleanup:
+        context.close()
+    }
+
     void 'test generated serializers honor default inclusion NON_EMPTY for null properties'() {
         given:
         def context = ApplicationContext.run()

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeSourceGenSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeSourceGenSpec.groovy
@@ -24,9 +24,18 @@ import tools.jackson.core.json.JsonFactory
 
 class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
+    /**
+     * Compile-time sourcegen tests that assert explicit {@code null} property output need
+     * {@code ALWAYS} inclusion. Production default is {@code NON_EMPTY}; generated serializers
+     * now honor that setting (see micronaut-core#12838).
+     */
+    private static ApplicationContext runWithAlwaysInclusion(Map extra = [:]) {
+        ApplicationContext.run(['micronaut.serde.serialization.inclusion': 'ALWAYS'] + extra)
+    }
+
     void 'test generated serializers use object encoder and generated classes use indexed fields'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         Class<?> beanType = SourceGenIndexedShapeBean.class
         Class<?> recordType = SourceGenIndexedShapeRecord.class
         def introspections = context.getBean(SerdeIntrospections)
@@ -92,7 +101,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated serializers and deserializers are selected for bean and record shapes'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
         Class<?> beanType = SourceGenIndexedShapeBean.class
@@ -132,7 +141,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated property serdes fall back for customised property metadata'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
         Argument payloadArgument = Argument.of(SourceGenPropertyAnnotationPayload)
@@ -158,7 +167,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated bean shape supports field properties'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
         Class<?> beanType = SourceGenFieldShapeBean.class
@@ -186,7 +195,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated default serializers are selected and functional'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
 
@@ -245,7 +254,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated field default serdes are selected and functional'() {
         given:
-        def context = ApplicationContext.run([
+        def context = runWithAlwaysInclusion([
             'micronaut.serde.deserialization.fail-on-null-for-primitives': false
         ])
         jsonMapper = context.getBean(JsonMapper)
@@ -331,7 +340,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated enum serializer object and formatted branches are functional'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
         Argument enumArgument = Argument.of(SourceGenFeatureEnum)
@@ -362,7 +371,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated enum deserializer reports unknown values'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
         Argument enumArgument = Argument.of(SourceGenFeatureEnum)
@@ -381,7 +390,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated serializers can be disabled with serialization feature'() {
         given:
-        def context = ApplicationContext.run([
+        def context = runWithAlwaysInclusion([
             'micronaut.serde.serialization.disable-generated-serializer': true
         ])
         jsonMapper = context.getBean(JsonMapper)
@@ -410,9 +419,64 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
         context.close()
     }
 
-    void 'test generated deserializers can be disabled with deserialization feature'() {
+    void 'test generated serializers honor global inclusion NON_NULL'() {
         given:
         def context = ApplicationContext.run([
+            'micronaut.serde.serialization.inclusion': 'NON_NULL'
+        ])
+        jsonMapper = context.getBean(JsonMapper)
+        def registry = context.getBean(SerdeRegistry)
+        Argument recordArgument = Argument.of(SourceGenIndexedShapeRecord)
+        Argument beanArgument = Argument.of(SourceGenIndexedShapeBean)
+
+        when:
+        def record = new SourceGenIndexedShapeRecord(null, null)
+        def bean = new SourceGenIndexedShapeBean()
+        bean.value = null
+        bean.tags = null
+        String recordJson = serializeToString(jsonMapper, record)
+        String beanJson = serializeToString(jsonMapper, bean)
+        String recordPresentJson = serializeToString(jsonMapper, new SourceGenIndexedShapeRecord('hi', ['x']))
+        def beanPresent = new SourceGenIndexedShapeBean()
+        beanPresent.value = 'hi'
+        beanPresent.tags = ['x']
+        String beanPresentJson = serializeToString(jsonMapper, beanPresent)
+
+        then:
+        assertGeneratedSerializer(registry, recordArgument)
+        assertGeneratedSerializer(registry, beanArgument)
+        recordJson == '{}'
+        beanJson == '{}'
+        validateJsonWithoutOrder(jsonMapper, '{"value":"hi","tags":["x"]}', recordPresentJson)
+        validateJsonWithoutOrder(jsonMapper, '{"value":"hi","tags":["x"]}', beanPresentJson)
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test generated serializers honor default inclusion NON_EMPTY for null properties'() {
+        given:
+        def context = ApplicationContext.run()
+        jsonMapper = context.getBean(JsonMapper)
+        def registry = context.getBean(SerdeRegistry)
+        Argument recordArgument = Argument.of(SourceGenIndexedShapeRecord)
+
+        when:
+        String nullJson = serializeToString(jsonMapper, new SourceGenIndexedShapeRecord(null, null))
+        String emptyJson = serializeToString(jsonMapper, new SourceGenIndexedShapeRecord('', []))
+
+        then:
+        assertGeneratedSerializer(registry, recordArgument)
+        nullJson == '{}'
+        emptyJson == '{}'
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test generated deserializers can be disabled with deserialization feature'() {
+        given:
+        def context = runWithAlwaysInclusion([
             'micronaut.serde.deserialization.disable-generated-deserializer': true
         ])
         jsonMapper = context.getBean(JsonMapper)
@@ -444,7 +508,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
     @SuppressWarnings('JsonDuplicatePropertyKeys')
     void 'test generated bean deserializer dispatch source for small boundary and large property sets'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
         def decoderContext = registry.newDecoderContext(Object)
@@ -530,7 +594,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated large bean serializer wraps property exceptions'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         def registry = context.getBean(SerdeRegistry)
         def encoderContext = registry.newEncoderContext(Object)
         Argument argument = Argument.of(SourceGenLargeDispatchBean)
@@ -568,7 +632,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated large record serializers cover nullable branches'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
         Argument argument = Argument.of(type)
@@ -595,7 +659,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated large record serializers wrap property exceptions'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         def registry = context.getBean(SerdeRegistry)
         def encoderContext = registry.newEncoderContext(Object)
         Argument argument = Argument.of(type)
@@ -639,7 +703,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated record deserializer dispatch source for small boundary and large property sets'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
         def decoderContext = registry.newDecoderContext(Object)
@@ -700,7 +764,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated non null record serializers are selected and functional'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
         Argument smallArgument = Argument.of(SourceGenSmallDispatchNonNullRecord)
@@ -730,7 +794,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated record constructor failures match runtime for small and large property sets'() {
         given:
-        def context = ApplicationContext.run(['micronaut.serde.deserialization.strict-nullable': true])
+        def context = runWithAlwaysInclusion(['micronaut.serde.deserialization.strict-nullable': true])
         jsonMapper = context.getBean(JsonMapper)
 
         expect:

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/SerdeableGeneratedSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/SerdeableGeneratedSpec.groovy
@@ -25,7 +25,9 @@ class SerdeableGeneratedSpec extends JsonCompileSpec {
 
     void 'test serdeable generated serializer and deserializer are functional'() {
         given:
-        def context = ApplicationContext.run()
+        def context = ApplicationContext.run([
+            'micronaut.serde.serialization.inclusion': 'ALWAYS'
+        ])
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
         Argument argument = Argument.of(SourceGenGeneratedShape)
@@ -42,6 +44,28 @@ class SerdeableGeneratedSpec extends JsonCompileSpec {
         nullJson == '{"name":null,"count":7}'
         decoded.name() == 'Ada'
         decoded.count() == 42
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test serdeable generated serializer honors global inclusion NON_NULL'() {
+        given:
+        def context = ApplicationContext.run([
+            'micronaut.serde.serialization.inclusion': 'NON_NULL'
+        ])
+        jsonMapper = context.getBean(JsonMapper)
+        def registry = context.getBean(SerdeRegistry)
+        Argument argument = Argument.of(SourceGenGeneratedShape)
+
+        when:
+        String nullJson = serializeToString(jsonMapper, new SourceGenGeneratedShape(null, 7))
+        String presentJson = serializeToString(jsonMapper, new SourceGenGeneratedShape('Ada', 42))
+
+        then:
+        assertRegistrySelection(registry, argument, 'Serializer', true)
+        nullJson == '{"count":7}'
+        presentJson == '{"name":"Ada","count":42}'
 
         cleanup:
         context.close()

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenNonDefaultScalarBean.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenNonDefaultScalarBean.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+@SerdeableGenerated
+@Introspected
+public class SourceGenNonDefaultScalarBean {
+    private Integer count;
+    private BigInteger bigCount;
+    private BigDecimal bigAmount;
+
+    public Integer getCount() {
+        return count;
+    }
+
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+
+    public BigInteger getBigCount() {
+        return bigCount;
+    }
+
+    public void setBigCount(BigInteger bigCount) {
+        this.bigCount = bigCount;
+    }
+
+    public BigDecimal getBigAmount() {
+        return bigAmount;
+    }
+
+    public void setBigAmount(BigDecimal bigAmount) {
+        this.bigAmount = bigAmount;
+    }
+}

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanSerializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanSerializerSourceGen.java
@@ -32,6 +32,7 @@ import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.processor.sourcegen.SerdeSourceGenClassNaming;
 import io.micronaut.serde.util.GeneratedSerdeExceptionUtil;
 import io.micronaut.serde.util.GeneratedSerdeFallbackUtil;
+import io.micronaut.serde.util.GeneratedSerdeInclusionUtil;
 import io.micronaut.sourcegen.model.AnnotationDef;
 import io.micronaut.sourcegen.model.ClassDef;
 import io.micronaut.sourcegen.model.ClassTypeDef;
@@ -116,6 +117,26 @@ public final class BeanSerializerSourceGen {
         Argument.class,
         Argument.class
     );
+    private static final Method SHOULD_SERIALIZE_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerialize",
+        Serializer.EncoderContext.class,
+        Serializer.class,
+        Object.class
+    );
+    private static final Method SHOULD_SERIALIZE_SCALAR_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerializeScalar",
+        Serializer.EncoderContext.class,
+        Object.class
+    );
+    private static final Method SHOULD_SERIALIZE_PRIMITIVE_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerializePrimitive",
+        Serializer.EncoderContext.class,
+        boolean.class
+    );
+    private static final ClassTypeDef INCLUSION_UTIL_TYPE = ClassTypeDef.of(GeneratedSerdeInclusionUtil.class);
 
     private static String required(Map<String, String> names, String key) {
         return Objects.requireNonNull(names.get(key));
@@ -347,8 +368,19 @@ public final class BeanSerializerSourceGen {
         List<StatementDef> statements = new ArrayList<>();
         int index = 0;
         for (BeanSerdeShape.BeanProperty property : beanSerdeShape.properties()) {
-            statements.add(encodeKeyStatement(serializerClassTypeDef, keyEncoder, index));
-            statements.add(serializeProperty(aThis, serializerClassTypeDef, valueEncoder, context, type, value, property, index++, argumentFieldNames, serializerFieldNames));
+            statements.add(serializeProperty(
+                aThis,
+                serializerClassTypeDef,
+                valueEncoder,
+                keyEncoder,
+                context,
+                type,
+                value,
+                property,
+                index++,
+                argumentFieldNames,
+                serializerFieldNames
+            ));
         }
         return statements;
     }
@@ -367,6 +399,7 @@ public final class BeanSerializerSourceGen {
     private StatementDef serializeProperty(VariableDef.This aThis,
                                            ClassTypeDef serializerClassTypeDef,
                                            VariableDef objectEncoder,
+                                           VariableDef keyEncoder,
                                            VariableDef.MethodParameter context,
                                            VariableDef.MethodParameter type,
                                            VariableDef.MethodParameter value,
@@ -377,38 +410,63 @@ public final class BeanSerializerSourceGen {
         ExpressionDef argumentExpression = serializerClassTypeDef.getStaticField(required(argumentFieldNames, property.name()), ARGUMENT_TYPE);
         Method scalarMethod = scalarEncoderMethod(property.serializationType());
         ExpressionDef propertyValue = readPropertyValue(value, property);
+        StatementDef encodeKey = encodeKeyStatement(serializerClassTypeDef, keyEncoder, index);
         if (scalarMethod != null) {
-            StatementDef scalarStatement;
             if (property.serializationType().isPrimitive() && !property.serializationType().isArray()) {
-                scalarStatement = objectEncoder.invoke(scalarMethod, propertyValue);
-            } else {
-                StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(BeanSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
-                scalarStatement = StatementDef.multi(
-                    propertyValueDef,
-                    propertyValueDef.variable().isNull().ifTrue(
-                        objectEncoder.invoke(ENCODE_NULL_METHOD),
-                        StatementDef.multi(objectEncoder.invoke(scalarMethod, propertyValueDef.variable()))
-                    )
+                ExpressionDef isDefault = primitiveIsDefaultExpression(property.serializationType(), propertyValue);
+                StatementDef writePrimitive = StatementDef.multi(
+                    encodeKey,
+                    objectEncoder.invoke(scalarMethod, propertyValue)
+                );
+                return wrapWithPropertyPath(
+                    INCLUSION_UTIL_TYPE.invokeStatic(SHOULD_SERIALIZE_PRIMITIVE_METHOD, context, isDefault)
+                        .ifTrue(writePrimitive),
+                    type,
+                    argumentExpression
                 );
             }
-            return wrapWithPropertyPath(scalarStatement, type, argumentExpression);
+            StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(BeanSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
+            StatementDef writeScalar = StatementDef.multi(
+                encodeKey,
+                propertyValueDef.variable().isNull().ifTrue(
+                    objectEncoder.invoke(ENCODE_NULL_METHOD),
+                    StatementDef.multi(objectEncoder.invoke(scalarMethod, propertyValueDef.variable()))
+                )
+            );
+            return wrapWithPropertyPath(StatementDef.multi(
+                propertyValueDef,
+                INCLUSION_UTIL_TYPE.invokeStatic(
+                    SHOULD_SERIALIZE_SCALAR_METHOD,
+                    context,
+                    propertyValueDef.variable().cast(TypeDef.OBJECT)
+                ).ifTrue(writeScalar)
+            ), type, argumentExpression);
         }
         String serializerFieldName = required(serializerFieldNames, property.name());
         ExpressionDef serializer = aThis.field(serializerFieldName, SERIALIZER_TYPE);
 
-        StatementDef serializeStatement = serializer.invoke(
-            SERIALIZE_METHOD,
-            objectEncoder,
-            context,
-            argumentExpression,
-            propertyValue.cast(TypeDef.OBJECT)
-        );
         if (property.serializationType().isPrimitive() && !property.serializationType().isArray()) {
-            return wrapWithPropertyPath(serializeStatement, type, argumentExpression);
+            ExpressionDef isDefault = primitiveIsDefaultExpression(property.serializationType(), propertyValue);
+            StatementDef writePrimitive = StatementDef.multi(
+                encodeKey,
+                serializer.invoke(
+                    SERIALIZE_METHOD,
+                    objectEncoder,
+                    context,
+                    argumentExpression,
+                    propertyValue.cast(TypeDef.OBJECT)
+                )
+            );
+            return wrapWithPropertyPath(
+                INCLUSION_UTIL_TYPE.invokeStatic(SHOULD_SERIALIZE_PRIMITIVE_METHOD, context, isDefault)
+                    .ifTrue(writePrimitive),
+                type,
+                argumentExpression
+            );
         }
         StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(BeanSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
-        return wrapWithPropertyPath(StatementDef.multi(
-            propertyValueDef,
+        StatementDef writeValue = StatementDef.multi(
+            encodeKey,
             propertyValueDef.variable().isNull().ifTrue(
                 objectEncoder.invoke(ENCODE_NULL_METHOD),
                 StatementDef.multi(
@@ -421,7 +479,29 @@ public final class BeanSerializerSourceGen {
                     )
                 )
             )
+        );
+        return wrapWithPropertyPath(StatementDef.multi(
+            propertyValueDef,
+            INCLUSION_UTIL_TYPE.invokeStatic(
+                SHOULD_SERIALIZE_METHOD,
+                context,
+                serializer,
+                propertyValueDef.variable().cast(TypeDef.OBJECT)
+            ).ifTrue(writeValue)
         ), type, argumentExpression);
+    }
+
+    private ExpressionDef primitiveIsDefaultExpression(ClassElement type, ExpressionDef propertyValue) {
+        return switch (type.getName()) {
+            case "boolean" -> propertyValue.isFalse();
+            case "char" -> propertyValue.equalsStructurally(ExpressionDef.constant(0).cast(TypeDef.Primitive.CHAR));
+            case "float" -> propertyValue.equalsStructurally(ExpressionDef.constant(0f));
+            case "double" -> propertyValue.equalsStructurally(ExpressionDef.constant(0d));
+            case "long" -> propertyValue.equalsStructurally(ExpressionDef.constant(0L));
+            case "byte" -> propertyValue.equalsStructurally(ExpressionDef.constant(0).cast(TypeDef.Primitive.BYTE));
+            case "short" -> propertyValue.equalsStructurally(ExpressionDef.constant(0).cast(TypeDef.Primitive.SHORT));
+            default -> propertyValue.equalsStructurally(ExpressionDef.constant(0));
+        };
     }
 
     private ExpressionDef readPropertyValue(VariableDef.MethodParameter value, BeanSerdeShape.BeanProperty property) {

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerializerSourceGen.java
@@ -29,6 +29,7 @@ import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.processor.sourcegen.SerdeSourceGenClassNaming;
 import io.micronaut.serde.util.GeneratedSerdeExceptionUtil;
 import io.micronaut.serde.util.GeneratedSerdeFallbackUtil;
+import io.micronaut.serde.util.GeneratedSerdeInclusionUtil;
 import io.micronaut.sourcegen.model.AnnotationDef;
 import io.micronaut.sourcegen.model.ClassDef;
 import io.micronaut.sourcegen.model.ClassTypeDef;
@@ -113,6 +114,26 @@ public final class RecordSerializerSourceGen {
         Argument.class,
         Argument.class
     );
+    private static final Method SHOULD_SERIALIZE_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerialize",
+        Serializer.EncoderContext.class,
+        Serializer.class,
+        Object.class
+    );
+    private static final Method SHOULD_SERIALIZE_SCALAR_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerializeScalar",
+        Serializer.EncoderContext.class,
+        Object.class
+    );
+    private static final Method SHOULD_SERIALIZE_PRIMITIVE_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerializePrimitive",
+        Serializer.EncoderContext.class,
+        boolean.class
+    );
+    private static final ClassTypeDef INCLUSION_UTIL_TYPE = ClassTypeDef.of(GeneratedSerdeInclusionUtil.class);
 
     public ClassDef generate(ClassElement element, RecordSerdeShape recordSerdeShape) {
         TypeDef recordTypeDef = TypeDef.of(element);
@@ -326,8 +347,19 @@ public final class RecordSerializerSourceGen {
         List<StatementDef> statements = new ArrayList<>();
         int index = 0;
         for (RecordSerdeShape.RecordComponent component : recordSerdeShape.components()) {
-            statements.add(encodeKeyStatement(serializerClassTypeDef, keyEncoder, index));
-            statements.add(serializeComponent(aThis, serializerClassTypeDef, valueEncoder, context, type, value, component, index++, argumentFieldNames, serializerFieldNames));
+            statements.add(serializeComponent(
+                aThis,
+                serializerClassTypeDef,
+                valueEncoder,
+                keyEncoder,
+                context,
+                type,
+                value,
+                component,
+                index++,
+                argumentFieldNames,
+                serializerFieldNames
+            ));
         }
         return statements;
     }
@@ -346,6 +378,7 @@ public final class RecordSerializerSourceGen {
     private StatementDef serializeComponent(VariableDef.This aThis,
                                             ClassTypeDef serializerClassTypeDef,
                                             VariableDef objectEncoder,
+                                            VariableDef keyEncoder,
                                             VariableDef.MethodParameter context,
                                             VariableDef.MethodParameter type,
                                             VariableDef.MethodParameter value,
@@ -356,38 +389,63 @@ public final class RecordSerializerSourceGen {
         ExpressionDef argumentExpression = serializerClassTypeDef.getStaticField(required(argumentFieldNames, component.name()), ARGUMENT_TYPE);
         Method scalarMethod = scalarEncoderMethod(component.type());
         ExpressionDef propertyValue = value.getPropertyValue(component.propertyElement());
+        StatementDef encodeKey = encodeKeyStatement(serializerClassTypeDef, keyEncoder, index);
         if (scalarMethod != null) {
-            StatementDef scalarStatement;
             if (component.type().isPrimitive() && !component.type().isArray()) {
-                scalarStatement = objectEncoder.invoke(scalarMethod, propertyValue);
-            } else {
-                StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(RecordSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
-                scalarStatement = StatementDef.multi(
-                    propertyValueDef,
-                    propertyValueDef.variable().isNull().ifTrue(
-                        objectEncoder.invoke(ENCODE_NULL_METHOD),
-                        StatementDef.multi(objectEncoder.invoke(scalarMethod, propertyValueDef.variable()))
-                    )
+                ExpressionDef isDefault = primitiveIsDefaultExpression(component.type(), propertyValue);
+                StatementDef writePrimitive = StatementDef.multi(
+                    encodeKey,
+                    objectEncoder.invoke(scalarMethod, propertyValue)
+                );
+                return wrapWithPropertyPath(
+                    INCLUSION_UTIL_TYPE.invokeStatic(SHOULD_SERIALIZE_PRIMITIVE_METHOD, context, isDefault)
+                        .ifTrue(writePrimitive),
+                    type,
+                    argumentExpression
                 );
             }
-            return wrapWithPropertyPath(scalarStatement, type, argumentExpression);
+            StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(RecordSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
+            StatementDef writeScalar = StatementDef.multi(
+                encodeKey,
+                propertyValueDef.variable().isNull().ifTrue(
+                    objectEncoder.invoke(ENCODE_NULL_METHOD),
+                    StatementDef.multi(objectEncoder.invoke(scalarMethod, propertyValueDef.variable()))
+                )
+            );
+            return wrapWithPropertyPath(StatementDef.multi(
+                propertyValueDef,
+                INCLUSION_UTIL_TYPE.invokeStatic(
+                    SHOULD_SERIALIZE_SCALAR_METHOD,
+                    context,
+                    propertyValueDef.variable().cast(TypeDef.OBJECT)
+                ).ifTrue(writeScalar)
+            ), type, argumentExpression);
         }
         String serializerFieldName = required(serializerFieldNames, component.name());
         ExpressionDef serializer = aThis.field(serializerFieldName, SERIALIZER_TYPE);
 
-        StatementDef serializeStatement = serializer.invoke(
-            SERIALIZE_METHOD,
-            objectEncoder,
-            context,
-            argumentExpression,
-            propertyValue.cast(TypeDef.OBJECT)
-        );
         if (component.type().isPrimitive() && !component.type().isArray()) {
-            return wrapWithPropertyPath(serializeStatement, type, argumentExpression);
+            ExpressionDef isDefault = primitiveIsDefaultExpression(component.type(), propertyValue);
+            StatementDef writePrimitive = StatementDef.multi(
+                encodeKey,
+                serializer.invoke(
+                    SERIALIZE_METHOD,
+                    objectEncoder,
+                    context,
+                    argumentExpression,
+                    propertyValue.cast(TypeDef.OBJECT)
+                )
+            );
+            return wrapWithPropertyPath(
+                INCLUSION_UTIL_TYPE.invokeStatic(SHOULD_SERIALIZE_PRIMITIVE_METHOD, context, isDefault)
+                    .ifTrue(writePrimitive),
+                type,
+                argumentExpression
+            );
         }
         StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(RecordSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
-        return wrapWithPropertyPath(StatementDef.multi(
-            propertyValueDef,
+        StatementDef writeValue = StatementDef.multi(
+            encodeKey,
             propertyValueDef.variable().isNull().ifTrue(
                 objectEncoder.invoke(ENCODE_NULL_METHOD),
                 StatementDef.multi(
@@ -400,7 +458,29 @@ public final class RecordSerializerSourceGen {
                     )
                 )
             )
+        );
+        return wrapWithPropertyPath(StatementDef.multi(
+            propertyValueDef,
+            INCLUSION_UTIL_TYPE.invokeStatic(
+                SHOULD_SERIALIZE_METHOD,
+                context,
+                serializer,
+                propertyValueDef.variable().cast(TypeDef.OBJECT)
+            ).ifTrue(writeValue)
         ), type, argumentExpression);
+    }
+
+    private ExpressionDef primitiveIsDefaultExpression(ClassElement type, ExpressionDef propertyValue) {
+        return switch (type.getName()) {
+            case "boolean" -> propertyValue.isFalse();
+            case "char" -> propertyValue.equalsStructurally(ExpressionDef.constant(0).cast(TypeDef.Primitive.CHAR));
+            case "float" -> propertyValue.equalsStructurally(ExpressionDef.constant(0f));
+            case "double" -> propertyValue.equalsStructurally(ExpressionDef.constant(0d));
+            case "long" -> propertyValue.equalsStructurally(ExpressionDef.constant(0L));
+            case "byte" -> propertyValue.equalsStructurally(ExpressionDef.constant(0).cast(TypeDef.Primitive.BYTE));
+            case "short" -> propertyValue.equalsStructurally(ExpressionDef.constant(0).cast(TypeDef.Primitive.SHORT));
+            default -> propertyValue.equalsStructurally(ExpressionDef.constant(0));
+        };
     }
 
     private String indexedName(String prefix, int index) {


### PR DESCRIPTION
## Description

Fixes [micronaut-projects/micronaut-core#12838](https://github.com/micronaut-projects/micronaut-core/issues/12838).

Source-generated serializers for simple `@Serdeable` beans/records always wrote every property (including `null`), so configuration such as:

```yaml
micronaut:
  serde:
    serialization:
      inclusion: NON_NULL
```

had no effect. Runtime (`CustomizedObjectSerializer` / `SerBean`) already honored `micronaut.serde.serialization.inclusion`; the compile-time path did not.

### Change

- Add `GeneratedSerdeInclusionUtil` for inclusion checks used by generated code
- Teach `BeanSerializerSourceGen` / `RecordSerializerSourceGen` to skip properties according to the active global inclusion (`NON_NULL`, `NON_EMPTY`, `NON_ABSENT`, `NON_DEFAULT`, `NEVER`, etc.)
- Keep generated serializers selected (no forced fallback to the runtime object serializer)

Workaround from the issue (`disable-generated-serializer=true` or type-level `@JsonInclude`) is no longer required for this case.

## Related Issue

Fixes micronaut-projects/micronaut-core#12838

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Improvement / performance

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/micronaut-projects/micronaut-serialization/blob/3.1.x/CONTRIBUTING.md) guidelines
- [x] Tests are included
- [x] License headers present / Spotless applied

## Testing

```text
./gradlew :micronaut-serde-jackson:test
# SUCCESS: 1579 tests (15 skipped), JDK 26 (Homebrew openjdk@25)
```

Focused coverage:

- `CompileTimeSourceGenSpec` — global `NON_NULL` and default `NON_EMPTY` omit null/empty properties while still selecting generated serializers
- `SerdeableGeneratedSpec` — `NON_NULL` omits null name fields
- Recursive serialize tests set `inclusion=ALWAYS` when they assert explicit `null` output