### PR TITLE
Pin the Netty HTTP server TCK to localhost

### DIFF
--- a/test-suite-http-server-tck-netty/build.gradle.kts
+++ b/test-suite-http-server-tck-netty/build.gradle.kts
@@ -23,4 +23,9 @@ dependencies {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    // NettyHttpServer.getHost() falls back to $HOSTNAME before "localhost". Shells on many Linux
+    // distros export HOSTNAME (macOS/Windows do not), which makes the server advertise the machine
+    // name, so the TCK client connects over a non-loopback interface and the remote-address and
+    // CORS isHostLocal assertions fail. Pin the host so the suite behaves the same everywhere.
+    systemProperty("micronaut.server.host", "localhost")
 }


### PR DESCRIPTION
NettyHttpServer.getHost() resolves to
serverConfiguration.getHost().orElseGet(() -> getenv("HOSTNAME")).orElse("localhost").

Shells on many Linux distributions export HOSTNAME (Fedora does so from /etc/profile), while macOS and Windows do not, and neither do most non-interactive CI shells. Where it is exported, the embedded server advertises the machine name, EmbeddedServer.getURL() points at a non-loopback interface, and the TCK client connects over it. Four tests then fail locally while CI stays green:

- RemoteAddressTest expects a source IP of 127.0.0.1 but sees the host's LAN address.
- Three CorsSimpleRequestTest cases expect 403. CorsFilter only denies via shouldDenyToPreventDriveByLocalhostAttack when isHostLocal(resolved host) matches a literal http://localhost or http://127. prefix, which the machine name does not, so disallowed origins are accepted.

Pinning micronaut.server.host makes the suite behave identically on every platform rather than depending on an environment variable, and keeps the test server off the local network. It is a no-op where HOSTNAME was never set.