### PR TITLE
feat(serde): make deserialization coercions configurable

### DIFF
--- a/.github/workflows/graalvm-latest.yml
+++ b/.github/workflows/graalvm-latest.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - master
       - '[0-9]+.[0-9]+.x'
-      - serdeintfloat3x
   pull_request:
     branches:
       - master

--- a/.github/workflows/graalvm-latest.yml
+++ b/.github/workflows/graalvm-latest.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
       - '[0-9]+.[0-9]+.x'
+      - serdeintfloat3x
   pull_request:
     branches:
       - master

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,7 +9,6 @@ on:
     branches:
       - master
       - '[0-9]+.[0-9]+.x'
-      - serdeintfloat3x
   pull_request:
     branches:
       - master

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
       - '[0-9]+.[0-9]+.x'
+      - serdeintfloat3x
   pull_request:
     branches:
       - master

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 
 jmh {
     includes = [
-        ".*(StartupBenchmark|SourceGenRoutingBenchmark|UserBeanSerdeBenchmark|PropertyAccessShapeBenchmark|PropertyAccessOrderBenchmark|PropertyValueKindBenchmark|PropertyValueKindSerializationCeilingBenchmark|PropertyValueKindSerializationLifecycleBenchmark|BeanIntrospectionAccessBenchmark|SpecificObjectDeserializerComplexShapeBenchmark).*"
+        ".*(StartupBenchmark|SourceGenRoutingBenchmark|UserBeanSerdeBenchmark|PropertyAccessShapeBenchmark|PropertyAccessOrderBenchmark|PropertyValueKindBenchmark|PropertyValueKindSerializationCeilingBenchmark|PropertyValueKindSerializationLifecycleBenchmark|BeanIntrospectionAccessBenchmark|SpecificObjectDeserializerComplexShapeBenchmark|CoercionPolicyBenchmark).*"
     ]
     fork = 10
     iterations = 1

--- a/benchmarks/src/jmh/java/io/micronaut/serde/CoercionPolicyBenchmark.java
+++ b/benchmarks/src/jmh/java/io/micronaut/serde/CoercionPolicyBenchmark.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.type.Argument;
+import io.micronaut.json.JsonMapper;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+import io.micronaut.serde.jackson.JacksonJsonMapper;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Guards that restricting coercions costs nothing at read time. The policy is reduced to one
+ * precalculated bit set per target type before any value is read, so a strict decoder runs the
+ * same instructions as a lenient one and only the mask constant differs. A difference between the
+ * two modes here means that the strategy is being derived per value again.
+ * <p>
+ * Every value in the payloads has the shape of the property it is read into, so neither mode
+ * takes a coercion or an error path.
+ */
+public class CoercionPolicyBenchmark {
+
+    private static final byte[] INT_JSON = """
+        {"a":1000,"b":2000,"c":3000,"d":4000,"e":5000,"f":6000,"g":7000,"h":8000,"i":9000,"j":10000}
+        """.getBytes(StandardCharsets.UTF_8);
+    private static final byte[] STRING_JSON = """
+        {"a":"value-1000","b":"value-2000","c":"value-3000","d":"value-4000","e":"value-5000","f":"value-6000","g":"value-7000","h":"value-8000","i":"value-9000","j":"value-10000"}
+        """.getBytes(StandardCharsets.UTF_8);
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    public Object deserializeInts(Holder holder) throws IOException {
+        return holder.mapper.readValue(INT_JSON, holder.intArgument);
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    public Object deserializeStrings(Holder holder) throws IOException {
+        return holder.mapper.readValue(STRING_JSON, holder.stringArgument);
+    }
+
+    @State(Scope.Thread)
+    public static class Holder {
+
+        @Param({"LENIENT", "STRICT"})
+        String coercionMode = "LENIENT";
+
+        final Argument<IntBean> intArgument = Argument.of(IntBean.class);
+        final Argument<StringBean> stringArgument = Argument.of(StringBean.class);
+
+        JsonMapper mapper;
+        ApplicationContext context;
+
+        @Setup
+        public void setUp() {
+            Map<String, Object> properties = new HashMap<>();
+            properties.put("micronaut.serde.serialization.inclusion", "ALWAYS");
+            properties.put("micronaut.serde.deserialization.coercion-mode", coercionMode);
+            context = ApplicationContext.run(properties);
+            mapper = context.getBean(JacksonJsonMapper.class);
+        }
+
+        @TearDown
+        public void tearDown() {
+            if (context != null) {
+                context.close();
+            }
+        }
+    }
+
+    @Introspected(accessKind = Introspected.AccessKind.FIELD)
+    @SerdeableGenerated
+    public static class IntBean {
+        public int a;
+        public int b;
+        public int c;
+        public int d;
+        public int e;
+        public int f;
+        public int g;
+        public int h;
+        public int i;
+        public int j;
+    }
+
+    @Introspected(accessKind = Introspected.AccessKind.FIELD)
+    @SerdeableGenerated
+    public static class StringBean {
+        public String a;
+        public String b;
+        public String c;
+        public String d;
+        public String e;
+        public String f;
+        public String g;
+        public String h;
+        public String i;
+        public String j;
+    }
+}

--- a/serde-api/src/main/java/io/micronaut/serde/Decoder.java
+++ b/serde-api/src/main/java/io/micronaut/serde/Decoder.java
@@ -17,6 +17,7 @@ package io.micronaut.serde;
 
 import io.micronaut.core.type.Argument;
 import io.micronaut.json.tree.JsonNode;
+import io.micronaut.serde.config.CoercionPolicy;
 import io.micronaut.serde.util.BinaryCodecUtil;
 import org.jspecify.annotations.Nullable;
 
@@ -436,4 +437,17 @@ public interface Decoder extends AutoCloseable {
      * @return The exception, never {@code null}
      */
     IOException createDeserializationException(String message, @Nullable Object invalidValue);
+
+    /**
+     * The coercions this decoder performs. A decoder that creates another decoder over the same
+     * data, such as {@link #decodeBuffer()}, must pass this on, so that the same document is
+     * accepted or rejected no matter which decoder ends up reading a given value.
+     *
+     * @return The coercion policy, {@link CoercionPolicy#LENIENT} for a decoder that does not
+     *         support restricting coercions
+     * @since 3.2
+     */
+    default CoercionPolicy getCoercionPolicy() {
+        return CoercionPolicy.LENIENT;
+    }
 }

--- a/serde-api/src/main/java/io/micronaut/serde/DelegatingDecoder.java
+++ b/serde-api/src/main/java/io/micronaut/serde/DelegatingDecoder.java
@@ -213,7 +213,7 @@ public abstract class DelegatingDecoder implements Decoder {
     public CoercionPolicy getCoercionPolicy() {
         try {
             return delegate().getCoercionPolicy();
-        } catch (IOException e) {
+        } catch (IOException _) {
             // the delegate is not available yet, the caller will hit the same failure when it decodes
             return Decoder.super.getCoercionPolicy();
         }

--- a/serde-api/src/main/java/io/micronaut/serde/DelegatingDecoder.java
+++ b/serde-api/src/main/java/io/micronaut/serde/DelegatingDecoder.java
@@ -17,6 +17,7 @@ package io.micronaut.serde;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
+import io.micronaut.serde.config.CoercionPolicy;
 import io.micronaut.json.tree.JsonNode;
 import org.jspecify.annotations.Nullable;
 
@@ -206,6 +207,16 @@ public abstract class DelegatingDecoder implements Decoder {
     @Override
     public JsonNode decodeNode() throws IOException {
         return delegate().decodeNode();
+    }
+
+    @Override
+    public CoercionPolicy getCoercionPolicy() {
+        try {
+            return delegate().getCoercionPolicy();
+        } catch (IOException e) {
+            // the delegate is not available yet, the caller will hit the same failure when it decodes
+            return Decoder.super.getCoercionPolicy();
+        }
     }
 
     @Override

--- a/serde-api/src/main/java/io/micronaut/serde/config/CoercionMode.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/CoercionMode.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.config;
+
+/**
+ * The baseline for the scalar coercions a decoder performs. Individual coercions can always be
+ * turned on or off explicitly, the mode only decides the default for the ones that are not
+ * configured.
+ *
+ * @author Denis Stepanov
+ * @since 3.2
+ */
+public enum CoercionMode {
+    /**
+     * Values of the wrong shape are coerced where a sensible conversion exists, for example a JSON
+     * string is read into an {@code int} property. This is the historical behaviour.
+     */
+    LENIENT,
+    /**
+     * Values must have the shape of the target type. A JSON string is not read into an {@code int}
+     * property, a floating point number is not read into an integer property, and so on.
+     */
+    STRICT
+}

--- a/serde-api/src/main/java/io/micronaut/serde/config/CoercionPolicy.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/CoercionPolicy.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2017-2025 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.config;
+
+import io.micronaut.serde.Decoder;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The scalar coercions a {@link Decoder} is allowed to perform, resolved once from the
+ * {@link DeserializationConfiguration} and then passed to every decoder that is created, in the
+ * same way as {@link io.micronaut.serde.LimitingStream.RemainingLimits}.
+ * <p>
+ * A decoder that is handed a policy must consult it at every point where it reads a value whose
+ * JSON shape does not match the requested type, and must pass its own policy on to the decoders it
+ * creates, in particular in {@link Decoder#decodeBuffer()}, so that the same input is accepted or
+ * rejected no matter which decoder ends up reading it.
+ *
+ * @author Denis Stepanov
+ * @since 3.2
+ */
+public final class CoercionPolicy {
+
+    /**
+     * All coercions allowed. This is the historical behaviour and the default.
+     */
+    public static final CoercionPolicy LENIENT = new CoercionPolicy(allMask());
+
+    /**
+     * No coercions allowed, values must have the shape of the target type.
+     */
+    public static final CoercionPolicy STRICT = new CoercionPolicy(0);
+
+    private final int allowed;
+    private final int[] allowedShapes;
+
+    private CoercionPolicy(int allowed) {
+        this.allowed = allowed;
+        this.allowedShapes = precalculate(allowed);
+    }
+
+    /**
+     * Turn the configured coercions into one bit set of acceptable {@link Shape}s per
+     * {@link Target}, so that a decoder can reduce every check to a single mask test instead of
+     * re-deriving which coercion a token would need.
+     */
+    private static int[] precalculate(int allowed) {
+        int[] shapes = new int[Target.VALUES.length];
+        for (Target target : Target.VALUES) {
+            int mask = bit(Shape.OTHER);
+            for (Shape shape : Shape.VALUES) {
+                if (shape == Shape.OTHER) {
+                    continue;
+                }
+                Coercion coercion = coercion(target, shape);
+                if (coercion == null || (allowed & coercion.mask) != 0) {
+                    mask |= bit(shape);
+                }
+            }
+            shapes[target.ordinal()] = mask;
+        }
+        return shapes;
+    }
+
+    /**
+     * The coercion needed to read a value of the given shape as the given target type, or
+     * {@code null} if the shape is the natural one for that target and no coercion is involved.
+     *
+     * @param target The target type
+     * @param shape  The shape of the value in the document
+     * @return The coercion, or {@code null} if none is needed
+     */
+    @Nullable
+    public static Coercion coercion(Target target, Shape shape) {
+        if (shape == Shape.ARRAY) {
+            return Coercion.UNWRAP_SINGLE_VALUE_ARRAY;
+        }
+        return switch (target) {
+            case INTEGER -> switch (shape) {
+                case FLOAT_NUMBER -> Coercion.FLOAT_AS_INT;
+                case STRING -> Coercion.STRING_AS_NUMBER;
+                case BOOLEAN -> Coercion.BOOLEAN_AS_NUMBER;
+                default -> null;
+            };
+            case DECIMAL -> switch (shape) {
+                case STRING -> Coercion.STRING_AS_NUMBER;
+                case BOOLEAN -> Coercion.BOOLEAN_AS_NUMBER;
+                default -> null;
+            };
+            case BOOLEAN -> switch (shape) {
+                case INTEGER_NUMBER, FLOAT_NUMBER -> Coercion.NUMBER_AS_BOOLEAN;
+                case STRING -> Coercion.STRING_AS_BOOLEAN;
+                default -> null;
+            };
+            case STRING -> switch (shape) {
+                case INTEGER_NUMBER, FLOAT_NUMBER, BOOLEAN -> Coercion.SCALAR_AS_STRING;
+                default -> null;
+            };
+            // a single character string is the natural shape of a char, and an integer is its code point
+            case CHAR -> switch (shape) {
+                case FLOAT_NUMBER -> Coercion.FLOAT_AS_INT;
+                case BOOLEAN -> Coercion.BOOLEAN_AS_NUMBER;
+                default -> null;
+            };
+        };
+    }
+
+    /**
+     * The precalculated bit set of {@link Shape}s that may be read as the given target type. A
+     * decoder should read this once, when it is created, and test it with
+     * {@link Shape#bit()} for every value it reads.
+     *
+     * @param target The target type
+     * @return The bit set of acceptable shapes
+     */
+    public int allowedShapes(Target target) {
+        return allowedShapes[target.ordinal()];
+    }
+
+    private static int bit(Shape shape) {
+        return 1 << shape.ordinal();
+    }
+
+    /**
+     * Resolve the policy from the given configuration.
+     *
+     * @param configuration The deserialization configuration, may be {@code null}
+     * @return The coercion policy, {@link #LENIENT} if there is no configuration
+     */
+    public static CoercionPolicy fromConfiguration(@Nullable DeserializationConfiguration configuration) {
+        if (configuration == null) {
+            return LENIENT;
+        }
+        int allowed = 0;
+        allowed |= mask(Coercion.FLOAT_AS_INT, configuration.isAcceptFloatAsInt());
+        allowed |= mask(Coercion.STRING_AS_NUMBER, configuration.isAcceptStringAsNumber());
+        allowed |= mask(Coercion.BOOLEAN_AS_NUMBER, configuration.isAcceptBooleanAsNumber());
+        allowed |= mask(Coercion.NUMBER_AS_BOOLEAN, configuration.isAcceptNumberAsBoolean());
+        allowed |= mask(Coercion.STRING_AS_BOOLEAN, configuration.isAcceptStringAsBoolean());
+        allowed |= mask(Coercion.SCALAR_AS_STRING, configuration.isAcceptScalarAsString());
+        allowed |= mask(Coercion.UNWRAP_SINGLE_VALUE_ARRAY, configuration.isUnwrapSingleValueArrays());
+        if (allowed == LENIENT.allowed) {
+            return LENIENT;
+        }
+        if (allowed == 0) {
+            return STRICT;
+        }
+        return new CoercionPolicy(allowed);
+    }
+
+    /**
+     * @param coercion The coercion
+     * @return Whether the decoder may perform it
+     */
+    public boolean isAllowed(Coercion coercion) {
+        return (allowed & coercion.mask) != 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof CoercionPolicy other && other.allowed == allowed;
+    }
+
+    @Override
+    public int hashCode() {
+        return allowed;
+    }
+
+    @Override
+    public String toString() {
+        if (allowed == LENIENT.allowed) {
+            return "CoercionPolicy.LENIENT";
+        }
+        if (allowed == 0) {
+            return "CoercionPolicy.STRICT";
+        }
+        StringBuilder builder = new StringBuilder("CoercionPolicy[");
+        boolean first = true;
+        for (Coercion coercion : Coercion.VALUES) {
+            if (isAllowed(coercion)) {
+                if (!first) {
+                    builder.append(", ");
+                }
+                builder.append(coercion.name());
+                first = false;
+            }
+        }
+        return builder.append(']').toString();
+    }
+
+    /**
+     * The shape of a value in the document, as far as coercion is concerned.
+     */
+    public enum Shape {
+        /**
+         * A string.
+         */
+        STRING,
+        /**
+         * A number without a fractional part.
+         */
+        INTEGER_NUMBER,
+        /**
+         * A number with a fractional part.
+         */
+        FLOAT_NUMBER,
+        /**
+         * A boolean.
+         */
+        BOOLEAN,
+        /**
+         * An array, which a decoder may unwrap if it holds a single value.
+         */
+        ARRAY,
+        /**
+         * Anything else: null, objects, structural tokens, format specific values. These are never
+         * coerced, the decoder rejects or handles them on its own.
+         */
+        OTHER;
+
+        static final Shape[] VALUES = values();
+
+        private final int bit = 1 << ordinal();
+
+        /**
+         * @return This shape as a bit, to test against {@link CoercionPolicy#allowedShapes(Target)}
+         */
+        public int bit() {
+            return bit;
+        }
+    }
+
+    /**
+     * The type a decoder is reading a value as.
+     */
+    public enum Target {
+        /**
+         * {@code byte}, {@code short}, {@code int}, {@code long} or {@link java.math.BigInteger}.
+         */
+        INTEGER,
+        /**
+         * {@code float}, {@code double} or {@link java.math.BigDecimal}.
+         */
+        DECIMAL,
+        /**
+         * {@code boolean}.
+         */
+        BOOLEAN,
+        /**
+         * {@link String}.
+         */
+        STRING,
+        /**
+         * {@code char}.
+         */
+        CHAR;
+
+        static final Target[] VALUES = values();
+    }
+
+    private static int mask(Coercion coercion, boolean allowed) {
+        return allowed ? coercion.mask : 0;
+    }
+
+    private static int allMask() {
+        int mask = 0;
+        for (Coercion coercion : Coercion.values()) {
+            mask |= coercion.mask;
+        }
+        return mask;
+    }
+
+    /**
+     * A single coercion a decoder may perform when the JSON shape does not match the requested
+     * type.
+     */
+    public enum Coercion {
+        /**
+         * Read a floating point number into an integer type, truncating it. {@code 42.5} becomes
+         * {@code 42}.
+         */
+        FLOAT_AS_INT("Cannot coerce a floating point value to an integer"),
+        /**
+         * Read a string into a numeric type. {@code "42"} becomes {@code 42}.
+         */
+        STRING_AS_NUMBER("Cannot coerce a string to a number"),
+        /**
+         * Read a boolean into a numeric type. {@code true} becomes {@code 1}.
+         */
+        BOOLEAN_AS_NUMBER("Cannot coerce a boolean to a number"),
+        /**
+         * Read a number into a boolean. Any non-zero value becomes {@code true}.
+         */
+        NUMBER_AS_BOOLEAN("Cannot coerce a number to a boolean"),
+        /**
+         * Read a string into a boolean. {@code "true"} becomes {@code true}, anything else
+         * {@code false}.
+         */
+        STRING_AS_BOOLEAN("Cannot coerce a string to a boolean"),
+        /**
+         * Read a number or boolean into a string. {@code 1234} becomes {@code "1234"}.
+         */
+        SCALAR_AS_STRING("Cannot coerce a non-string value to a string"),
+        /**
+         * Read a single element array into the scalar it contains. {@code [42]} becomes
+         * {@code 42}.
+         */
+        UNWRAP_SINGLE_VALUE_ARRAY("Cannot coerce a single element array to a single value");
+
+        static final Coercion[] VALUES = values();
+
+        final int mask;
+        private final String message;
+
+        Coercion(String message) {
+            this.mask = 1 << ordinal();
+            this.message = message;
+        }
+
+        /**
+         * @return The message to report when this coercion is not allowed
+         */
+        public String message() {
+            return message;
+        }
+    }
+}

--- a/serde-api/src/main/java/io/micronaut/serde/config/CoercionPolicy.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/CoercionPolicy.java
@@ -31,6 +31,9 @@ import org.jspecify.annotations.Nullable;
  * @author Denis Stepanov
  * @since 3.2
  */
+// the ordinals are used as bit positions in masks that are built and read in the same JVM run,
+// they are never persisted or exchanged
+@SuppressWarnings("EnumOrdinal")
 public final class CoercionPolicy {
 
     /**

--- a/serde-api/src/main/java/io/micronaut/serde/config/DefaultDeserializationConfiguration.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/DefaultDeserializationConfiguration.java
@@ -94,8 +94,8 @@ final class DefaultDeserializationConfiguration implements DeserializationConfig
         this.adjustDatesToContextTimeZone = adjustDatesToContextTimeZone;
         this.requireAllCreatorParameters = requireAllCreatorParameters;
         this.disableGeneratedDeserializer = disableGeneratedDeserializer;
-        this.coercionMode = coercionMode == null ? CoercionMode.LENIENT : coercionMode;
-        boolean lenient = this.coercionMode != CoercionMode.STRICT;
+        this.coercionMode = coercionMode;
+        boolean lenient = coercionMode != CoercionMode.STRICT;
         this.acceptFloatAsInt = acceptFloatAsInt == null ? lenient : acceptFloatAsInt;
         this.acceptStringAsNumber = acceptStringAsNumber == null ? lenient : acceptStringAsNumber;
         this.acceptBooleanAsNumber = acceptBooleanAsNumber == null ? lenient : acceptBooleanAsNumber;

--- a/serde-api/src/main/java/io/micronaut/serde/config/DefaultDeserializationConfiguration.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/DefaultDeserializationConfiguration.java
@@ -45,6 +45,7 @@ final class DefaultDeserializationConfiguration implements DeserializationConfig
     private final boolean adjustDatesToContextTimeZone;
     private final boolean requireAllCreatorParameters;
     private final boolean disableGeneratedDeserializer;
+    private final boolean acceptFloatAsInt;
     private final Set<DeserializationConfiguration.Feature> features;
 
     @ConfigurationInject
@@ -62,7 +63,8 @@ final class DefaultDeserializationConfiguration implements DeserializationConfig
                                         @Bindable(defaultValue = StringUtils.TRUE) boolean readDateTimestampsAsNanoseconds,
                                         @Bindable(defaultValue = StringUtils.FALSE) boolean adjustDatesToContextTimeZone,
                                         @Bindable(defaultValue = StringUtils.FALSE) boolean requireAllCreatorParameters,
-                                        @Bindable(defaultValue = StringUtils.FALSE) boolean disableGeneratedDeserializer) {
+                                        @Bindable(defaultValue = StringUtils.FALSE) boolean disableGeneratedDeserializer,
+                                        @Bindable(defaultValue = StringUtils.TRUE) boolean acceptFloatAsInt) {
         this.ignoreUnknown = ignoreUnknown;
         this.arraySizeThreshold = arraySizeThreshold;
         this.strictNullable = strictNullable;
@@ -77,6 +79,7 @@ final class DefaultDeserializationConfiguration implements DeserializationConfig
         this.adjustDatesToContextTimeZone = adjustDatesToContextTimeZone;
         this.requireAllCreatorParameters = requireAllCreatorParameters;
         this.disableGeneratedDeserializer = disableGeneratedDeserializer;
+        this.acceptFloatAsInt = acceptFloatAsInt;
         this.features = DeserializationConfiguration.super.features();
     }
 
@@ -108,6 +111,11 @@ final class DefaultDeserializationConfiguration implements DeserializationConfig
     @Override
     public boolean acceptCaseInsensitiveEnums() {
         return acceptCaseInsensitiveEnums;
+    }
+
+    @Override
+    public boolean isAcceptFloatAsInt() {
+        return acceptFloatAsInt;
     }
 
     @Override

--- a/serde-api/src/main/java/io/micronaut/serde/config/DefaultDeserializationConfiguration.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/DefaultDeserializationConfiguration.java
@@ -20,6 +20,7 @@ import io.micronaut.context.annotation.ConfigurationInject;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.bind.annotation.Bindable;
 import io.micronaut.core.util.StringUtils;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Set;
 
@@ -45,7 +46,14 @@ final class DefaultDeserializationConfiguration implements DeserializationConfig
     private final boolean adjustDatesToContextTimeZone;
     private final boolean requireAllCreatorParameters;
     private final boolean disableGeneratedDeserializer;
+    private final CoercionMode coercionMode;
     private final boolean acceptFloatAsInt;
+    private final boolean acceptStringAsNumber;
+    private final boolean acceptBooleanAsNumber;
+    private final boolean acceptNumberAsBoolean;
+    private final boolean acceptStringAsBoolean;
+    private final boolean acceptScalarAsString;
+    private final boolean unwrapSingleValueArrays;
     private final Set<DeserializationConfiguration.Feature> features;
 
     @ConfigurationInject
@@ -64,7 +72,14 @@ final class DefaultDeserializationConfiguration implements DeserializationConfig
                                         @Bindable(defaultValue = StringUtils.FALSE) boolean adjustDatesToContextTimeZone,
                                         @Bindable(defaultValue = StringUtils.FALSE) boolean requireAllCreatorParameters,
                                         @Bindable(defaultValue = StringUtils.FALSE) boolean disableGeneratedDeserializer,
-                                        @Bindable(defaultValue = StringUtils.TRUE) boolean acceptFloatAsInt) {
+                                        @Bindable(defaultValue = "LENIENT") CoercionMode coercionMode,
+                                        @Nullable Boolean acceptFloatAsInt,
+                                        @Nullable Boolean acceptStringAsNumber,
+                                        @Nullable Boolean acceptBooleanAsNumber,
+                                        @Nullable Boolean acceptNumberAsBoolean,
+                                        @Nullable Boolean acceptStringAsBoolean,
+                                        @Nullable Boolean acceptScalarAsString,
+                                        @Nullable Boolean unwrapSingleValueArrays) {
         this.ignoreUnknown = ignoreUnknown;
         this.arraySizeThreshold = arraySizeThreshold;
         this.strictNullable = strictNullable;
@@ -79,7 +94,15 @@ final class DefaultDeserializationConfiguration implements DeserializationConfig
         this.adjustDatesToContextTimeZone = adjustDatesToContextTimeZone;
         this.requireAllCreatorParameters = requireAllCreatorParameters;
         this.disableGeneratedDeserializer = disableGeneratedDeserializer;
-        this.acceptFloatAsInt = acceptFloatAsInt;
+        this.coercionMode = coercionMode == null ? CoercionMode.LENIENT : coercionMode;
+        boolean lenient = this.coercionMode != CoercionMode.STRICT;
+        this.acceptFloatAsInt = acceptFloatAsInt == null ? lenient : acceptFloatAsInt;
+        this.acceptStringAsNumber = acceptStringAsNumber == null ? lenient : acceptStringAsNumber;
+        this.acceptBooleanAsNumber = acceptBooleanAsNumber == null ? lenient : acceptBooleanAsNumber;
+        this.acceptNumberAsBoolean = acceptNumberAsBoolean == null ? lenient : acceptNumberAsBoolean;
+        this.acceptStringAsBoolean = acceptStringAsBoolean == null ? lenient : acceptStringAsBoolean;
+        this.acceptScalarAsString = acceptScalarAsString == null ? lenient : acceptScalarAsString;
+        this.unwrapSingleValueArrays = unwrapSingleValueArrays == null ? lenient : unwrapSingleValueArrays;
         this.features = DeserializationConfiguration.super.features();
     }
 
@@ -114,8 +137,43 @@ final class DefaultDeserializationConfiguration implements DeserializationConfig
     }
 
     @Override
+    public CoercionMode getCoercionMode() {
+        return coercionMode;
+    }
+
+    @Override
     public boolean isAcceptFloatAsInt() {
         return acceptFloatAsInt;
+    }
+
+    @Override
+    public boolean isAcceptStringAsNumber() {
+        return acceptStringAsNumber;
+    }
+
+    @Override
+    public boolean isAcceptBooleanAsNumber() {
+        return acceptBooleanAsNumber;
+    }
+
+    @Override
+    public boolean isAcceptNumberAsBoolean() {
+        return acceptNumberAsBoolean;
+    }
+
+    @Override
+    public boolean isAcceptStringAsBoolean() {
+        return acceptStringAsBoolean;
+    }
+
+    @Override
+    public boolean isAcceptScalarAsString() {
+        return acceptScalarAsString;
+    }
+
+    @Override
+    public boolean isUnwrapSingleValueArrays() {
+        return unwrapSingleValueArrays;
     }
 
     @Override

--- a/serde-api/src/main/java/io/micronaut/serde/config/DeserializationConfiguration.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/DeserializationConfiguration.java
@@ -170,6 +170,18 @@ public interface DeserializationConfiguration {
     }
 
     /**
+     * Whether floating-point JSON numbers should be coerced to integer values during
+     * deserialization. Defaults to {@code true} for backwards compatibility.
+     *
+     * @return {@code true} if floating-point values should be accepted as integers
+     * @since 3.2
+     */
+    @Bindable(defaultValue = StringUtils.TRUE)
+    default boolean isAcceptFloatAsInt() {
+        return true;
+    }
+
+    /**
      * Returns the active format features for deserialization.
      *
      * @return The active format features for deserialization.

--- a/serde-api/src/main/java/io/micronaut/serde/config/DeserializationConfiguration.java
+++ b/serde-api/src/main/java/io/micronaut/serde/config/DeserializationConfiguration.java
@@ -170,15 +170,96 @@ public interface DeserializationConfiguration {
     }
 
     /**
-     * Whether floating-point JSON numbers should be coerced to integer values during
-     * deserialization. Defaults to {@code true} for backwards compatibility.
+     * The baseline for the scalar coercions the decoders perform. Defaults to
+     * {@link CoercionMode#LENIENT} for backwards compatibility. Setting this to
+     * {@link CoercionMode#STRICT} turns off every coercion that is not configured explicitly.
+     *
+     * @return The coercion mode
+     * @since 3.2
+     */
+    @Bindable(defaultValue = "LENIENT")
+    default CoercionMode getCoercionMode() {
+        return CoercionMode.LENIENT;
+    }
+
+    /**
+     * Whether floating-point JSON numbers should be read into integer properties, truncating them.
      *
      * @return {@code true} if floating-point values should be accepted as integers
      * @since 3.2
      */
     @Bindable(defaultValue = StringUtils.TRUE)
     default boolean isAcceptFloatAsInt() {
-        return true;
+        return getCoercionMode() != CoercionMode.STRICT;
+    }
+
+    /**
+     * Whether JSON strings should be read into numeric properties.
+     *
+     * @return {@code true} if strings should be accepted as numbers
+     * @since 3.2
+     */
+    @Bindable(defaultValue = StringUtils.TRUE)
+    default boolean isAcceptStringAsNumber() {
+        return getCoercionMode() != CoercionMode.STRICT;
+    }
+
+    /**
+     * Whether JSON booleans should be read into numeric properties, {@code true} as {@code 1} and
+     * {@code false} as {@code 0}.
+     *
+     * @return {@code true} if booleans should be accepted as numbers
+     * @since 3.2
+     */
+    @Bindable(defaultValue = StringUtils.TRUE)
+    default boolean isAcceptBooleanAsNumber() {
+        return getCoercionMode() != CoercionMode.STRICT;
+    }
+
+    /**
+     * Whether JSON numbers should be read into boolean properties, any non-zero value as
+     * {@code true}.
+     *
+     * @return {@code true} if numbers should be accepted as booleans
+     * @since 3.2
+     */
+    @Bindable(defaultValue = StringUtils.TRUE)
+    default boolean isAcceptNumberAsBoolean() {
+        return getCoercionMode() != CoercionMode.STRICT;
+    }
+
+    /**
+     * Whether JSON strings should be read into boolean properties.
+     *
+     * @return {@code true} if strings should be accepted as booleans
+     * @since 3.2
+     */
+    @Bindable(defaultValue = StringUtils.TRUE)
+    default boolean isAcceptStringAsBoolean() {
+        return getCoercionMode() != CoercionMode.STRICT;
+    }
+
+    /**
+     * Whether JSON numbers and booleans should be read into string properties.
+     *
+     * @return {@code true} if other scalars should be accepted as strings
+     * @since 3.2
+     */
+    @Bindable(defaultValue = StringUtils.TRUE)
+    default boolean isAcceptScalarAsString() {
+        return getCoercionMode() != CoercionMode.STRICT;
+    }
+
+    /**
+     * Whether a single element JSON array should be read into a scalar property, unwrapping it.
+     * Note that this is the opposite direction of {@link #acceptSingleValueAsArray()}.
+     *
+     * @return {@code true} if single element arrays should be unwrapped
+     * @since 3.2
+     */
+    @Bindable(defaultValue = StringUtils.TRUE)
+    default boolean isUnwrapSingleValueArrays() {
+        return getCoercionMode() != CoercionMode.STRICT;
     }
 
     /**

--- a/serde-api/src/test/groovy/io/micronaut/serde/DelegatingDecoderCoercionSpec.groovy
+++ b/serde-api/src/test/groovy/io/micronaut/serde/DelegatingDecoderCoercionSpec.groovy
@@ -1,0 +1,39 @@
+package io.micronaut.serde
+
+import io.micronaut.serde.config.CoercionPolicy
+import spock.lang.Specification
+
+class DelegatingDecoderCoercionSpec extends Specification {
+
+    void "the policy of the delegate is used"() {
+        given:
+        def delegate = Stub(Decoder) {
+            getCoercionPolicy() >> CoercionPolicy.STRICT
+        }
+
+        expect:
+        new TestDelegatingDecoder(delegate: delegate).getCoercionPolicy().is(CoercionPolicy.STRICT)
+    }
+
+    void "a delegate that is not available yet falls back to the default"() {
+        expect: 'the caller hits the same failure when it decodes, so this does not rethrow'
+        new TestDelegatingDecoder().getCoercionPolicy().is(CoercionPolicy.LENIENT)
+    }
+
+    static class TestDelegatingDecoder extends DelegatingDecoder {
+        Decoder delegate
+
+        @Override
+        protected Decoder delegate() throws IOException {
+            if (delegate == null) {
+                throw new IOException('not ready')
+            }
+            return delegate
+        }
+
+        @Override
+        IOException createDeserializationException(String message, Object invalidValue) {
+            return new IOException(message)
+        }
+    }
+}

--- a/serde-api/src/test/groovy/io/micronaut/serde/config/CoercionPolicySpec.groovy
+++ b/serde-api/src/test/groovy/io/micronaut/serde/config/CoercionPolicySpec.groovy
@@ -1,0 +1,149 @@
+package io.micronaut.serde.config
+
+import io.micronaut.serde.config.CoercionPolicy.Coercion
+import io.micronaut.serde.config.CoercionPolicy.Shape
+import io.micronaut.serde.config.CoercionPolicy.Target
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class CoercionPolicySpec extends Specification {
+
+    void "the lenient policy allows everything"() {
+        expect:
+        Coercion.values().every { CoercionPolicy.LENIENT.isAllowed(it) }
+    }
+
+    void "the strict policy allows nothing"() {
+        expect:
+        Coercion.values().every { !CoercionPolicy.STRICT.isAllowed(it) }
+    }
+
+    void "a null configuration is lenient"() {
+        expect:
+        CoercionPolicy.fromConfiguration(null).is(CoercionPolicy.LENIENT)
+    }
+
+    void "a fully lenient configuration resolves to the shared lenient instance"() {
+        expect:
+        CoercionPolicy.fromConfiguration(new DeserializationConfiguration() {
+            @Override
+            boolean isIgnoreUnknown() { true }
+
+            @Override
+            int getArraySizeThreshold() { 100 }
+
+            @Override
+            boolean isStrictNullable() { false }
+        }).is(CoercionPolicy.LENIENT)
+    }
+
+    void "a strict configuration resolves to the shared strict instance"() {
+        expect:
+        CoercionPolicy.fromConfiguration(strict()).is(CoercionPolicy.STRICT)
+    }
+
+    void "a mixed configuration resolves to its own instance"() {
+        given:
+        def policy = CoercionPolicy.fromConfiguration(new StrictConfiguration() {
+            @Override
+            boolean isAcceptStringAsNumber() { true }
+        })
+
+        expect:
+        policy.isAllowed(Coercion.STRING_AS_NUMBER)
+        !policy.isAllowed(Coercion.FLOAT_AS_INT)
+        !policy.is(CoercionPolicy.LENIENT)
+        !policy.is(CoercionPolicy.STRICT)
+    }
+
+    void "policies with the same coercions are equal"() {
+        given:
+        def one = CoercionPolicy.fromConfiguration(new StrictConfiguration() {
+            @Override
+            boolean isAcceptStringAsNumber() { true }
+        })
+        def two = CoercionPolicy.fromConfiguration(new StrictConfiguration() {
+            @Override
+            boolean isAcceptStringAsNumber() { true }
+        })
+
+        expect:
+        one == two
+        one.hashCode() == two.hashCode()
+        one != CoercionPolicy.STRICT
+        one != 'not a policy'
+    }
+
+    void "the policy describes itself"() {
+        expect:
+        CoercionPolicy.LENIENT.toString() == 'CoercionPolicy.LENIENT'
+        CoercionPolicy.STRICT.toString() == 'CoercionPolicy.STRICT'
+        CoercionPolicy.fromConfiguration(new StrictConfiguration() {
+            @Override
+            boolean isAcceptStringAsNumber() { true }
+
+            @Override
+            boolean isAcceptScalarAsString() { true }
+        }).toString() == 'CoercionPolicy[STRING_AS_NUMBER, SCALAR_AS_STRING]'
+    }
+
+    @Unroll
+    void "reading a #shape as #target needs #coercion"() {
+        expect:
+        CoercionPolicy.coercion(target, shape) == coercion
+        CoercionPolicy.LENIENT.allowedShapes(target) & shape.bit()
+        (CoercionPolicy.STRICT.allowedShapes(target) & shape.bit()) == (coercion == null ? shape.bit() : 0)
+
+        where:
+        target          | shape                | coercion
+        Target.INTEGER  | Shape.INTEGER_NUMBER | null
+        Target.INTEGER  | Shape.FLOAT_NUMBER   | Coercion.FLOAT_AS_INT
+        Target.INTEGER  | Shape.STRING         | Coercion.STRING_AS_NUMBER
+        Target.INTEGER  | Shape.BOOLEAN        | Coercion.BOOLEAN_AS_NUMBER
+        Target.INTEGER  | Shape.ARRAY          | Coercion.UNWRAP_SINGLE_VALUE_ARRAY
+        Target.INTEGER  | Shape.OTHER          | null
+        Target.DECIMAL  | Shape.INTEGER_NUMBER | null
+        Target.DECIMAL  | Shape.FLOAT_NUMBER   | null
+        Target.DECIMAL  | Shape.STRING         | Coercion.STRING_AS_NUMBER
+        Target.DECIMAL  | Shape.BOOLEAN        | Coercion.BOOLEAN_AS_NUMBER
+        Target.DECIMAL  | Shape.ARRAY          | Coercion.UNWRAP_SINGLE_VALUE_ARRAY
+        Target.BOOLEAN  | Shape.BOOLEAN        | null
+        Target.BOOLEAN  | Shape.INTEGER_NUMBER | Coercion.NUMBER_AS_BOOLEAN
+        Target.BOOLEAN  | Shape.FLOAT_NUMBER   | Coercion.NUMBER_AS_BOOLEAN
+        Target.BOOLEAN  | Shape.STRING         | Coercion.STRING_AS_BOOLEAN
+        Target.BOOLEAN  | Shape.ARRAY          | Coercion.UNWRAP_SINGLE_VALUE_ARRAY
+        Target.STRING   | Shape.STRING         | null
+        Target.STRING   | Shape.INTEGER_NUMBER | Coercion.SCALAR_AS_STRING
+        Target.STRING   | Shape.FLOAT_NUMBER   | Coercion.SCALAR_AS_STRING
+        Target.STRING   | Shape.BOOLEAN        | Coercion.SCALAR_AS_STRING
+        Target.STRING   | Shape.ARRAY          | Coercion.UNWRAP_SINGLE_VALUE_ARRAY
+        Target.CHAR     | Shape.STRING         | null
+        Target.CHAR     | Shape.INTEGER_NUMBER | null
+        Target.CHAR     | Shape.FLOAT_NUMBER   | Coercion.FLOAT_AS_INT
+        Target.CHAR     | Shape.BOOLEAN        | Coercion.BOOLEAN_AS_NUMBER
+        Target.CHAR     | Shape.ARRAY          | Coercion.UNWRAP_SINGLE_VALUE_ARRAY
+    }
+
+    void "every coercion has a message"() {
+        expect:
+        Coercion.values().every { !it.message().isEmpty() }
+    }
+
+    private static DeserializationConfiguration strict() {
+        return new StrictConfiguration()
+    }
+
+    static class StrictConfiguration implements DeserializationConfiguration {
+        @Override
+        boolean isIgnoreUnknown() { true }
+
+        @Override
+        int getArraySizeThreshold() { 100 }
+
+        @Override
+        boolean isStrictNullable() { false }
+
+        @Override
+        CoercionMode getCoercionMode() { CoercionMode.STRICT }
+    }
+}

--- a/serde-api/src/test/groovy/io/micronaut/serde/config/DeserializationConfigurationSpec.groovy
+++ b/serde-api/src/test/groovy/io/micronaut/serde/config/DeserializationConfigurationSpec.groovy
@@ -15,19 +15,65 @@ class DeserializationConfigurationSpec extends Specification {
         deserializationConfiguration.arraySizeThreshold == 100
     }
 
-    void "micronaut.serde.deserialization.accept-float-as-int defaults to true"() {
+    void "coercions are lenient by default"() {
         expect:
+        deserializationConfiguration.coercionMode == CoercionMode.LENIENT
         deserializationConfiguration.isAcceptFloatAsInt()
+        deserializationConfiguration.isAcceptStringAsNumber()
+        deserializationConfiguration.isAcceptBooleanAsNumber()
+        deserializationConfiguration.isAcceptNumberAsBoolean()
+        deserializationConfiguration.isAcceptStringAsBoolean()
+        deserializationConfiguration.isAcceptScalarAsString()
+        deserializationConfiguration.isUnwrapSingleValueArrays()
+        CoercionPolicy.fromConfiguration(deserializationConfiguration) == CoercionPolicy.LENIENT
     }
 
-    void "micronaut.serde.deserialization.accept-float-as-int can be disabled"() {
+    void "a single coercion can be disabled"() {
         given:
         def context = ApplicationContext.run([
                 'micronaut.serde.deserialization.accept-float-as-int': 'false'
         ])
+        def configuration = context.getBean(DeserializationConfiguration)
 
         expect:
-        !context.getBean(DeserializationConfiguration).isAcceptFloatAsInt()
+        !configuration.isAcceptFloatAsInt()
+        configuration.isAcceptStringAsNumber()
+        !CoercionPolicy.fromConfiguration(configuration).isAllowed(CoercionPolicy.Coercion.FLOAT_AS_INT)
+        CoercionPolicy.fromConfiguration(configuration).isAllowed(CoercionPolicy.Coercion.STRING_AS_NUMBER)
+
+        cleanup:
+        context.close()
+    }
+
+    void "the strict mode disables every coercion"() {
+        given:
+        def context = ApplicationContext.run([
+                'micronaut.serde.deserialization.coercion-mode': 'STRICT'
+        ])
+        def configuration = context.getBean(DeserializationConfiguration)
+
+        expect:
+        !configuration.isAcceptFloatAsInt()
+        !configuration.isAcceptStringAsNumber()
+        !configuration.isAcceptScalarAsString()
+        !configuration.isUnwrapSingleValueArrays()
+        CoercionPolicy.fromConfiguration(configuration) == CoercionPolicy.STRICT
+
+        cleanup:
+        context.close()
+    }
+
+    void "an explicit coercion overrides the strict mode"() {
+        given:
+        def context = ApplicationContext.run([
+                'micronaut.serde.deserialization.coercion-mode'      : 'STRICT',
+                'micronaut.serde.deserialization.accept-string-as-number': 'true'
+        ])
+        def configuration = context.getBean(DeserializationConfiguration)
+
+        expect:
+        !configuration.isAcceptFloatAsInt()
+        configuration.isAcceptStringAsNumber()
 
         cleanup:
         context.close()

--- a/serde-api/src/test/groovy/io/micronaut/serde/config/DeserializationConfigurationSpec.groovy
+++ b/serde-api/src/test/groovy/io/micronaut/serde/config/DeserializationConfigurationSpec.groovy
@@ -1,5 +1,6 @@
 package io.micronaut.serde.config
 
+import io.micronaut.context.ApplicationContext
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import spock.lang.Specification

--- a/serde-api/src/test/groovy/io/micronaut/serde/config/DeserializationConfigurationSpec.groovy
+++ b/serde-api/src/test/groovy/io/micronaut/serde/config/DeserializationConfigurationSpec.groovy
@@ -13,4 +13,22 @@ class DeserializationConfigurationSpec extends Specification {
         expect:
         deserializationConfiguration.arraySizeThreshold == 100
     }
+
+    void "micronaut.serde.deserialization.accept-float-as-int defaults to true"() {
+        expect:
+        deserializationConfiguration.isAcceptFloatAsInt()
+    }
+
+    void "micronaut.serde.deserialization.accept-float-as-int can be disabled"() {
+        given:
+        def context = ApplicationContext.run([
+                'micronaut.serde.deserialization.accept-float-as-int': 'false'
+        ])
+
+        expect:
+        !context.getBean(DeserializationConfiguration).isAcceptFloatAsInt()
+
+        cleanup:
+        context.close()
+    }
 }

--- a/serde-bson/src/main/java/io/micronaut/serde/bson/AbstractBsonMapper.java
+++ b/serde-bson/src/main/java/io/micronaut/serde/bson/AbstractBsonMapper.java
@@ -25,6 +25,7 @@ import io.micronaut.serde.LimitingStream;
 import io.micronaut.serde.ObjectMapper;
 import io.micronaut.serde.SerdeRegistry;
 import io.micronaut.serde.Serializer;
+import io.micronaut.serde.config.CoercionPolicy;
 import io.micronaut.serde.config.SerdeConfiguration;
 import io.micronaut.serde.support.util.BufferingJsonNodeProcessor;
 import io.micronaut.serde.support.util.JsonNodeDecoder;
@@ -55,6 +56,7 @@ public abstract class AbstractBsonMapper implements ObjectMapper {
     protected final Class<?> view;
     protected Serializer.EncoderContext encoderContext;
     protected Deserializer.DecoderContext decoderContext;
+    private final CoercionPolicy coercionPolicy;
 
     public AbstractBsonMapper(SerdeRegistry registry, @Nullable SerdeConfiguration serdeConfiguration) {
         this(registry, serdeConfiguration, null);
@@ -66,6 +68,7 @@ public abstract class AbstractBsonMapper implements ObjectMapper {
         this.view = view;
         this.encoderContext = registry.newEncoderContext(view);
         this.decoderContext = registry.newDecoderContext(view);
+        this.coercionPolicy = CoercionPolicy.fromConfiguration(this.decoderContext.getDeserializationConfiguration().orElse(null));
     }
 
     @Override
@@ -114,7 +117,7 @@ public abstract class AbstractBsonMapper implements ObjectMapper {
     @Override
     public <T> @Nullable T readValueFromTree(JsonNode tree, Argument<T> type) throws IOException {
         final Deserializer<? extends T> deserializer = this.decoderContext.findDeserializer(type).createSpecific(decoderContext, type);
-        return deserializer.deserialize(JsonNodeDecoder.create(tree, limits()), decoderContext, type);
+        return deserializer.deserialize(JsonNodeDecoder.create(tree, limits(), coercionPolicy), decoderContext, type);
     }
 
     @Override
@@ -136,7 +139,7 @@ public abstract class AbstractBsonMapper implements ObjectMapper {
     private <T> @Nullable T readValue(BsonReader bsonReader, Argument<T> type) throws IOException {
         return decoderContext.findDeserializer(type)
             .createSpecific(decoderContext, type)
-            .deserialize(new BsonReaderDecoder(bsonReader, limits()), decoderContext, type);
+            .deserialize(new BsonReaderDecoder(bsonReader, limits(), coercionPolicy), decoderContext, type);
     }
 
     @Override
@@ -146,7 +149,7 @@ public abstract class AbstractBsonMapper implements ObjectMapper {
             @Override
             protected JsonNode parseOne(InputStream is) throws IOException {
                 try (BsonReader bsonReader = createBsonReader(toByteBuffer(is))) {
-                    final BsonReaderDecoder decoder = new BsonReaderDecoder(bsonReader, limits());
+                    final BsonReaderDecoder decoder = new BsonReaderDecoder(bsonReader, limits(), coercionPolicy);
                     final Object o = decoder.decodeArbitrary();
                     return writeValueToTree(o);
                 }
@@ -155,7 +158,7 @@ public abstract class AbstractBsonMapper implements ObjectMapper {
             @Override
             protected JsonNode parseOne(byte[] remaining) throws IOException {
                 try (BsonReader bsonReader = createBsonReader(ByteBuffer.wrap(remaining))) {
-                    final BsonReaderDecoder decoder = new BsonReaderDecoder(bsonReader, limits());
+                    final BsonReaderDecoder decoder = new BsonReaderDecoder(bsonReader, limits(), coercionPolicy);
                     final Object o = decoder.decodeArbitrary();
                     return writeValueToTree(o);
                 }

--- a/serde-bson/src/main/java/io/micronaut/serde/bson/AbstractBsonMapper.java
+++ b/serde-bson/src/main/java/io/micronaut/serde/bson/AbstractBsonMapper.java
@@ -58,7 +58,7 @@ public abstract class AbstractBsonMapper implements ObjectMapper {
     protected Deserializer.DecoderContext decoderContext;
     private final CoercionPolicy coercionPolicy;
 
-    public AbstractBsonMapper(SerdeRegistry registry, @Nullable SerdeConfiguration serdeConfiguration) {
+    protected AbstractBsonMapper(SerdeRegistry registry, @Nullable SerdeConfiguration serdeConfiguration) {
         this(registry, serdeConfiguration, null);
     }
 

--- a/serde-bson/src/main/java/io/micronaut/serde/bson/BsonReaderDecoder.java
+++ b/serde-bson/src/main/java/io/micronaut/serde/bson/BsonReaderDecoder.java
@@ -17,6 +17,7 @@ package io.micronaut.serde.bson;
 
 import io.micronaut.core.annotation.Internal;
 import io.micronaut.serde.Decoder;
+import io.micronaut.serde.config.CoercionPolicy;
 import io.micronaut.serde.Keys;
 import io.micronaut.serde.KeysAwareDecoder;
 import io.micronaut.serde.exceptions.SerdeException;
@@ -60,7 +61,11 @@ public final class BsonReaderDecoder extends AbstractDecoderPerStructureStreamDe
     private String pendingUnknownKey;
 
     public BsonReaderDecoder(BsonReader bsonReader, RemainingLimits remainingLimits) {
-        super(remainingLimits);
+        this(bsonReader, remainingLimits, CoercionPolicy.LENIENT);
+    }
+
+    public BsonReaderDecoder(BsonReader bsonReader, RemainingLimits remainingLimits, CoercionPolicy coercionPolicy) {
+        super(remainingLimits, coercionPolicy);
         this.bsonReader = bsonReader;
         this.contextStack = new ArrayDeque<>();
         BsonType currentBsonType = bsonReader.getCurrentBsonType();
@@ -365,6 +370,11 @@ public final class BsonReaderDecoder extends AbstractDecoderPerStructureStreamDe
     @Override
     protected boolean getBoolean() {
         return bsonReader.readBoolean();
+    }
+
+    @Override
+    protected boolean isCurrentNumberFloat() {
+        return currentBsonType == BsonType.DOUBLE || currentBsonType == BsonType.DECIMAL128;
     }
 
     @Override

--- a/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonCoercionPolicySpec.groovy
+++ b/serde-bson/src/test/groovy/io/micronaut/serde/bson/BsonCoercionPolicySpec.groovy
@@ -1,0 +1,67 @@
+package io.micronaut.serde.bson
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.serde.annotation.Serdeable
+import io.micronaut.serde.exceptions.SerdeException
+import org.bson.BsonDocument
+import org.bson.BsonBinaryWriter
+import org.bson.io.BasicOutputBuffer
+import org.bson.codecs.BsonDocumentCodec
+import org.bson.codecs.EncoderContext
+import spock.lang.Specification
+
+class BsonCoercionPolicySpec extends Specification {
+
+    private static byte[] bson(String json) {
+        def buffer = new BasicOutputBuffer()
+        def writer = new BsonBinaryWriter(buffer)
+        new BsonDocumentCodec().encode(writer, BsonDocument.parse(json), EncoderContext.builder().build())
+        writer.flush()
+        return buffer.toByteArray()
+    }
+
+    def 'the bson decoder honours the strict mode'() {
+        given:
+        def ctx = ApplicationContext.run(['micronaut.serde.deserialization.coercion-mode': 'STRICT'])
+        def mapper = ctx.getBean(BsonBinaryMapper)
+
+        when: 'a bson double read into an integer property'
+        mapper.readValue(bson('{"number": 42.5}'), Plain)
+
+        then:
+        thrown SerdeException
+
+        when: 'a bson string read into an integer property'
+        mapper.readValue(bson('{"number": "42"}'), Plain)
+
+        then:
+        thrown SerdeException
+
+        and: 'well shaped values still read'
+        mapper.readValue(bson('{"number": 42}'), Plain).number == 42
+        mapper.readValue(bson('{"text": "a"}'), Plain).text == 'a'
+
+        cleanup:
+        ctx.close()
+    }
+
+    def 'the default configuration is unchanged'() {
+        given:
+        def ctx = ApplicationContext.run()
+        def mapper = ctx.getBean(BsonBinaryMapper)
+
+        expect:
+        mapper.readValue(bson('{"number": 42.5}'), Plain).number == 42
+        mapper.readValue(bson('{"number": "42"}'), Plain).number == 42
+        mapper.readValue(bson('{"text": 1234}'), Plain).text == '1234'
+
+        cleanup:
+        ctx.close()
+    }
+
+    @Serdeable
+    static class Plain {
+        Integer number
+        String text
+    }
+}

--- a/serde-jackson-cbor/src/main/java/io/micronaut/serde/cbor/CborObjectMapper.java
+++ b/serde-jackson-cbor/src/main/java/io/micronaut/serde/cbor/CborObjectMapper.java
@@ -33,6 +33,7 @@ import io.micronaut.serde.SerdeRegistry;
 import io.micronaut.serde.Serializer;
 import io.micronaut.serde.UpdatingDeserializer;
 import io.micronaut.serde.config.DeserializationConfiguration;
+import io.micronaut.serde.config.CoercionPolicy;
 import io.micronaut.serde.config.SerdeConfiguration;
 import io.micronaut.serde.config.SerializationConfiguration;
 import io.micronaut.serde.jackson.JacksonDecoder;
@@ -85,6 +86,7 @@ public final class CborObjectMapper implements ObjectMapper {
     private final SerdeCborConfiguration cborConfiguration;
     private final CBORFactory cborFactory;
     private final LimitingStream.RemainingLimits streamLimits;
+    private final CoercionPolicy coercionPolicy;
     @Nullable
     private final Class<?> view;
     private final Serializer.EncoderContext encoderContext;
@@ -136,6 +138,7 @@ public final class CborObjectMapper implements ObjectMapper {
         // the factory is thread-safe and configuration-derived, so clones share it
         this.cborFactory = cborFactory;
         this.streamLimits = LimitingStream.limitsFromConfiguration(serdeConfiguration);
+        this.coercionPolicy = CoercionPolicy.fromConfiguration(this.decoderContext.getDeserializationConfiguration().orElse(null));
         this.specificType = specificType;
         this.specificDeserializer = specificDeserializer;
         this.specificSerializer = specificSerializer;
@@ -310,7 +313,7 @@ public final class CborObjectMapper implements ObjectMapper {
             }
             deserializer = decoderContext.findDeserializer(type).createSpecific(decoderContext, (Argument) type);
         }
-        final Decoder decoder = JacksonDecoder.create(parser, streamLimits);
+        final Decoder decoder = JacksonDecoder.create(parser, streamLimits, coercionPolicy);
         return (T) deserializer.deserializeNullable(decoder, decoderContext, type);
     }
 
@@ -327,7 +330,7 @@ public final class CborObjectMapper implements ObjectMapper {
             }
             deserializer = decoderContext.findDeserializer(type).createSpecific(decoderContext, type);
         }
-        return (T) deserializer.deserializeNullable(JsonNodeDecoder.create(tree, streamLimits), decoderContext, type);
+        return (T) deserializer.deserializeNullable(JsonNodeDecoder.create(tree, streamLimits, coercionPolicy), decoderContext, type);
     }
 
     @Override
@@ -456,14 +459,14 @@ public final class CborObjectMapper implements ObjectMapper {
             @Override
             protected JsonNode parseOne(InputStream is) throws IOException {
                 try (JsonParser parser = cborFactory.createParser(is)) {
-                    return JacksonDecoder.create(parser, streamLimits).decodeNode();
+                    return JacksonDecoder.create(parser, streamLimits, coercionPolicy).decodeNode();
                 }
             }
 
             @Override
             protected JsonNode parseOne(byte[] remaining) throws IOException {
                 try (JsonParser parser = cborFactory.createParser(remaining)) {
-                    return JacksonDecoder.create(parser, streamLimits).decodeNode();
+                    return JacksonDecoder.create(parser, streamLimits, coercionPolicy).decodeNode();
                 }
             }
         };
@@ -533,7 +536,7 @@ public final class CborObjectMapper implements ObjectMapper {
     private <T> T updateValueFromNode(T value, Argument<T> type, JsonNode tree) throws IOException {
         // for jackson compat we need to support deserializing null, but most deserializers don't support it.
         if (!tree.isNull()) {
-            updateValue(JsonNodeDecoder.create(tree, streamLimits), value, type);
+            updateValue(JsonNodeDecoder.create(tree, streamLimits, coercionPolicy), value, type);
         }
         return value;
     }
@@ -544,7 +547,7 @@ public final class CborObjectMapper implements ObjectMapper {
         }
         // for jackson compat we need to support deserializing null, but most deserializers don't support it.
         if (parser.currentToken() != JsonToken.VALUE_NULL) {
-            updateValue(JacksonDecoder.create(parser, streamLimits), value, type);
+            updateValue(JacksonDecoder.create(parser, streamLimits, coercionPolicy), value, type);
         }
         return value;
     }

--- a/serde-jackson-cbor/src/test/groovy/io/micronaut/serde/cbor/CborCoercionPolicySpec.groovy
+++ b/serde-jackson-cbor/src/test/groovy/io/micronaut/serde/cbor/CborCoercionPolicySpec.groovy
@@ -1,0 +1,139 @@
+package io.micronaut.serde.cbor
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.type.Argument
+import io.micronaut.json.tree.JsonNode
+import io.micronaut.serde.annotation.Serdeable
+import io.micronaut.serde.exceptions.SerdeException
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * The coercion configuration is format independent, so CBOR has to honour it on every path that
+ * creates a decoder.
+ */
+class CborCoercionPolicySpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext strictContext = ApplicationContext.run(['micronaut.serde.deserialization.coercion-mode': 'STRICT'])
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext lenientContext = ApplicationContext.run()
+
+    private CborObjectMapper strict() {
+        strictContext.getBean(CborObjectMapper)
+    }
+
+    private CborObjectMapper lenient() {
+        lenientContext.getBean(CborObjectMapper)
+    }
+
+    private static final JsonNode FLOAT_TREE = JsonNode.from([number: 42.5d])
+
+    private byte[] floatBytes(CborObjectMapper mapper) {
+        mapper.writeValueAsBytes(Argument.of(JsonNode), FLOAT_TREE)
+    }
+
+    void "reading bytes honours the policy"() {
+        given:
+        byte[] bytes = floatBytes(lenient())
+
+        expect:
+        lenient().readValue(bytes, Argument.of(Plain)).number == 42
+
+        when:
+        strict().readValue(bytes, Argument.of(Plain))
+
+        then:
+        thrown SerdeException
+    }
+
+    void "reading an input stream honours the policy"() {
+        given:
+        byte[] bytes = floatBytes(lenient())
+
+        expect:
+        lenient().readValue(new ByteArrayInputStream(bytes), Argument.of(Plain)).number == 42
+
+        when:
+        strict().readValue(new ByteArrayInputStream(bytes), Argument.of(Plain))
+
+        then:
+        thrown SerdeException
+    }
+
+    void "reading a tree honours the policy"() {
+        expect:
+        lenient().readValueFromTree(FLOAT_TREE, Argument.of(Plain)).number == 42
+
+        when:
+        strict().readValueFromTree(FLOAT_TREE, Argument.of(Plain))
+
+        then:
+        thrown SerdeException
+    }
+
+    void "a specific mapper honours the policy"() {
+        given:
+        byte[] bytes = floatBytes(lenient())
+
+        expect:
+        lenient().createSpecific(Argument.of(Plain)).readValue(bytes, Argument.of(Plain)).number == 42
+
+        when:
+        strict().createSpecific(Argument.of(Plain)).readValue(bytes, Argument.of(Plain))
+
+        then:
+        thrown SerdeException
+    }
+
+    void "updating from bytes honours the policy"() {
+        given:
+        byte[] bytes = floatBytes(lenient())
+
+        when:
+        def target = new Plain(number: 1)
+        lenient().updateValue(target, Argument.of(Plain), bytes)
+
+        then:
+        target.number == 42
+
+        when:
+        strict().updateValue(new Plain(number: 1), Argument.of(Plain), bytes)
+
+        then:
+        thrown SerdeException
+    }
+
+    void "updating from a tree honours the policy"() {
+        when:
+        def target = new Plain(number: 1)
+        lenient().updateValueFromTree(target, FLOAT_TREE)
+
+        then:
+        target.number == 42
+
+        when:
+        strict().updateValueFromTree(new Plain(number: 1), FLOAT_TREE)
+
+        then:
+        thrown SerdeException
+    }
+
+    void "well shaped values still read under the strict policy"() {
+        given:
+        byte[] bytes = lenient().writeValueAsBytes(Argument.of(JsonNode), JsonNode.from([number: 42]))
+
+        expect:
+        strict().readValue(bytes, Argument.of(Plain)).number == 42
+        strict().readValueFromTree(JsonNode.from([number: 42]), Argument.of(Plain)).number == 42
+    }
+
+    @Serdeable
+    static class Plain {
+        Integer number
+    }
+}

--- a/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonDecoder.java
+++ b/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonDecoder.java
@@ -627,6 +627,16 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             case VALUE_NUMBER_INT -> {
                 return (char) parser.getIntValue();
             }
+            case VALUE_NUMBER_FLOAT -> {
+                // a float is truncated to its code point, as the other decoders do
+                return (char) parser.getValueAsInt();
+            }
+            case VALUE_TRUE -> {
+                return (char) 1;
+            }
+            case VALUE_FALSE -> {
+                return (char) 0;
+            }
             case VALUE_NULL -> {
                 return null;
             }
@@ -663,6 +673,10 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
                 yield string.charAt(0);
             }
             case VALUE_NUMBER_INT -> (char) parser.getIntValue();
+            // a float is truncated to its code point, as the other decoders do
+            case VALUE_NUMBER_FLOAT -> (char) parser.getValueAsInt();
+            case VALUE_TRUE -> (char) 1;
+            case VALUE_FALSE -> (char) 0;
             case VALUE_NULL -> throw unexpectedNullToken(JsonToken.VALUE_NUMBER_INT, t);
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
             default -> {

--- a/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonDecoder.java
+++ b/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonDecoder.java
@@ -23,6 +23,10 @@ import io.micronaut.serde.Keys;
 import io.micronaut.serde.KeysAwareDecoder;
 import io.micronaut.serde.KeysSupport;
 import io.micronaut.serde.LimitingStream;
+import io.micronaut.serde.config.CoercionPolicy;
+import io.micronaut.serde.config.CoercionPolicy.Coercion;
+import io.micronaut.serde.config.CoercionPolicy.Shape;
+import io.micronaut.serde.config.CoercionPolicy.Target;
 import io.micronaut.serde.exceptions.InvalidFormatException;
 import io.micronaut.serde.exceptions.NullValueSerdeException;
 import io.micronaut.serde.exceptions.SerdeException;
@@ -61,6 +65,11 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
      * encountered, we enter the slow parse path.
      */
     private static final long LONG_CANARY = 0xff1234567890abcdL;
+    /**
+     * The {@link Shape} of every {@link JsonToken}, as a bit, so that a coercion check is a single
+     * mask test against the shapes the policy precalculated.
+     */
+    private static final int[] TOKEN_SHAPE_BITS = tokenShapeBits();
     private static final int JACKSON_KEYS_INDEX = KeysSupport.indexOf(new JacksonKeysProvider());
     private static final Object[] EMPTY_JACKSON_KEYS = new JacksonKeysProvider().create(List.of(), false);
     private static final SerializableString[] EMPTY_SERIALIZABLE_KEYS =
@@ -70,7 +79,12 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
 
     @Internal
     private final JsonParser parser;
-    private final boolean acceptFloatAsInt;
+    private final CoercionPolicy coercionPolicy;
+    private final int integerShapes;
+    private final int decimalShapes;
+    private final int booleanShapes;
+    private final int stringShapes;
+    private final int charShapes;
 
     @Nullable
     private JsonToken peekedToken;
@@ -82,10 +96,15 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
     private int sequentialKeyIndex;
     private boolean currentlyUnwrappingArray;
 
-    private JacksonDecoder(JsonParser parser, RemainingLimits remainingLimits, boolean acceptFloatAsInt) throws IOException {
+    private JacksonDecoder(JsonParser parser, RemainingLimits remainingLimits, CoercionPolicy coercionPolicy) throws IOException {
         super(remainingLimits);
         this.parser = parser;
-        this.acceptFloatAsInt = acceptFloatAsInt;
+        this.coercionPolicy = coercionPolicy;
+        this.integerShapes = coercionPolicy.allowedShapes(Target.INTEGER);
+        this.decimalShapes = coercionPolicy.allowedShapes(Target.DECIMAL);
+        this.booleanShapes = coercionPolicy.allowedShapes(Target.BOOLEAN);
+        this.stringShapes = coercionPolicy.allowedShapes(Target.STRING);
+        this.charShapes = coercionPolicy.allowedShapes(Target.CHAR);
         if (!parser.hasCurrentToken()) {
             peekedToken = parser.nextToken();
             if (!parser.hasCurrentToken()) {
@@ -97,20 +116,25 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
     }
 
     public static Decoder create(JsonParser parser, RemainingLimits remainingLimits) throws IOException {
-        return new JacksonDecoder(parser, remainingLimits, true);
+        return new JacksonDecoder(parser, remainingLimits, CoercionPolicy.LENIENT);
     }
 
     /**
-     * Create a decoder with configurable floating-point to integer coercion.
+     * Create a decoder that only performs the coercions the given policy allows.
      *
-     * @param parser The Jackson parser
+     * @param parser          The Jackson parser
      * @param remainingLimits The remaining stream limits
-     * @param acceptFloatAsInt Whether floating-point values should be coerced to integers
+     * @param coercionPolicy  The coercions this decoder may perform
      * @return The decoder
      * @throws IOException If the parser cannot be initialized
      */
-    public static Decoder create(JsonParser parser, RemainingLimits remainingLimits, boolean acceptFloatAsInt) throws IOException {
-        return new JacksonDecoder(parser, remainingLimits, acceptFloatAsInt);
+    public static Decoder create(JsonParser parser, RemainingLimits remainingLimits, CoercionPolicy coercionPolicy) throws IOException {
+        return new JacksonDecoder(parser, remainingLimits, coercionPolicy);
+    }
+
+    @Override
+    public CoercionPolicy getCoercionPolicy() {
+        return coercionPolicy;
     }
 
     @Override
@@ -343,6 +367,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
                 return parser.getText();
             }
         }
+        checkStringSource(t);
         switch (t) {
             case START_ARRAY -> {
                 if (beginUnwrapArray(t)) {
@@ -394,6 +419,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
         } else {
             t = nextToken();
         }
+        checkBooleanSource(t);
         switch (t) {
             case VALUE_TRUE -> {
                 return true;
@@ -426,6 +452,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
     }
 
     private boolean decodeBooleanValue(JsonToken t) throws IOException {
+        checkBooleanSource(t);
         return switch (t) {
             case VALUE_TRUE -> true;
             case VALUE_FALSE -> false;
@@ -456,6 +483,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
     @Override
     public Byte decodeByteNullable() throws IOException {
         JsonToken t = nextToken();
+        checkIntegerSource(t);
         switch (t) {
             case VALUE_TRUE -> {
                 return 1;
@@ -479,13 +507,13 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             }
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
             default -> {
-                ensureFloatAsIntAllowed(t);
                 return parser.getByteValue();
             }
         }
     }
 
     private byte decodeByteValue(JsonToken t) throws IOException {
+        checkIntegerSource(t);
         return switch (t) {
             case VALUE_TRUE -> 1;
             case VALUE_FALSE -> 0;
@@ -503,7 +531,6 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             case VALUE_NULL -> throw unexpectedNullToken(JsonToken.VALUE_NUMBER_INT, t);
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
             default -> {
-                ensureFloatAsIntAllowed(t);
                 yield parser.getByteValue();
             }
         };
@@ -518,6 +545,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
     @Override
     public Short decodeShortNullable() throws IOException {
         JsonToken t = nextToken();
+        checkIntegerSource(t);
         switch (t) {
             case VALUE_TRUE -> {
                 return 1;
@@ -541,13 +569,13 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             }
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
             default -> {
-                ensureFloatAsIntAllowed(t);
                 return parser.getShortValue();
             }
         }
     }
 
     private short decodeShortValue(JsonToken t) throws IOException {
+        checkIntegerSource(t);
         return switch (t) {
             case VALUE_TRUE -> 1;
             case VALUE_FALSE -> 0;
@@ -565,7 +593,6 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             case VALUE_NULL -> throw unexpectedNullToken(JsonToken.VALUE_NUMBER_INT, t);
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
             default -> {
-                ensureFloatAsIntAllowed(t);
                 yield parser.getShortValue();
             }
         };
@@ -580,6 +607,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
     @Override
     public Character decodeCharNullable() throws IOException {
         JsonToken t = nextToken();
+        checkCharSource(t);
         switch (t) {
             case START_ARRAY -> {
                 if (beginUnwrapArray(t)) {
@@ -617,6 +645,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
     }
 
     private char decodeCharValue(JsonToken t) throws IOException {
+        checkCharSource(t);
         return switch (t) {
             case START_ARRAY -> {
                 if (beginUnwrapArray(t)) {
@@ -676,6 +705,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
     @Nullable
     private Integer decodeIntSlow() throws IOException {
         JsonToken t = peekedToken == null ? parser.currentToken() : nextToken();
+        checkIntegerSource(t);
         switch (t) {
             case VALUE_NUMBER_INT -> {
                 return parser.getIntValue();
@@ -710,13 +740,13 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             }
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
             default -> {
-                ensureFloatAsIntAllowed(t);
                 return parser.getValueAsInt();
             }
         }
     }
 
     private int decodeIntValue(JsonToken t) throws IOException {
+        checkIntegerSource(t);
         return switch (t) {
             case VALUE_NUMBER_INT -> parser.getIntValue();
             case VALUE_STRING -> {
@@ -743,7 +773,6 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             case VALUE_NULL -> throw unexpectedNullToken(JsonToken.VALUE_NUMBER_INT, t);
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
             default -> {
-                ensureFloatAsIntAllowed(t);
                 yield parser.getValueAsInt();
             }
         };
@@ -780,6 +809,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
         } else {
             t = nextToken();
         }
+        checkIntegerSource(t);
         switch (t) {
             case VALUE_NUMBER_INT -> {
                 return parser.getLongValue();
@@ -816,13 +846,13 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             }
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
             default -> {
-                ensureFloatAsIntAllowed(t);
                 return parser.getValueAsLong();
             }
         }
     }
 
     private long decodeLongValue(JsonToken t) throws IOException {
+        checkIntegerSource(t);
         return switch (t) {
             case VALUE_NUMBER_INT -> parser.getLongValue();
             case VALUE_STRING -> {
@@ -849,7 +879,6 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             case VALUE_NULL -> throw unexpectedNullToken(JsonToken.VALUE_NUMBER_INT, t);
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
             default -> {
-                ensureFloatAsIntAllowed(t);
                 yield parser.getValueAsLong();
             }
         };
@@ -864,6 +893,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
     @Override
     public Float decodeFloatNullable() throws IOException {
         JsonToken t = nextToken();
+        checkDecimalSource(t);
         switch (t) {
             case VALUE_STRING -> {
                 String string = parser.getText();
@@ -903,6 +933,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
     }
 
     private float decodeFloatValue(JsonToken t) throws IOException {
+        checkDecimalSource(t);
         return switch (t) {
             case VALUE_STRING -> {
                 String string = parser.getText();
@@ -952,6 +983,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
 
     @Nullable
     private Double decodeDoubleSlow(JsonToken t) throws IOException {
+        checkDecimalSource(t);
         switch (t) {
             case VALUE_NUMBER_INT, VALUE_NUMBER_FLOAT -> {
                 return parser.getDoubleValue();
@@ -992,6 +1024,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
     }
 
     private double decodeDoubleValue(JsonToken t) throws IOException {
+        checkDecimalSource(t);
         return switch (t) {
             case VALUE_NUMBER_INT, VALUE_NUMBER_FLOAT -> parser.getDoubleValue();
             case VALUE_STRING -> {
@@ -1034,6 +1067,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
     @Override
     public BigInteger decodeBigIntegerNullable() throws IOException {
         JsonToken t = nextToken();
+        checkIntegerSource(t);
         switch (t) {
             case VALUE_STRING -> {
                 String string = parser.getText();
@@ -1065,7 +1099,6 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             }
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
             default -> {
-                ensureFloatAsIntAllowed(t);
                 return parser.getBigIntegerValue();
             }
         }
@@ -1084,6 +1117,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
     @Override
     public BigDecimal decodeBigDecimalNullable() throws IOException {
         JsonToken t = nextToken();
+        checkDecimalSource(t);
         switch (t) {
             case VALUE_STRING -> {
                 String string = parser.getText();
@@ -1253,7 +1287,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
     @Override
     public Decoder decodeBuffer() throws IOException {
         JsonNode node = decodeNode();
-        return JsonNodeDecoder.create(node, ourLimits());
+        return JsonNodeDecoder.create(node, ourLimits(), coercionPolicy);
     }
 
     @Override
@@ -1340,10 +1374,68 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
         parser.skipChildren();
     }
 
-    private void ensureFloatAsIntAllowed(JsonToken token) throws IOException {
-        if (!acceptFloatAsInt && token == JsonToken.VALUE_NUMBER_FLOAT) {
-            throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, token);
+    private static int[] tokenShapeBits() {
+        JsonToken[] tokens = JsonToken.values();
+        int[] bits = new int[tokens.length];
+        for (JsonToken token : tokens) {
+            Shape shape = switch (token) {
+                case VALUE_STRING -> Shape.STRING;
+                case VALUE_NUMBER_INT -> Shape.INTEGER_NUMBER;
+                case VALUE_NUMBER_FLOAT -> Shape.FLOAT_NUMBER;
+                case VALUE_TRUE, VALUE_FALSE -> Shape.BOOLEAN;
+                case START_ARRAY -> Shape.ARRAY;
+                default -> Shape.OTHER;
+            };
+            bits[token.ordinal()] = shape.bit();
         }
+        return bits;
+    }
+
+    private void checkIntegerSource(JsonToken t) throws IOException {
+        if ((integerShapes & TOKEN_SHAPE_BITS[t.ordinal()]) == 0) {
+            throw coercionFailure(Target.INTEGER, t);
+        }
+    }
+
+    private void checkDecimalSource(JsonToken t) throws IOException {
+        if ((decimalShapes & TOKEN_SHAPE_BITS[t.ordinal()]) == 0) {
+            throw coercionFailure(Target.DECIMAL, t);
+        }
+    }
+
+    private void checkBooleanSource(JsonToken t) throws IOException {
+        if ((booleanShapes & TOKEN_SHAPE_BITS[t.ordinal()]) == 0) {
+            throw coercionFailure(Target.BOOLEAN, t);
+        }
+    }
+
+    private void checkStringSource(JsonToken t) throws IOException {
+        if ((stringShapes & TOKEN_SHAPE_BITS[t.ordinal()]) == 0) {
+            throw coercionFailure(Target.STRING, t);
+        }
+    }
+
+    private void checkCharSource(JsonToken t) throws IOException {
+        if ((charShapes & TOKEN_SHAPE_BITS[t.ordinal()]) == 0) {
+            throw coercionFailure(Target.CHAR, t);
+        }
+    }
+
+    private IOException coercionFailure(Target target, JsonToken t) throws IOException {
+        Shape shape = switch (t) {
+            case VALUE_STRING -> Shape.STRING;
+            case VALUE_NUMBER_INT -> Shape.INTEGER_NUMBER;
+            case VALUE_NUMBER_FLOAT -> Shape.FLOAT_NUMBER;
+            case VALUE_TRUE, VALUE_FALSE -> Shape.BOOLEAN;
+            case START_ARRAY -> Shape.ARRAY;
+            default -> Shape.OTHER;
+        };
+        Coercion coercion = CoercionPolicy.coercion(target, shape);
+        if (coercion == null) {
+            // should not happen, OTHER is always allowed
+            throw unexpectedToken(JsonToken.VALUE_STRING, t);
+        }
+        return createDeserializationException(coercion.message(), shape == Shape.ARRAY ? null : parser.getValueAsString());
     }
 
     private abstract static class ArbitraryBuilder {

--- a/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonDecoder.java
+++ b/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonDecoder.java
@@ -47,6 +47,7 @@ import java.util.Base64;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Implementation of the {@link Decoder} interface for Jackson.
@@ -530,9 +531,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             }
             case VALUE_NULL -> throw unexpectedNullToken(JsonToken.VALUE_NUMBER_INT, t);
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
-            default -> {
-                yield parser.getByteValue();
-            }
+            default -> parser.getByteValue();
         };
     }
 
@@ -592,9 +591,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             }
             case VALUE_NULL -> throw unexpectedNullToken(JsonToken.VALUE_NUMBER_INT, t);
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
-            default -> {
-                yield parser.getShortValue();
-            }
+            default -> parser.getShortValue();
         };
     }
 
@@ -772,9 +769,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             case VALUE_TRUE -> 1;
             case VALUE_NULL -> throw unexpectedNullToken(JsonToken.VALUE_NUMBER_INT, t);
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
-            default -> {
-                yield parser.getValueAsInt();
-            }
+            default -> parser.getValueAsInt();
         };
     }
 
@@ -878,9 +873,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             }
             case VALUE_NULL -> throw unexpectedNullToken(JsonToken.VALUE_NUMBER_INT, t);
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
-            default -> {
-                yield parser.getValueAsLong();
-            }
+            default -> parser.getValueAsLong();
         };
     }
 
@@ -1430,11 +1423,8 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             case START_ARRAY -> Shape.ARRAY;
             default -> Shape.OTHER;
         };
-        Coercion coercion = CoercionPolicy.coercion(target, shape);
-        if (coercion == null) {
-            // should not happen, OTHER is always allowed
-            throw unexpectedToken(JsonToken.VALUE_STRING, t);
-        }
+        // a shape that needs no coercion is always allowed, so this one needs one
+        Coercion coercion = Objects.requireNonNull(CoercionPolicy.coercion(target, shape));
         return createDeserializationException(coercion.message(), shape == Shape.ARRAY ? null : parser.getValueAsString());
     }
 

--- a/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonDecoder.java
+++ b/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonDecoder.java
@@ -70,6 +70,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
 
     @Internal
     private final JsonParser parser;
+    private final boolean acceptFloatAsInt;
 
     @Nullable
     private JsonToken peekedToken;
@@ -81,9 +82,10 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
     private int sequentialKeyIndex;
     private boolean currentlyUnwrappingArray;
 
-    private JacksonDecoder(JsonParser parser, RemainingLimits remainingLimits) throws IOException {
+    private JacksonDecoder(JsonParser parser, RemainingLimits remainingLimits, boolean acceptFloatAsInt) throws IOException {
         super(remainingLimits);
         this.parser = parser;
+        this.acceptFloatAsInt = acceptFloatAsInt;
         if (!parser.hasCurrentToken()) {
             peekedToken = parser.nextToken();
             if (!parser.hasCurrentToken()) {
@@ -95,7 +97,20 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
     }
 
     public static Decoder create(JsonParser parser, RemainingLimits remainingLimits) throws IOException {
-        return new JacksonDecoder(parser, remainingLimits);
+        return new JacksonDecoder(parser, remainingLimits, true);
+    }
+
+    /**
+     * Create a decoder with configurable floating-point to integer coercion.
+     *
+     * @param parser The Jackson parser
+     * @param remainingLimits The remaining stream limits
+     * @param acceptFloatAsInt Whether floating-point values should be coerced to integers
+     * @return The decoder
+     * @throws IOException If the parser cannot be initialized
+     */
+    public static Decoder create(JsonParser parser, RemainingLimits remainingLimits, boolean acceptFloatAsInt) throws IOException {
+        return new JacksonDecoder(parser, remainingLimits, acceptFloatAsInt);
     }
 
     @Override
@@ -464,6 +479,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             }
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
             default -> {
+                ensureFloatAsIntAllowed(t);
                 return parser.getByteValue();
             }
         }
@@ -486,7 +502,10 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             }
             case VALUE_NULL -> throw unexpectedNullToken(JsonToken.VALUE_NUMBER_INT, t);
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
-            default -> parser.getByteValue();
+            default -> {
+                ensureFloatAsIntAllowed(t);
+                yield parser.getByteValue();
+            }
         };
     }
 
@@ -522,6 +541,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             }
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
             default -> {
+                ensureFloatAsIntAllowed(t);
                 return parser.getShortValue();
             }
         }
@@ -544,7 +564,10 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             }
             case VALUE_NULL -> throw unexpectedNullToken(JsonToken.VALUE_NUMBER_INT, t);
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
-            default -> parser.getShortValue();
+            default -> {
+                ensureFloatAsIntAllowed(t);
+                yield parser.getShortValue();
+            }
         };
     }
 
@@ -687,6 +710,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             }
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
             default -> {
+                ensureFloatAsIntAllowed(t);
                 return parser.getValueAsInt();
             }
         }
@@ -718,7 +742,10 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             case VALUE_TRUE -> 1;
             case VALUE_NULL -> throw unexpectedNullToken(JsonToken.VALUE_NUMBER_INT, t);
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
-            default -> parser.getValueAsInt();
+            default -> {
+                ensureFloatAsIntAllowed(t);
+                yield parser.getValueAsInt();
+            }
         };
     }
 
@@ -789,6 +816,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             }
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
             default -> {
+                ensureFloatAsIntAllowed(t);
                 return parser.getValueAsLong();
             }
         }
@@ -820,7 +848,10 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             }
             case VALUE_NULL -> throw unexpectedNullToken(JsonToken.VALUE_NUMBER_INT, t);
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
-            default -> parser.getValueAsLong();
+            default -> {
+                ensureFloatAsIntAllowed(t);
+                yield parser.getValueAsLong();
+            }
         };
     }
 
@@ -1034,6 +1065,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
             }
             case START_OBJECT, END_OBJECT, END_ARRAY, PROPERTY_NAME -> throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, t);
             default -> {
+                ensureFloatAsIntAllowed(t);
                 return parser.getBigIntegerValue();
             }
         }
@@ -1306,6 +1338,12 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
     public void skipValue() throws IOException {
         nextToken();
         parser.skipChildren();
+    }
+
+    private void ensureFloatAsIntAllowed(JsonToken token) throws IOException {
+        if (!acceptFloatAsInt && token == JsonToken.VALUE_NUMBER_FLOAT) {
+            throw unexpectedToken(JsonToken.VALUE_NUMBER_INT, token);
+        }
     }
 
     private abstract static class ArbitraryBuilder {

--- a/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonDecoder.java
+++ b/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonDecoder.java
@@ -1414,7 +1414,7 @@ public final class JacksonDecoder extends LimitingStream implements KeysAwareDec
         }
     }
 
-    private IOException coercionFailure(Target target, JsonToken t) throws IOException {
+    private IOException coercionFailure(Target target, JsonToken t) {
         Shape shape = switch (t) {
             case VALUE_STRING -> Shape.STRING;
             case VALUE_NUMBER_INT -> Shape.INTEGER_NUMBER;

--- a/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonJsonMapper.java
+++ b/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonJsonMapper.java
@@ -264,10 +264,7 @@ public final class JacksonJsonMapper implements JacksonObjectMapper {
             }
             deserializer = decoderContext.findDeserializer(type).createSpecific(decoderContext, (Argument) type);
         }
-        boolean acceptFloatAsInt = decoderContext.getDeserializationConfiguration()
-            .map(DeserializationConfiguration::isAcceptFloatAsInt)
-            .orElse(true);
-        final Decoder decoder = JacksonDecoder.create(parser, streamLimits, acceptFloatAsInt);
+        final Decoder decoder = createDecoder(parser, decoderContext);
         return (T) deserializer.deserializeNullable(
             decoder,
             decoderContext,
@@ -506,10 +503,7 @@ public final class JacksonJsonMapper implements JacksonObjectMapper {
         }
         // for jackson compat we need to support deserializing null, but most deserializers don't support it.
         if (parser.currentToken() != JsonToken.VALUE_NULL) {
-            boolean acceptFloatAsInt = decoderContext.getDeserializationConfiguration()
-                .map(DeserializationConfiguration::isAcceptFloatAsInt)
-                .orElse(true);
-            final Decoder decoder = JacksonDecoder.create(parser, streamLimits, acceptFloatAsInt);
+            final Decoder decoder = createDecoder(parser, decoderContext);
             updatingDeserializer.deserializeInto(
                 decoder,
                 decoderContext,
@@ -518,6 +512,13 @@ public final class JacksonJsonMapper implements JacksonObjectMapper {
             );
         }
         return value;
+    }
+
+    private Decoder createDecoder(JsonParser parser, Deserializer.DecoderContext decoderContext) throws IOException {
+        boolean acceptFloatAsInt = decoderContext.getDeserializationConfiguration()
+            .map(DeserializationConfiguration::isAcceptFloatAsInt)
+            .orElse(true);
+        return JacksonDecoder.create(parser, streamLimits, acceptFloatAsInt);
     }
 
     private boolean isSpecificType(Argument<?> type) {

--- a/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonJsonMapper.java
+++ b/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonJsonMapper.java
@@ -37,6 +37,7 @@ import io.micronaut.serde.SerdeIntrospections;
 import io.micronaut.serde.SerdeRegistry;
 import io.micronaut.serde.Serializer;
 import io.micronaut.serde.UpdatingDeserializer;
+import io.micronaut.serde.config.CoercionPolicy;
 import io.micronaut.serde.config.DeserializationConfiguration;
 import io.micronaut.serde.config.SerdeConfiguration;
 import io.micronaut.serde.config.SerializationConfiguration;
@@ -92,6 +93,7 @@ public final class JacksonJsonMapper implements JacksonObjectMapper {
     private final Deserializer.DecoderContext decoderContext;
     private final JsonFactory jsonFactory;
     private final LimitingStream.RemainingLimits streamLimits;
+    private final CoercionPolicy coercionPolicy;
     @Nullable
     private final Argument<?> specificType;
     @Nullable
@@ -123,6 +125,7 @@ public final class JacksonJsonMapper implements JacksonObjectMapper {
         this.jacksonConfiguration = jacksonConfiguration;
         this.jsonFactory = buildJsonFactory(jacksonConfiguration);
         this.streamLimits = LimitingStream.limitsFromConfiguration(serdeConfiguration);
+        this.coercionPolicy = CoercionPolicy.fromConfiguration(this.decoderContext.getDeserializationConfiguration().orElse(null));
         this.specificType = specificType;
         this.specificDeserializer = specificDeserializer;
         this.specificSerializer = serializer;
@@ -264,7 +267,7 @@ public final class JacksonJsonMapper implements JacksonObjectMapper {
             }
             deserializer = decoderContext.findDeserializer(type).createSpecific(decoderContext, (Argument) type);
         }
-        final Decoder decoder = createDecoder(parser, decoderContext);
+        final Decoder decoder = createDecoder(parser);
         return (T) deserializer.deserializeNullable(
             decoder,
             decoderContext,
@@ -503,7 +506,7 @@ public final class JacksonJsonMapper implements JacksonObjectMapper {
         }
         // for jackson compat we need to support deserializing null, but most deserializers don't support it.
         if (parser.currentToken() != JsonToken.VALUE_NULL) {
-            final Decoder decoder = createDecoder(parser, decoderContext);
+            final Decoder decoder = createDecoder(parser);
             updatingDeserializer.deserializeInto(
                 decoder,
                 decoderContext,
@@ -514,11 +517,8 @@ public final class JacksonJsonMapper implements JacksonObjectMapper {
         return value;
     }
 
-    private Decoder createDecoder(JsonParser parser, Deserializer.DecoderContext decoderContext) throws IOException {
-        boolean acceptFloatAsInt = decoderContext.getDeserializationConfiguration()
-            .map(DeserializationConfiguration::isAcceptFloatAsInt)
-            .orElse(true);
-        return JacksonDecoder.create(parser, streamLimits, acceptFloatAsInt);
+    private Decoder createDecoder(JsonParser parser) throws IOException {
+        return JacksonDecoder.create(parser, streamLimits, coercionPolicy);
     }
 
     private boolean isSpecificType(Argument<?> type) {

--- a/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonJsonMapper.java
+++ b/serde-jackson/src/main/java/io/micronaut/serde/jackson/JacksonJsonMapper.java
@@ -264,7 +264,10 @@ public final class JacksonJsonMapper implements JacksonObjectMapper {
             }
             deserializer = decoderContext.findDeserializer(type).createSpecific(decoderContext, (Argument) type);
         }
-        final Decoder decoder = JacksonDecoder.create(parser, streamLimits);
+        boolean acceptFloatAsInt = decoderContext.getDeserializationConfiguration()
+            .map(DeserializationConfiguration::isAcceptFloatAsInt)
+            .orElse(true);
+        final Decoder decoder = JacksonDecoder.create(parser, streamLimits, acceptFloatAsInt);
         return (T) deserializer.deserializeNullable(
             decoder,
             decoderContext,
@@ -503,7 +506,10 @@ public final class JacksonJsonMapper implements JacksonObjectMapper {
         }
         // for jackson compat we need to support deserializing null, but most deserializers don't support it.
         if (parser.currentToken() != JsonToken.VALUE_NULL) {
-            final Decoder decoder = JacksonDecoder.create(parser, streamLimits);
+            boolean acceptFloatAsInt = decoderContext.getDeserializationConfiguration()
+                .map(DeserializationConfiguration::isAcceptFloatAsInt)
+                .orElse(true);
+            final Decoder decoder = JacksonDecoder.create(parser, streamLimits, acceptFloatAsInt);
             updatingDeserializer.deserializeInto(
                 decoder,
                 decoderContext,

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/CoercionPolicySpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/CoercionPolicySpec.groovy
@@ -1,0 +1,243 @@
+package io.micronaut.serde.jackson
+
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import io.micronaut.context.ApplicationContext
+import io.micronaut.serde.Decoder
+import io.micronaut.serde.LimitingStream
+import io.micronaut.serde.ObjectMapper
+import io.micronaut.serde.annotation.Serdeable
+import io.micronaut.serde.config.CoercionPolicy
+import io.micronaut.serde.config.DeserializationConfiguration
+import io.micronaut.serde.exceptions.SerdeException
+import org.intellij.lang.annotations.Language
+import spock.lang.Specification
+import spock.lang.Unroll
+import tools.jackson.core.json.JsonFactoryBuilder
+
+class CoercionPolicySpec extends Specification {
+
+    private static Decoder createDecoder(@Language('json') String json, CoercionPolicy policy) {
+        return JacksonDecoder.create(new JsonFactoryBuilder().build().createParser(json), LimitingStream.DEFAULT_LIMITS, policy)
+    }
+
+    @Unroll
+    def 'strict rejects #json read as #method'() {
+        when:
+        createDecoder(json, CoercionPolicy.STRICT)."$method"()
+
+        then:
+        thrown SerdeException
+
+        when: 'the same input is lenient'
+        def lenient = createDecoder(json, CoercionPolicy.LENIENT)."$method"()
+
+        then:
+        lenient == coerced
+
+        where:
+        json      | method            || coerced
+        '42.5'    | 'decodeInt'       || 42
+        '42.5'    | 'decodeLong'      || 42L
+        '42.5'    | 'decodeByte'      || (byte) 42
+        '42.5'    | 'decodeShort'     || (short) 42
+        '42.5'    | 'decodeBigInteger'|| BigInteger.valueOf(42)
+        '"42"'    | 'decodeInt'       || 42
+        '"42"'    | 'decodeLong'      || 42L
+        '"42.5"'  | 'decodeDouble'    || 42.5d
+        '"42.5"'  | 'decodeBigDecimal'|| new BigDecimal('42.5')
+        'true'    | 'decodeInt'       || 1
+        'true'    | 'decodeDouble'    || 1d
+        'true'    | 'decodeBigInteger'|| BigInteger.ONE
+        '1'       | 'decodeBoolean'   || true
+        '0.1'     | 'decodeBoolean'   || true
+        '"true"'  | 'decodeBoolean'   || true
+        '1234'    | 'decodeString'    || '1234'
+        'true'    | 'decodeString'    || 'true'
+        '[42]'    | 'decodeInt'       || 42
+        '["a"]'   | 'decodeString'    || 'a'
+        '[true]'  | 'decodeBoolean'   || true
+    }
+
+    def 'values of the right shape are untouched by the strict policy'() {
+        expect:
+        createDecoder('42', CoercionPolicy.STRICT).decodeInt() == 42
+        createDecoder('42', CoercionPolicy.STRICT).decodeLong() == 42L
+        createDecoder('42', CoercionPolicy.STRICT).decodeDouble() == 42d
+        createDecoder('42.5', CoercionPolicy.STRICT).decodeDouble() == 42.5d
+        createDecoder('42.5', CoercionPolicy.STRICT).decodeBigDecimal() == new BigDecimal('42.5')
+        createDecoder('"a"', CoercionPolicy.STRICT).decodeString() == 'a'
+        createDecoder('"a"', CoercionPolicy.STRICT).decodeChar() == (char) 'a'
+        createDecoder('true', CoercionPolicy.STRICT).decodeBoolean()
+        createDecoder('null', CoercionPolicy.STRICT).decodeStringNullable() == null
+        createDecoder('null', CoercionPolicy.STRICT).decodeIntNullable() == null
+    }
+
+    def 'individual coercions can be allowed on top of the strict mode'() {
+        given:
+        def ctx = ApplicationContext.run([
+                'micronaut.serde.deserialization.coercion-mode'          : 'STRICT',
+                'micronaut.serde.deserialization.accept-string-as-number': true
+        ])
+        def policy = CoercionPolicy.fromConfiguration(ctx.getBean(DeserializationConfiguration))
+
+        expect:
+        createDecoder('"42"', policy).decodeInt() == 42
+
+        when:
+        createDecoder('42.5', policy).decodeInt()
+
+        then:
+        thrown SerdeException
+
+        cleanup:
+        ctx.close()
+    }
+
+    def 'the buffered decoder applies the same policy'() {
+        expect: 'decodeX() and decodeBuffer().decodeX() agree, as Decoder#decodeBuffer documents'
+        createDecoder('42.5', CoercionPolicy.LENIENT).decodeBuffer().decodeInt() == 42
+
+        when:
+        createDecoder('42.5', CoercionPolicy.STRICT).decodeBuffer().decodeInt()
+
+        then:
+        thrown SerdeException
+
+        when:
+        createDecoder('[42]', CoercionPolicy.STRICT).decodeBuffer().decodeInt()
+
+        then:
+        thrown SerdeException
+
+        and: 'the lenient direction agrees as well'
+        createDecoder('"42"', CoercionPolicy.LENIENT).decodeBuffer().decodeInt() == 42
+        createDecoder('true', CoercionPolicy.LENIENT).decodeBuffer().decodeInt() == 1
+        createDecoder('1234', CoercionPolicy.LENIENT).decodeBuffer().decodeString() == '1234'
+        createDecoder('1', CoercionPolicy.LENIENT).decodeBuffer().decodeBoolean()
+        createDecoder('"42.5"', CoercionPolicy.LENIENT).decodeBuffer().decodeDouble() == 42.5d
+    }
+
+    def 'a buffered property is validated like an inline one'() {
+        given:
+        def ctx = ApplicationContext.run(['micronaut.serde.deserialization.accept-float-as-int': false])
+        def mapper = ctx.getBean(ObjectMapper)
+
+        when: 'read inline'
+        mapper.readValue('{"type":"sub","number":42.5}', Base)
+
+        then:
+        thrown SerdeException
+
+        when: 'the discriminator comes last, so the property is buffered'
+        mapper.readValue('{"number":42.5,"type":"sub"}', Base)
+
+        then:
+        thrown SerdeException
+
+        cleanup:
+        ctx.close()
+    }
+
+    def 'buffered and inline properties agree under the default configuration'() {
+        given:
+        def ctx = ApplicationContext.run()
+        def mapper = ctx.getBean(ObjectMapper)
+
+        expect: 'the discriminator first, so the property is read inline'
+        mapper.readValue('{"type":"sub","number":"42"}', Base).number == 42
+        mapper.readValue('{"type":"sub","number":42.5}', Base).number == 42
+        mapper.readValue('{"type":"sub","number":true}', Base).number == 1
+        mapper.readValue('{"type":"sub","text":1234}', Base).text == '1234'
+
+        and: 'the discriminator last, so the property is buffered'
+        mapper.readValue('{"number":"42","type":"sub"}', Base).number == 42
+        mapper.readValue('{"number":42.5,"type":"sub"}', Base).number == 42
+        mapper.readValue('{"number":true,"type":"sub"}', Base).number == 1
+        mapper.readValue('{"text":1234,"type":"sub"}', Base).text == '1234'
+
+        cleanup:
+        ctx.close()
+    }
+
+    def 'strict mode rejects the whole matrix through the mapper'() {
+        given:
+        def ctx = ApplicationContext.run(['micronaut.serde.deserialization.coercion-mode': 'STRICT'])
+        def mapper = ctx.getBean(ObjectMapper)
+
+        when:
+        mapper.readValue(json, Plain)
+
+        then:
+        thrown SerdeException
+
+        cleanup:
+        ctx.close()
+
+        where:
+        json << [
+                '{"number":42.5}',
+                '{"number":"42"}',
+                '{"number":true}',
+                '{"number":[42]}',
+                '{"text":1234}',
+                '{"text":true}',
+                '{"flag":1}',
+                '{"amount":"42.5"}'
+        ]
+    }
+
+    def 'strict mode still reads well shaped values'() {
+        given:
+        def ctx = ApplicationContext.run(['micronaut.serde.deserialization.coercion-mode': 'STRICT'])
+        def mapper = ctx.getBean(ObjectMapper)
+        def read = mapper.readValue('{"number":42,"text":"a","flag":true,"amount":42.5}', Plain)
+
+        expect:
+        read.number == 42
+        read.text == 'a'
+        read.flag
+        read.amount == 42.5d
+
+        cleanup:
+        ctx.close()
+    }
+
+    def 'the default configuration keeps every historical coercion'() {
+        given:
+        def ctx = ApplicationContext.run()
+        def mapper = ctx.getBean(ObjectMapper)
+
+        expect:
+        mapper.readValue('{"number":42.5}', Plain).number == 42
+        mapper.readValue('{"number":"42"}', Plain).number == 42
+        mapper.readValue('{"number":true}', Plain).number == 1
+        mapper.readValue('{"number":[42]}', Plain).number == 42
+        mapper.readValue('{"text":1234}', Plain).text == '1234'
+        mapper.readValue('{"flag":1}', Plain).flag
+        mapper.readValue('{"amount":"42.5"}', Plain).amount == 42.5d
+
+        cleanup:
+        ctx.close()
+    }
+
+    @Serdeable
+    static class Plain {
+        Integer number
+        String text
+        Boolean flag
+        Double amount
+    }
+
+    @Serdeable
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+    @JsonSubTypes(@JsonSubTypes.Type(value = Sub.class, name = "sub"))
+    static abstract class Base {
+        Integer number
+        String text
+    }
+
+    @Serdeable
+    static class Sub extends Base {
+    }
+}

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/CoercionPolicySpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/CoercionPolicySpec.groovy
@@ -118,6 +118,40 @@ class CoercionPolicySpec extends Specification {
         createDecoder('"42.5"', CoercionPolicy.LENIENT).decodeBuffer().decodeDouble() == 42.5d
     }
 
+    @Unroll
+    def 'char reads agree between the streaming and buffered decoders for #json (#policyName)'() {
+        given:
+        def streaming = { -> createDecoder(json, policy).decodeChar() }
+        def buffered = { -> createDecoder(json, policy).decodeBuffer().decodeChar() }
+
+        expect:
+        outcome(streaming) == outcome(buffered)
+        outcome(streaming) == expected
+
+        where:
+        json   | policyName | policy                  || expected
+        '"a"'  | 'lenient'  | CoercionPolicy.LENIENT  || 'a' as char
+        '"a"'  | 'strict'   | CoercionPolicy.STRICT   || 'a' as char
+        '"42"' | 'lenient'  | CoercionPolicy.LENIENT  || 'threw'
+        '"42"' | 'strict'   | CoercionPolicy.STRICT   || 'threw'
+        '""'   | 'lenient'  | CoercionPolicy.LENIENT  || 'threw'
+        '""'   | 'strict'   | CoercionPolicy.STRICT   || 'threw'
+        '42'   | 'lenient'  | CoercionPolicy.LENIENT  || 42 as char
+        '42'   | 'strict'   | CoercionPolicy.STRICT   || 42 as char
+        '42.5' | 'lenient'  | CoercionPolicy.LENIENT  || 42 as char
+        '42.5' | 'strict'   | CoercionPolicy.STRICT   || 'threw'
+        'true' | 'lenient'  | CoercionPolicy.LENIENT  || 1 as char
+        'true' | 'strict'   | CoercionPolicy.STRICT   || 'threw'
+    }
+
+    private static Object outcome(Closure<?> read) {
+        try {
+            return read.call()
+        } catch (IOException ignored) {
+            return 'threw'
+        }
+    }
+
     def 'a buffered property is validated like an inline one'() {
         given:
         def ctx = ApplicationContext.run(['micronaut.serde.deserialization.accept-float-as-int': false])

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/ConfigCloneSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/ConfigCloneSpec.groovy
@@ -37,6 +37,14 @@ class ConfigCloneSpec extends Specification {
         then:
         noExceptionThrown()
         when:
+        def defaultValue = original.readValue('{"number":42.5}', TestBean)
+        then:
+        defaultValue.number == 42
+        when:
+        modified.readValue('{"number":42.5}', TestBean)
+        then:
+        thrown SerdeException
+        when:
         modified.readValue('{"missing":"foo"}', TestBean)
         then:
         thrown SerdeException
@@ -85,6 +93,7 @@ class ConfigCloneSpec extends Specification {
     static class TestBean {
         List<String> empty
         byte[] bytes
+        Integer number
     }
 
     @ConfigurationProperties("oci.serde")
@@ -110,5 +119,9 @@ class ConfigCloneSpec extends Specification {
         @Bindable(defaultValue = "false")
         @Override
         boolean isIgnoreUnknown()
+
+        @Bindable(defaultValue = "false")
+        @Override
+        boolean isAcceptFloatAsInt()
     }
 }

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/JacksonDecoderSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/JacksonDecoderSpec.groovy
@@ -9,7 +9,11 @@ import tools.jackson.core.json.JsonFactoryBuilder
 
 class JacksonDecoderSpec extends Specification {
     private static Decoder createDecoder(@Language('json') String json) {
-        return JacksonDecoder.create(new JsonFactoryBuilder().build().createParser(json), LimitingStream.DEFAULT_LIMITS)
+        return createDecoder(json, true)
+    }
+
+    private static Decoder createDecoder(@Language('json') String json, boolean acceptFloatAsInt) {
+        return JacksonDecoder.create(new JsonFactoryBuilder().build().createParser(json), LimitingStream.DEFAULT_LIMITS, acceptFloatAsInt)
     }
 
     def "unwrap arrays normal"() {
@@ -77,6 +81,47 @@ class JacksonDecoderSpec extends Specification {
 
         createDecoder('true').decodeBigDecimal() == BigDecimal.ONE
         createDecoder('false').decodeBigDecimal() == BigDecimal.ZERO
+    }
+
+    def 'floating-point values are accepted as integers by default'() {
+        expect:
+        createDecoder('42.5').decodeByte() == 42
+        createDecoder('42.5').decodeShort() == 42
+        createDecoder('42.5').decodeInt() == 42
+        createDecoder('42.5').decodeLong() == 42L
+        createDecoder('42.5').decodeBigInteger() == BigInteger.valueOf(42)
+    }
+
+    def 'floating-point values can be rejected as integers'() {
+        when:
+        createDecoder('42.5', false).decodeInt()
+
+        then:
+        thrown SerdeException
+
+        when:
+        createDecoder('42.5', false).decodeByte()
+
+        then:
+        thrown SerdeException
+
+        when:
+        createDecoder('42.5', false).decodeShort()
+
+        then:
+        thrown SerdeException
+
+        when:
+        createDecoder('42.5', false).decodeLong()
+
+        then:
+        thrown SerdeException
+
+        when:
+        createDecoder('42.5', false).decodeBigInteger()
+
+        then:
+        thrown SerdeException
     }
 
     def 'buffering'() {

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/JacksonDecoderSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/JacksonDecoderSpec.groovy
@@ -2,6 +2,7 @@ package io.micronaut.serde.jackson
 
 import io.micronaut.serde.Decoder
 import io.micronaut.serde.LimitingStream
+import io.micronaut.serde.config.CoercionPolicy
 import io.micronaut.serde.exceptions.SerdeException
 import org.intellij.lang.annotations.Language
 import spock.lang.Specification
@@ -9,11 +10,11 @@ import tools.jackson.core.json.JsonFactoryBuilder
 
 class JacksonDecoderSpec extends Specification {
     private static Decoder createDecoder(@Language('json') String json) {
-        return createDecoder(json, true)
+        return createDecoder(json, CoercionPolicy.LENIENT)
     }
 
-    private static Decoder createDecoder(@Language('json') String json, boolean acceptFloatAsInt) {
-        return JacksonDecoder.create(new JsonFactoryBuilder().build().createParser(json), LimitingStream.DEFAULT_LIMITS, acceptFloatAsInt)
+    private static Decoder createDecoder(@Language('json') String json, CoercionPolicy policy) {
+        return JacksonDecoder.create(new JsonFactoryBuilder().build().createParser(json), LimitingStream.DEFAULT_LIMITS, policy)
     }
 
     def "unwrap arrays normal"() {
@@ -94,31 +95,31 @@ class JacksonDecoderSpec extends Specification {
 
     def 'floating-point values can be rejected as integers'() {
         when:
-        createDecoder('42.5', false).decodeInt()
+        createDecoder('42.5', CoercionPolicy.STRICT).decodeInt()
 
         then:
         thrown SerdeException
 
         when:
-        createDecoder('42.5', false).decodeByte()
+        createDecoder('42.5', CoercionPolicy.STRICT).decodeByte()
 
         then:
         thrown SerdeException
 
         when:
-        createDecoder('42.5', false).decodeShort()
+        createDecoder('42.5', CoercionPolicy.STRICT).decodeShort()
 
         then:
         thrown SerdeException
 
         when:
-        createDecoder('42.5', false).decodeLong()
+        createDecoder('42.5', CoercionPolicy.STRICT).decodeLong()
 
         then:
         thrown SerdeException
 
         when:
-        createDecoder('42.5', false).decodeBigInteger()
+        createDecoder('42.5', CoercionPolicy.STRICT).decodeBigInteger()
 
         then:
         thrown SerdeException

--- a/serde-jsonb/src/main/java/io/micronaut/serde/jsonb/JsonbFallbackCodec.java
+++ b/serde-jsonb/src/main/java/io/micronaut/serde/jsonb/JsonbFallbackCodec.java
@@ -19,6 +19,7 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.json.tree.JsonNode;
 import io.micronaut.serde.Deserializer;
 import io.micronaut.serde.LimitingStream;
+import io.micronaut.serde.config.CoercionPolicy;
 import io.micronaut.serde.ObjectMapper;
 import io.micronaut.serde.SerdeRegistry;
 import io.micronaut.serde.Serializer;
@@ -82,6 +83,12 @@ final class JsonbFallbackCodec {
         return limits;
     }
 
+    static CoercionPolicy coercionPolicy(Deserializer.DecoderContext decoderContext) {
+        return decoderContext.getDeserializationConfiguration()
+            .map(CoercionPolicy::fromConfiguration)
+            .orElse(CoercionPolicy.LENIENT);
+    }
+
     /**
      * Deserializes an already-buffered fallback tree through the normal Serde
      * registry. Use this instead of hand-converting JSON-B fallback values.
@@ -96,7 +103,7 @@ final class JsonbFallbackCodec {
     <T> @Nullable T readValue(JsonNode node, Argument<T> argument) throws IOException {
         Deserializer.DecoderContext decoderContext = registry.newDecoderContext(null);
         Deserializer<? extends T> deserializer = findDeserializer(decoderContext, argument);
-        return deserializer.deserializeNullable(new JsonbDecoder(JsonNodeDecoder.create(node, limits), binaryDataStrategy), decoderContext, argument);
+        return deserializer.deserializeNullable(new JsonbDecoder(JsonNodeDecoder.create(node, limits, coercionPolicy(decoderContext)), binaryDataStrategy), decoderContext, argument);
     }
 
     /**

--- a/serde-jsonb/src/main/java/io/micronaut/serde/jsonb/MicronautJsonbProvider.java
+++ b/serde-jsonb/src/main/java/io/micronaut/serde/jsonb/MicronautJsonbProvider.java
@@ -20,6 +20,7 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.clhm.ConcurrentLinkedHashMap;
 import io.micronaut.serde.Deserializer;
 import io.micronaut.serde.LimitingStream;
+import io.micronaut.serde.config.CoercionPolicy;
 import io.micronaut.serde.ObjectMapper;
 import io.micronaut.serde.SerdeRegistry;
 import io.micronaut.serde.Serializer;
@@ -357,7 +358,7 @@ public class MicronautJsonbProvider extends JsonbProvider {
                 Deserializer.DecoderContext decoderContext = registry.newDecoderContext(null);
                 Deserializer<? extends T> deserializer = decoderContext.findDeserializer(argument).createSpecific(decoderContext, argument);
                 try (JsonParser parser = parserSource.createParser()) {
-                    return deserializer.deserializeNullable(new JsonbDecoder(JacksonDecoder.create(parser, limits()), binaryDataStrategy), decoderContext, argument);
+                    return deserializer.deserializeNullable(new JsonbDecoder(JacksonDecoder.create(parser, limits(), coercionPolicy(decoderContext)), binaryDataStrategy), decoderContext, argument);
                 }
             } catch (IOException | RuntimeException e) {
                 throw new JsonbException("Cannot read JSON-B value", e);
@@ -438,6 +439,12 @@ public class MicronautJsonbProvider extends JsonbProvider {
                     serializer.serialize(new JsonbEncoder(JacksonEncoder.create(generator, limits()), binaryDataStrategy), encoderContext, argument, object);
                 }
             }
+        }
+
+        protected final CoercionPolicy coercionPolicy(Deserializer.DecoderContext decoderContext) {
+            return decoderContext.getDeserializationConfiguration()
+                .map(CoercionPolicy::fromConfiguration)
+                .orElse(CoercionPolicy.LENIENT);
         }
 
         protected final LimitingStream.RemainingLimits limits() {

--- a/serde-jsonp/src/main/java/io/micronaut/serde/json/stream/JsonParserDecoder.java
+++ b/serde-jsonp/src/main/java/io/micronaut/serde/json/stream/JsonParserDecoder.java
@@ -38,6 +38,12 @@ public class JsonParserDecoder extends AbstractStreamDecoder {
     }
 
     @Internal
+    JsonParserDecoder(JsonParser jsonParser, RemainingLimits remainingLimits, io.micronaut.serde.config.CoercionPolicy coercionPolicy) {
+        super(remainingLimits, coercionPolicy);
+        this.jsonParser = jsonParser;
+        nextToken();
+    }
+
     JsonParserDecoder(JsonParser jsonParser, RemainingLimits remainingLimits) {
         super(remainingLimits);
         this.jsonParser = jsonParser;
@@ -134,6 +140,11 @@ public class JsonParserDecoder extends AbstractStreamDecoder {
     @Override
     protected BigDecimal getBigDecimal() {
         return jsonParser.getBigDecimal();
+    }
+
+    @Override
+    protected boolean isCurrentNumberFloat() {
+        return !jsonParser.isIntegralNumber();
     }
 
     @Override

--- a/serde-jsonp/src/main/java/io/micronaut/serde/json/stream/JsonStreamMapper.java
+++ b/serde-jsonp/src/main/java/io/micronaut/serde/json/stream/JsonStreamMapper.java
@@ -29,6 +29,7 @@ import io.micronaut.serde.ObjectMapper;
 import io.micronaut.serde.SerdeIntrospections;
 import io.micronaut.serde.SerdeRegistry;
 import io.micronaut.serde.Serializer;
+import io.micronaut.serde.config.CoercionPolicy;
 import io.micronaut.serde.config.DeserializationConfiguration;
 import io.micronaut.serde.config.SerdeConfiguration;
 import io.micronaut.serde.config.SerializationConfiguration;
@@ -62,6 +63,7 @@ public class JsonStreamMapper implements ObjectMapper {
     private final SerdeConfiguration serdeConfiguration;
     @Nullable
     private final Class<?> view;
+    private final CoercionPolicy coercionPolicy;
 
     @Inject
     public JsonStreamMapper(SerdeRegistry registry, SerdeConfiguration serdeConfiguration) {
@@ -72,6 +74,8 @@ public class JsonStreamMapper implements ObjectMapper {
         this.registry = registry;
         this.serdeConfiguration = serdeConfiguration;
         this.view = view;
+        this.coercionPolicy = CoercionPolicy.fromConfiguration(
+            registry.newDecoderContext(view).getDeserializationConfiguration().orElse(null));
     }
 
     @Override
@@ -105,7 +109,7 @@ public class JsonStreamMapper implements ObjectMapper {
         Deserializer.DecoderContext context = registry.newDecoderContext(JsonViewUtil.extractView(serdeConfiguration, type, view));
         final Deserializer<? extends T> deserializer = context.findDeserializer(type).createSpecific(context, type);
         return deserializer.deserialize(
-                JsonNodeDecoder.create(tree, limits()),
+                JsonNodeDecoder.create(tree, limits(), coercionPolicy()),
                 context,
                 type
         );
@@ -126,7 +130,7 @@ public class JsonStreamMapper implements ObjectMapper {
     }
 
     private <T> @Nullable T readValue(JsonParser parser, Argument<T> type) throws IOException {
-        Decoder decoder = new JsonParserDecoder(parser, limits());
+        Decoder decoder = new JsonParserDecoder(parser, limits(), coercionPolicy());
         Deserializer.DecoderContext context = registry.newDecoderContext(JsonViewUtil.extractView(serdeConfiguration, type, view));
         final Deserializer<? extends T> deserializer = context.findDeserializer(type).createSpecific(context, type);
         return deserializer.deserialize(
@@ -143,7 +147,7 @@ public class JsonStreamMapper implements ObjectMapper {
             @Override
             protected JsonNode parseOne(InputStream is) throws IOException {
                 try (JsonParser parser = Json.createParser(is)) {
-                    final JsonParserDecoder decoder = new JsonParserDecoder(parser, limits());
+                    final JsonParserDecoder decoder = new JsonParserDecoder(parser, limits(), coercionPolicy());
                     final Object o = decoder.decodeArbitrary();
                     return writeValueToTree(o);
                 }
@@ -195,6 +199,10 @@ public class JsonStreamMapper implements ObjectMapper {
             }
             generator.flush();
         }
+    }
+
+    private CoercionPolicy coercionPolicy() {
+        return this.coercionPolicy;
     }
 
     private LimitingStream.RemainingLimits limits() {

--- a/serde-jsonp/src/test/groovy/io/micronaut/serde/json/stream/JsonpCoercionPolicySpec.groovy
+++ b/serde-jsonp/src/test/groovy/io/micronaut/serde/json/stream/JsonpCoercionPolicySpec.groovy
@@ -1,0 +1,101 @@
+package io.micronaut.serde.json.stream
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.serde.Decoder
+import io.micronaut.serde.LimitingStream
+import io.micronaut.serde.ObjectMapper
+import io.micronaut.serde.annotation.Serdeable
+import io.micronaut.serde.config.CoercionPolicy
+import io.micronaut.serde.exceptions.SerdeException
+import jakarta.json.Json
+import jakarta.json.stream.JsonParser
+import org.intellij.lang.annotations.Language
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class JsonpCoercionPolicySpec extends Specification {
+
+    private static Decoder createDecoder(@Language('json') String json, CoercionPolicy policy) {
+        JsonParser parser = Json.createParser(new StringReader(json))
+        return new JsonParserDecoder(parser, LimitingStream.DEFAULT_LIMITS, policy)
+    }
+
+    @Unroll
+    def 'the streaming decoder honours the policy for #json read as #method'() {
+        when:
+        createDecoder(json, CoercionPolicy.STRICT)."$method"()
+
+        then:
+        thrown SerdeException
+
+        when: 'the same input is lenient'
+        def lenient = createDecoder(json, CoercionPolicy.LENIENT)."$method"()
+
+        then:
+        lenient == coerced
+
+        where:
+        json     | method             || coerced
+        '42.5'   | 'decodeInt'        || 42
+        '42.5'   | 'decodeLong'       || 42L
+        '42.5'   | 'decodeBigInteger' || BigInteger.valueOf(42)
+        '"42"'   | 'decodeInt'        || 42
+        '"42.5"' | 'decodeDouble'     || 42.5d
+        'true'   | 'decodeInt'        || 1
+        '1'      | 'decodeBoolean'    || true
+        '1234'   | 'decodeString'     || '1234'
+        '[42]'   | 'decodeInt'        || 42
+    }
+
+    def 'values of the right shape are untouched'() {
+        expect:
+        createDecoder('42', CoercionPolicy.STRICT).decodeInt() == 42
+        createDecoder('42.5', CoercionPolicy.STRICT).decodeDouble() == 42.5d
+        createDecoder('42', CoercionPolicy.STRICT).decodeDouble() == 42d
+        createDecoder('"a"', CoercionPolicy.STRICT).decodeString() == 'a'
+        createDecoder('true', CoercionPolicy.STRICT).decodeBoolean()
+    }
+
+    def 'the mapper picks the policy up from the configuration'() {
+        given:
+        def ctx = ApplicationContext.run(['micronaut.serde.deserialization.coercion-mode': 'STRICT'])
+        def mapper = ctx.getBean(JsonStreamMapper)
+
+        when:
+        mapper.readValue('{"number":42.5}', Plain)
+
+        then:
+        thrown SerdeException
+
+        when:
+        mapper.readValue('{"number":"42"}', Plain)
+
+        then:
+        thrown SerdeException
+
+        and: 'a well shaped value still reads'
+        mapper.readValue('{"number":42}', Plain).number == 42
+
+        cleanup:
+        ctx.close()
+    }
+
+    def 'the default configuration is unchanged'() {
+        given:
+        def ctx = ApplicationContext.run()
+        def mapper = ctx.getBean(JsonStreamMapper)
+
+        expect:
+        mapper.readValue('{"number":42.5}', Plain).number == 42
+        mapper.readValue('{"number":"42"}', Plain).number == 42
+        mapper.readValue('{"number":[42]}', Plain).number == 42
+
+        cleanup:
+        ctx.close()
+    }
+
+    @Serdeable
+    static class Plain {
+        Integer number
+    }
+}

--- a/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/AbstractOracleJdbcJsonObjectMapper.java
+++ b/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/AbstractOracleJdbcJsonObjectMapper.java
@@ -22,6 +22,7 @@ import io.micronaut.json.tree.JsonNode;
 import io.micronaut.serde.Deserializer;
 import io.micronaut.serde.Encoder;
 import io.micronaut.serde.LimitingStream;
+import io.micronaut.serde.config.CoercionPolicy;
 import io.micronaut.serde.ObjectMapper;
 import io.micronaut.serde.SerdeRegistry;
 import io.micronaut.serde.Serializer;
@@ -60,17 +61,18 @@ abstract class AbstractOracleJdbcJsonObjectMapper implements ObjectMapper {
     @Nullable
     protected final Class<?> view;
     protected final OracleJsonFactory oracleJsonFactory = new OracleJsonFactory();
+    private final CoercionPolicy coercionPolicy;
 
     protected AbstractOracleJdbcJsonObjectMapper(SerdeRegistry registry, @Nullable SerdeConfiguration serdeConfiguration) {
-        this.registry = registry;
-        this.serdeConfiguration = serdeConfiguration;
-        this.view = null;
+        this(registry, serdeConfiguration, null);
     }
 
     protected AbstractOracleJdbcJsonObjectMapper(SerdeRegistry registry, @Nullable SerdeConfiguration serdeConfiguration, @Nullable Class<?> view) {
         this.registry = registry;
         this.serdeConfiguration = serdeConfiguration;
         this.view = view;
+        this.coercionPolicy = CoercionPolicy.fromConfiguration(
+            registry.newDecoderContext(view).getDeserializationConfiguration().orElse(null));
     }
 
     @Override
@@ -87,7 +89,7 @@ abstract class AbstractOracleJdbcJsonObjectMapper implements ObjectMapper {
         Deserializer.DecoderContext context = registry.newDecoderContext(view);
         final Deserializer<? extends T> deserializer = this.registry.findDeserializer(type).createSpecific(context, type);
         return deserializer.deserialize(
-            JsonNodeDecoder.create(tree, limits()),
+            JsonNodeDecoder.create(tree, limits(), coercionPolicy()),
             context,
             type
         );
@@ -134,7 +136,7 @@ abstract class AbstractOracleJdbcJsonObjectMapper implements ObjectMapper {
         Deserializer.DecoderContext context = registry.newDecoderContext(view);
         final Deserializer<? extends T> deserializer = this.registry.findDeserializer(type).createSpecific(context, type);
         return deserializer.deserialize(
-            new OracleJdbcJsonParserDecoder(parser, limits()),
+            new OracleJdbcJsonParserDecoder(parser, limits(), coercionPolicy()),
             context,
             type
         );
@@ -147,12 +149,16 @@ abstract class AbstractOracleJdbcJsonObjectMapper implements ObjectMapper {
             @Override
             protected JsonNode parseOne(InputStream is) throws IOException {
                 try (OracleJsonParser parser = getJsonParser(is)) {
-                    final OracleJdbcJsonParserDecoder decoder = new OracleJdbcJsonParserDecoder(parser, limits());
+                    final OracleJdbcJsonParserDecoder decoder = new OracleJdbcJsonParserDecoder(parser, limits(), coercionPolicy());
                     final Object o = decoder.decodeArbitrary();
                     return writeValueToTree(o);
                 }
             }
         };
+    }
+
+    private CoercionPolicy coercionPolicy() {
+        return coercionPolicy;
     }
 
     private LimitingStream.RemainingLimits limits() {

--- a/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/OracleJdbcJsonParserDecoder.java
+++ b/serde-oracle-jdbc-json/src/main/java/io/micronaut/serde/oracle/jdbc/json/OracleJdbcJsonParserDecoder.java
@@ -45,6 +45,12 @@ public final class OracleJdbcJsonParserDecoder extends AbstractStreamDecoder {
     private final OracleJsonParser jsonParser;
     private OracleJsonParser.@Nullable Event currentEvent;
 
+    OracleJdbcJsonParserDecoder(OracleJsonParser jsonParser, RemainingLimits remainingLimits, io.micronaut.serde.config.CoercionPolicy coercionPolicy) {
+        super(remainingLimits, coercionPolicy);
+        this.jsonParser = jsonParser;
+        nextToken();
+    }
+
     OracleJdbcJsonParserDecoder(OracleJsonParser jsonParser, RemainingLimits remainingLimits) {
         super(remainingLimits);
         this.jsonParser = jsonParser;
@@ -149,6 +155,14 @@ public final class OracleJdbcJsonParserDecoder extends AbstractStreamDecoder {
     @Override
     protected BigDecimal getBigDecimal() {
         return jsonParser.getBigDecimal();
+    }
+
+    @Override
+    protected boolean isCurrentNumberFloat() {
+        return switch (requireCurrentEvent()) {
+            case VALUE_DECIMAL, VALUE_DOUBLE, VALUE_FLOAT -> true;
+            default -> false;
+        };
     }
 
     @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/AbstractDecoderPerStructureStreamDecoder.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/AbstractDecoderPerStructureStreamDecoder.java
@@ -16,6 +16,7 @@
 package io.micronaut.serde.support;
 
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.serde.config.CoercionPolicy;
 import io.micronaut.serde.exceptions.SerdeException;
 import org.jspecify.annotations.Nullable;
 
@@ -40,7 +41,7 @@ public abstract class AbstractDecoderPerStructureStreamDecoder extends AbstractS
      * @param remainingLimits The limits for this decoder
      */
     protected AbstractDecoderPerStructureStreamDecoder(AbstractDecoderPerStructureStreamDecoder parent, RemainingLimits remainingLimits) {
-        this(remainingLimits);
+        this(remainingLimits, parent.getCoercionPolicy());
         this.parent = parent;
     }
 
@@ -51,6 +52,17 @@ public abstract class AbstractDecoderPerStructureStreamDecoder extends AbstractS
      */
     protected AbstractDecoderPerStructureStreamDecoder(RemainingLimits remainingLimits) {
         super(remainingLimits);
+    }
+
+    /**
+     * Root constructor that only performs the coercions the given policy allows.
+     *
+     * @param remainingLimits The limits for this decoder
+     * @param coercionPolicy  The coercions this decoder may perform
+     * @since 3.2
+     */
+    protected AbstractDecoderPerStructureStreamDecoder(RemainingLimits remainingLimits, CoercionPolicy coercionPolicy) {
+        super(remainingLimits, coercionPolicy);
     }
 
     /**

--- a/serde-support/src/main/java/io/micronaut/serde/support/AbstractStreamDecoder.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/AbstractStreamDecoder.java
@@ -20,6 +20,10 @@ import io.micronaut.core.type.Argument;
 import io.micronaut.json.tree.JsonNode;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.LimitingStream;
+import io.micronaut.serde.config.CoercionPolicy;
+import io.micronaut.serde.config.CoercionPolicy.Coercion;
+import io.micronaut.serde.config.CoercionPolicy.Shape;
+import io.micronaut.serde.config.CoercionPolicy.Target;
 import io.micronaut.serde.exceptions.NullValueSerdeException;
 import io.micronaut.serde.support.util.JsonNodeDecoder;
 import io.micronaut.serde.util.BinaryCodecUtil;
@@ -40,10 +44,93 @@ import java.util.function.Function;
 @Internal
 public abstract class AbstractStreamDecoder extends LimitingStream implements Decoder {
 
+    private final CoercionPolicy coercionPolicy;
+    private final int integerShapes;
+    private final int decimalShapes;
+    private final int booleanShapes;
+    private final int stringShapes;
+    private final int charShapes;
+
     private boolean currentlyUnwrappingArray = false;
 
+    /**
+     * Create a decoder that performs every coercion, for backwards compatibility.
+     *
+     * @param remainingLimits The remaining stream limits
+     */
     public AbstractStreamDecoder(RemainingLimits remainingLimits) {
+        this(remainingLimits, CoercionPolicy.LENIENT);
+    }
+
+    /**
+     * Create a decoder that only performs the coercions the given policy allows.
+     *
+     * @param remainingLimits The remaining stream limits
+     * @param coercionPolicy  The coercions this decoder may perform
+     * @since 3.2
+     */
+    public AbstractStreamDecoder(RemainingLimits remainingLimits, CoercionPolicy coercionPolicy) {
         super(remainingLimits);
+        this.coercionPolicy = coercionPolicy;
+        this.integerShapes = coercionPolicy.allowedShapes(Target.INTEGER);
+        this.decimalShapes = coercionPolicy.allowedShapes(Target.DECIMAL);
+        this.booleanShapes = coercionPolicy.allowedShapes(Target.BOOLEAN);
+        this.stringShapes = coercionPolicy.allowedShapes(Target.STRING);
+        this.charShapes = coercionPolicy.allowedShapes(Target.CHAR);
+    }
+
+    @Override
+    public final CoercionPolicy getCoercionPolicy() {
+        return coercionPolicy;
+    }
+
+    /**
+     * Whether the current {@link TokenType#NUMBER} token has a fractional part. Only called when
+     * the configuration forbids reading a floating point number as an integer, so a decoder that
+     * never sees that configuration keeps working without implementing it.
+     * <p>
+     * The default implementation materialises the number with {@link #getBestNumber()}. A decoder
+     * whose underlying parser consumes the value when it is read, as a forward only BSON reader
+     * does, <b>must</b> override this and answer from the token type instead.
+     *
+     * @return {@code true} if the current number is a floating point number
+     * @throws IOException if an unrecoverable error occurs
+     * @since 3.2
+     */
+    protected boolean isCurrentNumberFloat() throws IOException {
+        Number number = getBestNumber();
+        return number instanceof Double || number instanceof Float || number instanceof BigDecimal;
+    }
+
+    /**
+     * Check that the current token may be read as the given target type. The shapes each target
+     * accepts are precalculated by the {@link CoercionPolicy}, so this is a single mask test unless
+     * the value is rejected.
+     *
+     * @param allowedShapes The precalculated shapes for the target
+     * @param currentToken  The current token
+     * @param target        The target type, only used to build the error
+     * @throws IOException if the coercion is not allowed
+     */
+    private void checkSource(int allowedShapes, TokenType currentToken, Target target) throws IOException {
+        Shape shape = switch (currentToken) {
+            case STRING -> Shape.STRING;
+            case BOOLEAN -> Shape.BOOLEAN;
+            case START_ARRAY -> Shape.ARRAY;
+            // the integer/float distinction only matters when the target rejects floats, and
+            // finding out costs a number lookup, so only ask then
+            case NUMBER -> (allowedShapes & Shape.FLOAT_NUMBER.bit()) == 0 && isCurrentNumberFloat()
+                ? Shape.FLOAT_NUMBER
+                : Shape.INTEGER_NUMBER;
+            default -> Shape.OTHER;
+        };
+        if ((allowedShapes & shape.bit()) == 0) {
+            Coercion coercion = CoercionPolicy.coercion(target, shape);
+            throw createDeserializationException(
+                coercion == null ? "Unexpected token " + currentToken : coercion.message(),
+                shape == Shape.ARRAY ? null : coerceScalarToString(currentToken)
+            );
+        }
     }
 
     private static JsonNode decodeObjectNode(AbstractStreamDecoder elementDecoder) throws IOException {
@@ -247,6 +334,7 @@ public abstract class AbstractStreamDecoder extends LimitingStream implements De
     public String decodeString() throws IOException {
         TokenType currentToken = requireCurrentToken();
         preDecodeValue(currentToken);
+        checkSource(stringShapes, currentToken, Target.STRING);
         switch (currentToken) {
             case STRING:
                 String text = getString();
@@ -295,6 +383,7 @@ public abstract class AbstractStreamDecoder extends LimitingStream implements De
     public final boolean decodeBoolean() throws IOException {
         TokenType currentToken = requireCurrentToken();
         preDecodeValue(currentToken);
+        checkSource(booleanShapes, currentToken, Target.BOOLEAN);
         switch (currentToken) {
             case BOOLEAN:
                 boolean bool = getBoolean();
@@ -458,6 +547,7 @@ public abstract class AbstractStreamDecoder extends LimitingStream implements De
     private int decodeInteger(long min, long max, boolean stringsAsChars) throws IOException {
         TokenType currentToken = requireCurrentToken();
         preDecodeValue(currentToken);
+        checkSource(stringsAsChars ? charShapes : integerShapes, currentToken, stringsAsChars ? Target.CHAR : Target.INTEGER);
         switch (currentToken) {
             case STRING:
                 String string = coerceScalarToString(currentToken);
@@ -507,6 +597,7 @@ public abstract class AbstractStreamDecoder extends LimitingStream implements De
     private long decodeLong(long min, long max, boolean stringsAsChars) throws IOException {
         TokenType currentToken = requireCurrentToken();
         preDecodeValue(currentToken);
+        checkSource(stringsAsChars ? charShapes : integerShapes, currentToken, stringsAsChars ? Target.CHAR : Target.INTEGER);
         switch (currentToken) {
             case STRING:
                 String string = coerceScalarToString(currentToken);
@@ -563,6 +654,7 @@ public abstract class AbstractStreamDecoder extends LimitingStream implements De
         // could use decodeNumber but this is more efficient
         TokenType currentToken = requireCurrentToken();
         preDecodeValue(currentToken);
+        checkSource(decimalShapes, currentToken, Target.DECIMAL);
         switch (currentToken) {
             case NUMBER:
                 double value = getDouble();
@@ -603,6 +695,7 @@ public abstract class AbstractStreamDecoder extends LimitingStream implements De
     public final BigInteger decodeBigInteger() throws IOException {
         TokenType currentToken = requireCurrentToken();
         preDecodeValue(currentToken);
+        checkSource(integerShapes, currentToken, Target.INTEGER);
         BigInteger value;
         switch (currentToken) {
             case NUMBER:
@@ -642,6 +735,7 @@ public abstract class AbstractStreamDecoder extends LimitingStream implements De
     public final BigDecimal decodeBigDecimal() throws IOException {
         TokenType currentToken = requireCurrentToken();
         preDecodeValue(currentToken);
+        checkSource(decimalShapes, currentToken, Target.DECIMAL);
         BigDecimal value;
         switch (currentToken) {
             case NUMBER:
@@ -694,6 +788,7 @@ public abstract class AbstractStreamDecoder extends LimitingStream implements De
                                        Function<String, T> fromString,
                                        T zero, T one) throws IOException {
         preDecodeValue(currentToken);
+        checkSource(decimalShapes, currentToken, Target.DECIMAL);
         T value;
         switch (currentToken) {
             case NUMBER:
@@ -787,7 +882,7 @@ public abstract class AbstractStreamDecoder extends LimitingStream implements De
     @Override
     public Decoder decodeBuffer() throws IOException {
         JsonNode node = decodeNode();
-        return JsonNodeDecoder.create(node, ourLimits());
+        return JsonNodeDecoder.create(node, ourLimits(), coercionPolicy);
     }
 
     @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/AbstractStreamDecoder.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/AbstractStreamDecoder.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 
 /**
@@ -43,6 +44,8 @@ import java.util.function.Function;
  */
 @Internal
 public abstract class AbstractStreamDecoder extends LimitingStream implements Decoder {
+
+    private static final String UNEXPECTED_TOKEN = "Unexpected token ";
 
     private final CoercionPolicy coercionPolicy;
     private final int integerShapes;
@@ -58,7 +61,7 @@ public abstract class AbstractStreamDecoder extends LimitingStream implements De
      *
      * @param remainingLimits The remaining stream limits
      */
-    public AbstractStreamDecoder(RemainingLimits remainingLimits) {
+    protected AbstractStreamDecoder(RemainingLimits remainingLimits) {
         this(remainingLimits, CoercionPolicy.LENIENT);
     }
 
@@ -69,7 +72,7 @@ public abstract class AbstractStreamDecoder extends LimitingStream implements De
      * @param coercionPolicy  The coercions this decoder may perform
      * @since 3.2
      */
-    public AbstractStreamDecoder(RemainingLimits remainingLimits, CoercionPolicy coercionPolicy) {
+    protected AbstractStreamDecoder(RemainingLimits remainingLimits, CoercionPolicy coercionPolicy) {
         super(remainingLimits);
         this.coercionPolicy = coercionPolicy;
         this.integerShapes = coercionPolicy.allowedShapes(Target.INTEGER);
@@ -125,9 +128,10 @@ public abstract class AbstractStreamDecoder extends LimitingStream implements De
             default -> Shape.OTHER;
         };
         if ((allowedShapes & shape.bit()) == 0) {
-            Coercion coercion = CoercionPolicy.coercion(target, shape);
+            // a shape that needs no coercion is always allowed, so this one needs one
+            Coercion coercion = Objects.requireNonNull(CoercionPolicy.coercion(target, shape));
             throw createDeserializationException(
-                coercion == null ? "Unexpected token " + currentToken : coercion.message(),
+                coercion.message(),
                 shape == Shape.ARRAY ? null : coerceScalarToString(currentToken)
             );
         }
@@ -172,7 +176,7 @@ public abstract class AbstractStreamDecoder extends LimitingStream implements De
      * @return The exception that should be thrown to signify an unexpected token.
      */
     protected IOException unexpectedToken(TokenType expected) {
-        return createDeserializationException("Unexpected token " + currentToken() + ", expected " + expected, null);
+        return createDeserializationException(UNEXPECTED_TOKEN + currentToken() + ", expected " + expected, null);
     }
 
     private NullValueSerdeException unexpectedNullToken(TokenType expected) throws IOException {
@@ -906,7 +910,7 @@ public abstract class AbstractStreamDecoder extends LimitingStream implements De
                 decodeNull();
                 return JsonNode.nullNode();
             default:
-                throw createDeserializationException("Unexpected token " + currentToken + ", expected value", null);
+                throw createDeserializationException(UNEXPECTED_TOKEN + currentToken + ", expected value", null);
         }
     }
 
@@ -1054,7 +1058,7 @@ public abstract class AbstractStreamDecoder extends LimitingStream implements De
                         put(key, null);
                         return this;
                     default:
-                        throw elementDecoder.createDeserializationException("Unexpected token " + currentToken + ", expected value", null);
+                        throw elementDecoder.createDeserializationException(UNEXPECTED_TOKEN + currentToken + ", expected value", null);
                 }
             } else {
                 return parent;

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DemuxingObjectDecoder.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DemuxingObjectDecoder.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.json.tree.JsonNode;
 import io.micronaut.serde.Decoder;
+import io.micronaut.serde.config.CoercionPolicy;
 import io.micronaut.serde.DelegatingDecoder;
 import io.micronaut.serde.Keys;
 import io.micronaut.serde.KeysAwareDecoder;
@@ -268,8 +269,9 @@ final class DemuxingObjectDecoder extends DelegatingDecoder implements KeysAware
                 } else {
                     // if we don't consume it, we need to duplicate the data using a JsonNode.
                     JsonNode node = decoder.decodeNode();
-                    buffer = JsonNodeDecoder.create(node, LimitingStream.DEFAULT_LIMITS);
-                    return JsonNodeDecoder.create(node, LimitingStream.DEFAULT_LIMITS);
+                    CoercionPolicy coercionPolicy = decoder.getCoercionPolicy();
+                    buffer = JsonNodeDecoder.create(node, LimitingStream.DEFAULT_LIMITS, coercionPolicy);
+                    return JsonNodeDecoder.create(node, LimitingStream.DEFAULT_LIMITS, coercionPolicy);
                 }
             }
 

--- a/serde-support/src/main/java/io/micronaut/serde/support/serdes/SingleElementArraySerde.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/serdes/SingleElementArraySerde.java
@@ -19,6 +19,7 @@ import io.micronaut.core.annotation.Internal;
 import io.micronaut.core.type.Argument;
 import io.micronaut.json.tree.JsonNode;
 import io.micronaut.serde.Decoder;
+import io.micronaut.serde.config.CoercionPolicy;
 import io.micronaut.serde.Deserializer;
 import io.micronaut.serde.Encoder;
 import io.micronaut.serde.LimitingStream;
@@ -93,6 +94,12 @@ public final class SingleElementArraySerde {
             .orElse(LimitingStream.DEFAULT_LIMITS);
     }
 
+    private static CoercionPolicy decoderCoercionPolicy(Deserializer.DecoderContext context) {
+        return context.getDeserializationConfiguration()
+            .map(CoercionPolicy::fromConfiguration)
+            .orElse(CoercionPolicy.LENIENT);
+    }
+
     private static final class SingleElementArrayUnwrappingSerializer<T> implements Serializer<T> {
 
         private static final Argument<JsonNode> JSON_NODE_ARGUMENT = Argument.of(JsonNode.class);
@@ -142,11 +149,13 @@ public final class SingleElementArraySerde {
     private static final class SingleValueAsArrayDeserializer<T> implements Deserializer<T> {
         private final Deserializer<T> delegate;
         private final LimitingStream.RemainingLimits remainingLimits;
+        private final CoercionPolicy coercionPolicy;
 
         private SingleValueAsArrayDeserializer(Deserializer<T> delegate,
                                                Deserializer.DecoderContext context) {
             this.delegate = delegate;
             this.remainingLimits = decoderLimits(context);
+            this.coercionPolicy = decoderCoercionPolicy(context);
         }
 
         @Override
@@ -157,7 +166,7 @@ public final class SingleElementArraySerde {
             if (!node.isArray()) {
                 node = JsonNode.createArrayNode(List.of(node));
             }
-            return delegate.deserialize(JsonNodeDecoder.create(node, remainingLimits), context, type);
+            return delegate.deserialize(JsonNodeDecoder.create(node, remainingLimits, coercionPolicy), context, type);
         }
 
         @Override
@@ -171,6 +180,7 @@ public final class SingleElementArraySerde {
         private final UpdatingDeserializer<T> updatingDelegate;
         private final Deserializer<T> delegate;
         private final LimitingStream.RemainingLimits remainingLimits;
+        private final CoercionPolicy coercionPolicy;
 
         private SingleValueAsArrayUpdatingDeserializer(UpdatingDeserializer<T> updatingDelegate,
                                                        Deserializer<T> delegate,
@@ -178,6 +188,7 @@ public final class SingleElementArraySerde {
             this.updatingDelegate = updatingDelegate;
             this.delegate = delegate;
             this.remainingLimits = decoderLimits(context);
+            this.coercionPolicy = decoderCoercionPolicy(context);
         }
 
         @Override
@@ -185,7 +196,7 @@ public final class SingleElementArraySerde {
                              DecoderContext context,
                              Argument<? super T> type) throws IOException {
             JsonNode node = arrayNode(decoder);
-            return delegate.deserialize(JsonNodeDecoder.create(node, remainingLimits), context, type);
+            return delegate.deserialize(JsonNodeDecoder.create(node, remainingLimits, coercionPolicy), context, type);
         }
 
         @Override
@@ -194,7 +205,7 @@ public final class SingleElementArraySerde {
                                     Argument<? super T> type,
                                     T value) throws IOException {
             JsonNode node = arrayNode(decoder);
-            updatingDelegate.deserializeInto(JsonNodeDecoder.create(node, remainingLimits), context, type, value);
+            updatingDelegate.deserializeInto(JsonNodeDecoder.create(node, remainingLimits, coercionPolicy), context, type, value);
         }
 
         @Override

--- a/serde-support/src/main/java/io/micronaut/serde/support/util/JsonArrayNodeDecoder.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/util/JsonArrayNodeDecoder.java
@@ -16,6 +16,7 @@
 package io.micronaut.serde.support.util;
 
 import io.micronaut.json.tree.JsonNode;
+import io.micronaut.serde.config.CoercionPolicy;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Iterator;
@@ -26,8 +27,8 @@ final class JsonArrayNodeDecoder extends JsonNodeDecoder {
     @Nullable
     private JsonNode peeked;
 
-    JsonArrayNodeDecoder(JsonNode node, RemainingLimits remainingLimits) {
-        super(remainingLimits);
+    JsonArrayNodeDecoder(JsonNode node, RemainingLimits remainingLimits, CoercionPolicy coercionPolicy) {
+        super(remainingLimits, coercionPolicy);
         iterator = node.values().iterator();
         skipValue();
     }

--- a/serde-support/src/main/java/io/micronaut/serde/support/util/JsonNodeDecoder.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/util/JsonNodeDecoder.java
@@ -21,6 +21,8 @@ import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.json.tree.JsonNode;
 import io.micronaut.serde.Decoder;
 import io.micronaut.serde.LimitingStream;
+import io.micronaut.serde.config.CoercionPolicy;
+import io.micronaut.serde.config.CoercionPolicy.Coercion;
 import io.micronaut.serde.exceptions.InvalidFormatException;
 import io.micronaut.serde.exceptions.NullValueSerdeException;
 import io.micronaut.serde.exceptions.SerdeException;
@@ -40,15 +42,98 @@ import java.util.Map;
  */
 @Internal
 public abstract sealed class JsonNodeDecoder extends LimitingStream implements Decoder permits JsonArrayNodeDecoder, JsonNodeDecoder.Buffered, JsonObjectNodeDecoder {
-    JsonNodeDecoder(LimitingStream.RemainingLimits remainingLimits) {
+    final CoercionPolicy coercionPolicy;
+
+    JsonNodeDecoder(LimitingStream.RemainingLimits remainingLimits, CoercionPolicy coercionPolicy) {
         super(remainingLimits);
+        this.coercionPolicy = coercionPolicy;
     }
 
     public static JsonNodeDecoder create(JsonNode node, LimitingStream.RemainingLimits remainingLimits) {
-        return new Buffered(node, remainingLimits);
+        return create(node, remainingLimits, CoercionPolicy.LENIENT);
+    }
+
+    /**
+     * Create a decoder that only performs the coercions the given policy allows.
+     *
+     * @param node            The node to read
+     * @param remainingLimits The remaining stream limits
+     * @param coercionPolicy  The coercions this decoder may perform
+     * @return The decoder
+     */
+    public static JsonNodeDecoder create(JsonNode node, LimitingStream.RemainingLimits remainingLimits, CoercionPolicy coercionPolicy) {
+        return new Buffered(node, remainingLimits, coercionPolicy);
+    }
+
+    /**
+     * Check the coercion needed to read the given number node as an integer type.
+     */
+    private void checkIntegerNode(JsonNode node) throws IOException {
+        if (!coercionPolicy.isAllowed(Coercion.FLOAT_AS_INT)) {
+            Number number = node.getNumberValue();
+            if (number instanceof Double || number instanceof Float || number instanceof BigDecimal) {
+                throw createDeserializationException(Coercion.FLOAT_AS_INT.message(), number);
+            }
+        }
+    }
+
+    /**
+     * Read the given node as a number, coercing it if the policy allows. Mirrors what the
+     * streaming decoders do for the same input.
+     *
+     * @return The coerced node, or {@code null} if no coercion is allowed for it
+     */
+    @Nullable
+    private Number coerceToNumber(JsonNode node, boolean integral) throws IOException {
+        if (node.isString()) {
+            if (!coercionPolicy.isAllowed(Coercion.STRING_AS_NUMBER)) {
+                return null;
+            }
+            String string = node.getStringValue();
+            try {
+                return integral ? new BigInteger(string) : new BigDecimal(string);
+            } catch (NumberFormatException e) {
+                throw createDeserializationException("Unable to coerce string to number", string);
+            }
+        }
+        if (node.isBoolean()) {
+            if (!coercionPolicy.isAllowed(Coercion.BOOLEAN_AS_NUMBER)) {
+                return null;
+            }
+            return node.getBooleanValue() ? 1 : 0;
+        }
+        return null;
+    }
+
+    /**
+     * Read the given node as a boolean, coercing it if the policy allows.
+     */
+    @Nullable
+    private Boolean coerceToBoolean(JsonNode node) {
+        if (node.isNumber() && coercionPolicy.isAllowed(Coercion.NUMBER_AS_BOOLEAN)) {
+            return node.getNumberValue().doubleValue() != 0;
+        }
+        if (node.isString() && coercionPolicy.isAllowed(Coercion.STRING_AS_BOOLEAN)) {
+            return Boolean.parseBoolean(node.getStringValue());
+        }
+        return null;
+    }
+
+    /**
+     * Check the coercion needed to unwrap a single element array into a single value.
+     */
+    private void checkUnwrapArray() throws IOException {
+        if (!coercionPolicy.isAllowed(Coercion.UNWRAP_SINGLE_VALUE_ARRAY)) {
+            throw createDeserializationException(Coercion.UNWRAP_SINGLE_VALUE_ARRAY.message(), null);
+        }
     }
 
     protected abstract JsonNode peekValue() throws IOException;
+
+    @Override
+    public final CoercionPolicy getCoercionPolicy() {
+        return coercionPolicy;
+    }
 
     private static NullValueSerdeException unexpectedNullToken(String expected) {
         return NullValueSerdeException.unexpectedToken(expected, "NULL");
@@ -59,7 +144,7 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
         JsonNode peeked = peekValue();
         if (peeked.isArray()) {
             skipValue();
-            return new JsonArrayNodeDecoder(peeked, childLimits());
+            return new JsonArrayNodeDecoder(peeked, childLimits(), coercionPolicy);
         } else {
             throw createDeserializationException("Not an array", toArbitrary(peeked));
         }
@@ -70,7 +155,7 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
         JsonNode peeked = peekValue();
         if (peeked.isObject()) {
             skipValue();
-            return new JsonObjectNodeDecoder(peeked, childLimits());
+            return new JsonObjectNodeDecoder(peeked, childLimits(), coercionPolicy);
         } else {
             throw createDeserializationException("Not an array", toArbitrary(peeked));
         }
@@ -85,6 +170,7 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
         } else if (peeked.isNull()) {
             throw unexpectedNullToken("STRING");
         } else if (peeked.isArray()) {
+            checkUnwrapArray();
             try (Decoder decoder = decodeArray(Argument.STRING)) {
                 String unwrapped = decoder.decodeString();
                 if (decoder.hasNextArrayValue()) {
@@ -93,6 +179,9 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
                     return unwrapped;
                 }
             }
+        } else if ((peeked.isNumber() || peeked.isBoolean()) && coercionPolicy.isAllowed(Coercion.SCALAR_AS_STRING)) {
+            skipValue();
+            return peeked.coerceStringValue();
         } else {
             throw createDeserializationException("Not a string", toArbitrary(peeked));
         }
@@ -107,6 +196,7 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
         } else if (peeked.isNull()) {
             throw unexpectedNullToken("BOOLEAN");
         } else if (peeked.isArray()) {
+            checkUnwrapArray();
             try (Decoder decoder = decodeArray(Argument.BOOLEAN)) {
                 boolean unwrapped = decoder.decodeBoolean();
                 if (decoder.hasNextArrayValue()) {
@@ -116,7 +206,12 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
                 }
             }
         } else {
-            throw createDeserializationException("Not a boolean", toArbitrary(peeked));
+            Boolean coerced = coerceToBoolean(peeked);
+            if (coerced == null) {
+                throw createDeserializationException("Not a boolean", toArbitrary(peeked));
+            }
+            skipValue();
+            return coerced;
         }
     }
 
@@ -124,11 +219,13 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
     public byte decodeByte() throws IOException {
         JsonNode peeked = peekValue();
         if (peeked.isNumber()) {
+            checkIntegerNode(peeked);
             skipValue();
             return (byte) peeked.getIntValue();
         } else if (peeked.isNull()) {
             throw unexpectedNullToken("NUMBER");
         } else if (peeked.isArray()) {
+            checkUnwrapArray();
             try (Decoder decoder = decodeArray(Argument.BYTE)) {
                 byte unwrapped = decoder.decodeByte();
                 if (decoder.hasNextArrayValue()) {
@@ -138,7 +235,12 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
                 }
             }
         } else {
-            throw createDeserializationException("Not a number", toArbitrary(peeked));
+            Number coerced = coerceToNumber(peeked, true);
+            if (coerced == null) {
+                throw createDeserializationException("Not a number", toArbitrary(peeked));
+            }
+            skipValue();
+            return (byte) coerced.intValue();
         }
     }
 
@@ -146,11 +248,13 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
     public short decodeShort() throws IOException {
         JsonNode peeked = peekValue();
         if (peeked.isNumber()) {
+            checkIntegerNode(peeked);
             skipValue();
             return (short) peeked.getIntValue();
         } else if (peeked.isNull()) {
             throw unexpectedNullToken("NUMBER");
         } else if (peeked.isArray()) {
+            checkUnwrapArray();
             try (Decoder decoder = decodeArray(Argument.SHORT)) {
                 short unwrapped = decoder.decodeShort();
                 if (decoder.hasNextArrayValue()) {
@@ -160,7 +264,12 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
                 }
             }
         } else {
-            throw createDeserializationException("Not a number", toArbitrary(peeked));
+            Number coerced = coerceToNumber(peeked, true);
+            if (coerced == null) {
+                throw createDeserializationException("Not a number", toArbitrary(peeked));
+            }
+            skipValue();
+            return (short) coerced.intValue();
         }
     }
 
@@ -168,11 +277,13 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
     public char decodeChar() throws IOException {
         JsonNode peeked = peekValue();
         if (peeked.isNumber()) {
+            checkIntegerNode(peeked);
             skipValue();
             return (char) peeked.getIntValue();
         } else if (peeked.isNull()) {
             throw unexpectedNullToken("NUMBER");
         } else if (peeked.isArray()) {
+            checkUnwrapArray();
             try (Decoder decoder = decodeArray(Argument.CHAR)) {
                 char unwrapped = decoder.decodeChar();
                 if (decoder.hasNextArrayValue()) {
@@ -182,7 +293,12 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
                 }
             }
         } else {
-            throw createDeserializationException("Not a number", toArbitrary(peeked));
+            Number coerced = coerceToNumber(peeked, true);
+            if (coerced == null) {
+                throw createDeserializationException("Not a number", toArbitrary(peeked));
+            }
+            skipValue();
+            return (char) coerced.intValue();
         }
     }
 
@@ -190,11 +306,13 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
     public int decodeInt() throws IOException {
         JsonNode peeked = peekValue();
         if (peeked.isNumber()) {
+            checkIntegerNode(peeked);
             skipValue();
             return peeked.getIntValue();
         } else if (peeked.isNull()) {
             throw unexpectedNullToken("NUMBER");
         } else if (peeked.isArray()) {
+            checkUnwrapArray();
             try (Decoder decoder = decodeArray(Argument.INT)) {
                 int unwrapped = decoder.decodeInt();
                 if (decoder.hasNextArrayValue()) {
@@ -204,7 +322,12 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
                 }
             }
         } else {
-            throw createDeserializationException("Not a number", toArbitrary(peeked));
+            Number coerced = coerceToNumber(peeked, true);
+            if (coerced == null) {
+                throw createDeserializationException("Not a number", toArbitrary(peeked));
+            }
+            skipValue();
+            return coerced.intValue();
         }
     }
 
@@ -212,11 +335,13 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
     public long decodeLong() throws IOException {
         JsonNode peeked = peekValue();
         if (peeked.isNumber()) {
+            checkIntegerNode(peeked);
             skipValue();
             return peeked.getLongValue();
         } else if (peeked.isNull()) {
             throw unexpectedNullToken("NUMBER");
         } else if (peeked.isArray()) {
+            checkUnwrapArray();
             try (Decoder decoder = decodeArray(Argument.LONG)) {
                 long unwrapped = decoder.decodeLong();
                 if (decoder.hasNextArrayValue()) {
@@ -226,7 +351,12 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
                 }
             }
         } else {
-            throw createDeserializationException("Not a number", toArbitrary(peeked));
+            Number coerced = coerceToNumber(peeked, true);
+            if (coerced == null) {
+                throw createDeserializationException("Not a number", toArbitrary(peeked));
+            }
+            skipValue();
+            return coerced.longValue();
         }
     }
 
@@ -239,6 +369,7 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
         } else if (peeked.isNull()) {
             throw unexpectedNullToken("NUMBER");
         } else if (peeked.isArray()) {
+            checkUnwrapArray();
             try (Decoder decoder = decodeArray(Argument.FLOAT)) {
                 float unwrapped = decoder.decodeFloat();
                 if (decoder.hasNextArrayValue()) {
@@ -248,7 +379,12 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
                 }
             }
         } else {
-            throw createDeserializationException("Not a number", toArbitrary(peeked));
+            Number coerced = coerceToNumber(peeked, false);
+            if (coerced == null) {
+                throw createDeserializationException("Not a number", toArbitrary(peeked));
+            }
+            skipValue();
+            return coerced.floatValue();
         }
     }
 
@@ -261,6 +397,7 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
         } else if (peeked.isNull()) {
             throw unexpectedNullToken("NUMBER");
         } else if (peeked.isArray()) {
+            checkUnwrapArray();
             try (Decoder decoder = decodeArray(Argument.DOUBLE)) {
                 double unwrapped = decoder.decodeDouble();
                 if (decoder.hasNextArrayValue()) {
@@ -270,7 +407,12 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
                 }
             }
         } else {
-            throw createDeserializationException("Not a number", toArbitrary(peeked));
+            Number coerced = coerceToNumber(peeked, false);
+            if (coerced == null) {
+                throw createDeserializationException("Not a number", toArbitrary(peeked));
+            }
+            skipValue();
+            return coerced.doubleValue();
         }
     }
 
@@ -278,11 +420,13 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
     public BigInteger decodeBigInteger() throws IOException {
         JsonNode peeked = peekValue();
         if (peeked.isNumber()) {
+            checkIntegerNode(peeked);
             skipValue();
             return peeked.getBigIntegerValue();
         } else if (peeked.isNull()) {
             throw unexpectedNullToken("NUMBER");
         } else if (peeked.isArray()) {
+            checkUnwrapArray();
             try (Decoder decoder = decodeArray()) {
                 BigInteger unwrapped = decoder.decodeBigInteger();
                 if (decoder.hasNextArrayValue()) {
@@ -292,7 +436,12 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
                 }
             }
         } else {
-            throw createDeserializationException("Not a number", toArbitrary(peeked));
+            Number coerced = coerceToNumber(peeked, true);
+            if (coerced == null) {
+                throw createDeserializationException("Not a number", toArbitrary(peeked));
+            }
+            skipValue();
+            return coerced instanceof BigInteger big ? big : BigInteger.valueOf(coerced.longValue());
         }
     }
 
@@ -305,6 +454,7 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
         } else if (peeked.isNull()) {
             throw unexpectedNullToken("NUMBER");
         } else if (peeked.isArray()) {
+            checkUnwrapArray();
             try (Decoder decoder = decodeArray()) {
                 BigDecimal unwrapped = decoder.decodeBigDecimal();
                 if (decoder.hasNextArrayValue()) {
@@ -314,7 +464,12 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
                 }
             }
         } else {
-            throw createDeserializationException("Not a number", toArbitrary(peeked));
+            Number coerced = coerceToNumber(peeked, false);
+            if (coerced == null) {
+                throw createDeserializationException("Not a number", toArbitrary(peeked));
+            }
+            skipValue();
+            return coerced instanceof BigDecimal big ? big : new BigDecimal(coerced.toString());
         }
     }
 
@@ -382,7 +537,7 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
     public Decoder decodeBuffer() throws IOException {
         JsonNode peeked = peekValue();
         skipValue();
-        return new Buffered(peeked, ourLimits());
+        return new Buffered(peeked, ourLimits(), coercionPolicy);
     }
 
     @Override
@@ -398,8 +553,8 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
         private final JsonNode node;
         private boolean complete = false;
 
-        Buffered(JsonNode node, RemainingLimits remainingLimits) {
-            super(remainingLimits);
+        Buffered(JsonNode node, RemainingLimits remainingLimits, CoercionPolicy coercionPolicy) {
+            super(remainingLimits, coercionPolicy);
             this.node = node;
         }
 

--- a/serde-support/src/main/java/io/micronaut/serde/support/util/JsonNodeDecoder.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/util/JsonNodeDecoder.java
@@ -276,6 +276,15 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
     @Override
     public char decodeChar() throws IOException {
         JsonNode peeked = peekValue();
+        if (peeked.isString()) {
+            // a single character string is the natural shape of a char, not a coercion
+            String string = peeked.getStringValue();
+            if (string.length() != 1) {
+                throw createDeserializationException("When decoding char value, must give a single character", string);
+            }
+            skipValue();
+            return string.charAt(0);
+        }
         if (peeked.isNumber()) {
             checkIntegerNode(peeked);
             skipValue();

--- a/serde-support/src/main/java/io/micronaut/serde/support/util/JsonNodeDecoder.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/util/JsonNodeDecoder.java
@@ -92,7 +92,7 @@ public abstract sealed class JsonNodeDecoder extends LimitingStream implements D
             String string = node.getStringValue();
             try {
                 return integral ? new BigInteger(string) : new BigDecimal(string);
-            } catch (NumberFormatException e) {
+            } catch (NumberFormatException _) {
                 throw createDeserializationException("Unable to coerce string to number", string);
             }
         }

--- a/serde-support/src/main/java/io/micronaut/serde/support/util/JsonObjectNodeDecoder.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/util/JsonObjectNodeDecoder.java
@@ -16,6 +16,7 @@
 package io.micronaut.serde.support.util;
 
 import io.micronaut.json.tree.JsonNode;
+import io.micronaut.serde.config.CoercionPolicy;
 import io.micronaut.serde.Keys;
 import io.micronaut.serde.KeysAwareDecoder;
 import org.jspecify.annotations.Nullable;
@@ -30,8 +31,8 @@ final class JsonObjectNodeDecoder extends JsonNodeDecoder implements KeysAwareDe
     @Nullable
     private JsonNode nextValue = null;
 
-    JsonObjectNodeDecoder(JsonNode node, RemainingLimits remainingLimits) {
-        super(remainingLimits);
+    JsonObjectNodeDecoder(JsonNode node, RemainingLimits remainingLimits, CoercionPolicy coercionPolicy) {
+        super(remainingLimits, coercionPolicy);
         iterator = node.entries().iterator();
     }
 

--- a/serde-support/src/test/groovy/io/micronaut/serde/support/util/JsonNodeDecoderCoercionSpec.groovy
+++ b/serde-support/src/test/groovy/io/micronaut/serde/support/util/JsonNodeDecoderCoercionSpec.groovy
@@ -1,0 +1,245 @@
+package io.micronaut.serde.support.util
+
+import io.micronaut.json.tree.JsonNode
+import io.micronaut.serde.Decoder
+import io.micronaut.serde.LimitingStream
+import io.micronaut.serde.config.CoercionPolicy
+import io.micronaut.serde.exceptions.SerdeException
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * The tree decoder reads every value that is buffered before it is deserialized, so it has to
+ * accept and reject exactly what the streaming decoders do.
+ */
+class JsonNodeDecoderCoercionSpec extends Specification {
+
+    private static Decoder decoder(JsonNode node, CoercionPolicy policy) {
+        return JsonNodeDecoder.create(node, LimitingStream.DEFAULT_LIMITS, policy)
+    }
+
+    private static final JsonNode FLOAT = JsonNode.createNumberNode(42.5d)
+    private static final JsonNode INT = JsonNode.createNumberNode(42)
+    private static final JsonNode STRING_NUMBER = JsonNode.createStringNode('42')
+    private static final JsonNode TRUE = JsonNode.createBooleanNode(true)
+
+    @Unroll
+    void "a float node read as #method is a coercion"() {
+        expect: 'truncated when allowed'
+        decoder(FLOAT, CoercionPolicy.LENIENT)."$method"() == truncated
+
+        when:
+        decoder(FLOAT, CoercionPolicy.STRICT)."$method"()
+
+        then:
+        thrown SerdeException
+
+        where:
+        method             || truncated
+        'decodeByte'       || (byte) 42
+        'decodeShort'      || (short) 42
+        'decodeInt'        || 42
+        'decodeLong'       || 42L
+        'decodeChar'       || (char) 42
+        'decodeBigInteger' || BigInteger.valueOf(42)
+    }
+
+    @Unroll
+    void "a string node read as #method is a coercion"() {
+        expect:
+        decoder(STRING_NUMBER, CoercionPolicy.LENIENT)."$method"() == parsed
+
+        when:
+        decoder(STRING_NUMBER, CoercionPolicy.STRICT)."$method"()
+
+        then:
+        thrown SerdeException
+
+        where:
+        method             || parsed
+        'decodeByte'       || (byte) 42
+        'decodeShort'      || (short) 42
+        'decodeInt'        || 42
+        'decodeLong'       || 42L
+        'decodeFloat'      || 42f
+        'decodeDouble'     || 42d
+        'decodeBigInteger' || BigInteger.valueOf(42)
+        'decodeBigDecimal' || BigDecimal.valueOf(42)
+    }
+
+    @Unroll
+    void "a boolean node read as #method is a coercion"() {
+        expect:
+        decoder(TRUE, CoercionPolicy.LENIENT)."$method"() == one
+
+        when:
+        decoder(TRUE, CoercionPolicy.STRICT)."$method"()
+
+        then:
+        thrown SerdeException
+
+        where:
+        method             || one
+        'decodeByte'       || (byte) 1
+        'decodeShort'      || (short) 1
+        'decodeInt'        || 1
+        'decodeLong'       || 1L
+        'decodeFloat'      || 1f
+        'decodeDouble'     || 1d
+        'decodeBigInteger' || BigInteger.ONE
+        'decodeBigDecimal' || BigDecimal.ONE
+    }
+
+    void "a number or boolean node read as a string is a coercion"() {
+        expect:
+        decoder(INT, CoercionPolicy.LENIENT).decodeString() == '42'
+        decoder(FLOAT, CoercionPolicy.LENIENT).decodeString() == '42.5'
+        decoder(TRUE, CoercionPolicy.LENIENT).decodeString() == 'true'
+
+        when:
+        decoder(INT, CoercionPolicy.STRICT).decodeString()
+
+        then:
+        thrown SerdeException
+
+        when:
+        decoder(TRUE, CoercionPolicy.STRICT).decodeString()
+
+        then:
+        thrown SerdeException
+    }
+
+    void "a number or string node read as a boolean is a coercion"() {
+        expect:
+        decoder(INT, CoercionPolicy.LENIENT).decodeBoolean()
+        decoder(FLOAT, CoercionPolicy.LENIENT).decodeBoolean()
+        !decoder(JsonNode.createNumberNode(0), CoercionPolicy.LENIENT).decodeBoolean()
+        decoder(JsonNode.createStringNode('true'), CoercionPolicy.LENIENT).decodeBoolean()
+        !decoder(JsonNode.createStringNode('nope'), CoercionPolicy.LENIENT).decodeBoolean()
+
+        when:
+        decoder(INT, CoercionPolicy.STRICT).decodeBoolean()
+
+        then:
+        thrown SerdeException
+
+        when:
+        decoder(JsonNode.createStringNode('true'), CoercionPolicy.STRICT).decodeBoolean()
+
+        then:
+        thrown SerdeException
+    }
+
+    @Unroll
+    void "a single element array read as #method is a coercion"() {
+        given:
+        def array = JsonNode.createArrayNode([INT])
+
+        expect:
+        decoder(array, CoercionPolicy.LENIENT)."$method"() == unwrapped
+
+        when:
+        decoder(array, CoercionPolicy.STRICT)."$method"()
+
+        then:
+        thrown SerdeException
+
+        where:
+        method             || unwrapped
+        'decodeByte'       || (byte) 42
+        'decodeShort'      || (short) 42
+        'decodeInt'        || 42
+        'decodeLong'       || 42L
+        'decodeFloat'      || 42f
+        'decodeDouble'     || 42d
+        'decodeBigInteger' || BigInteger.valueOf(42)
+        'decodeBigDecimal' || BigDecimal.valueOf(42)
+        'decodeChar'       || (char) 42
+    }
+
+    void "a single element string array read as a string is a coercion"() {
+        given:
+        def array = JsonNode.createArrayNode([JsonNode.createStringNode('a')])
+
+        expect:
+        decoder(array, CoercionPolicy.LENIENT).decodeString() == 'a'
+
+        when:
+        decoder(array, CoercionPolicy.STRICT).decodeString()
+
+        then:
+        thrown SerdeException
+    }
+
+    void "a single element boolean array read as a boolean is a coercion"() {
+        given:
+        def array = JsonNode.createArrayNode([TRUE])
+
+        expect:
+        decoder(array, CoercionPolicy.LENIENT).decodeBoolean()
+
+        when:
+        decoder(array, CoercionPolicy.STRICT).decodeBoolean()
+
+        then:
+        thrown SerdeException
+    }
+
+    void "values of the right shape are read under the strict policy"() {
+        expect:
+        decoder(INT, CoercionPolicy.STRICT).decodeInt() == 42
+        decoder(INT, CoercionPolicy.STRICT).decodeLong() == 42L
+        decoder(INT, CoercionPolicy.STRICT).decodeByte() == (byte) 42
+        decoder(INT, CoercionPolicy.STRICT).decodeShort() == (short) 42
+        decoder(INT, CoercionPolicy.STRICT).decodeBigInteger() == BigInteger.valueOf(42)
+        decoder(INT, CoercionPolicy.STRICT).decodeChar() == (char) 42
+        decoder(FLOAT, CoercionPolicy.STRICT).decodeFloat() == 42.5f
+        decoder(FLOAT, CoercionPolicy.STRICT).decodeDouble() == 42.5d
+        decoder(FLOAT, CoercionPolicy.STRICT).decodeBigDecimal() == BigDecimal.valueOf(42.5d)
+        decoder(JsonNode.createStringNode('a'), CoercionPolicy.STRICT).decodeString() == 'a'
+        decoder(TRUE, CoercionPolicy.STRICT).decodeBoolean()
+    }
+
+    void "an unparseable string is reported whatever the policy"() {
+        when:
+        decoder(JsonNode.createStringNode('nope'), CoercionPolicy.LENIENT).decodeInt()
+
+        then:
+        thrown SerdeException
+    }
+
+    void "the decoder exposes its policy and passes it to buffered decoders"() {
+        given:
+        def d = decoder(FLOAT, CoercionPolicy.STRICT)
+
+        expect:
+        d.getCoercionPolicy().is(CoercionPolicy.STRICT)
+        decoder(FLOAT, CoercionPolicy.LENIENT).decodeBuffer().getCoercionPolicy().is(CoercionPolicy.LENIENT)
+
+        when:
+        decoder(FLOAT, CoercionPolicy.STRICT).decodeBuffer().decodeInt()
+
+        then:
+        thrown SerdeException
+    }
+
+    void "object and array decoders inherit the policy"() {
+        given:
+        def object = JsonNode.createObjectNode([value: FLOAT])
+        def array = JsonNode.createArrayNode([FLOAT, FLOAT])
+
+        when:
+        def objectDecoder = decoder(object, CoercionPolicy.STRICT).decodeObject()
+        objectDecoder.decodeKey()
+        objectDecoder.decodeInt()
+
+        then:
+        thrown SerdeException
+
+        when:
+        decoder(array, CoercionPolicy.STRICT).decodeArray().decodeInt()
+
+        then:
+        thrown SerdeException
+    }
+}

--- a/serde-support/src/test/groovy/io/micronaut/serde/support/util/JsonNodeDecoderCoercionSpec.groovy
+++ b/serde-support/src/test/groovy/io/micronaut/serde/support/util/JsonNodeDecoderCoercionSpec.groovy
@@ -200,6 +200,29 @@ class JsonNodeDecoderCoercionSpec extends Specification {
         decoder(TRUE, CoercionPolicy.STRICT).decodeBoolean()
     }
 
+    @Unroll
+    void "a single character string is the natural shape of a char (#policyName)"() {
+        expect: 'accepted whatever the policy, like the streaming decoder'
+        decoder(JsonNode.createStringNode('a'), policy).decodeChar() == (char) 'a'
+
+        when: 'more than one character is not a char'
+        decoder(JsonNode.createStringNode('42'), policy).decodeChar()
+
+        then:
+        thrown SerdeException
+
+        when:
+        decoder(JsonNode.createStringNode(''), policy).decodeChar()
+
+        then:
+        thrown SerdeException
+
+        where:
+        policyName | policy
+        'lenient'  | CoercionPolicy.LENIENT
+        'strict'   | CoercionPolicy.STRICT
+    }
+
     void "an unparseable string is reported whatever the policy"() {
         when:
         decoder(JsonNode.createStringNode('nope'), CoercionPolicy.LENIENT).decodeInt()

--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -6,6 +6,8 @@ This section documents breaking changes between Micronaut Serialization versions
 
 - Which coercions the decoders perform is now configurable, see <<coercion>>. Every coercion stays enabled by default, so the shapes accepted for a given property are unchanged.
 
+- A `char` is read the same way whatever the format and whether or not the value was buffered. A single character string is its natural shape and is accepted in every mode; a number is its code point; and a floating point number is truncated to a code point rather than yielding the first character of its text, which is what the Jackson decoder used to do for `9.75` and `true`.
+
 - A property that is buffered before it is read, because a polymorphic discriminator or a creator argument appears later in the document, is now coerced exactly like a property that is read inline. Previously the buffered path rejected a string read into a numeric property, and a number read into a `String` property, while the inline path accepted them, so whether a document was accepted depended on the order of its properties.
 
 === Micronaut Serialization 3.0.0

--- a/src/main/docs/guide/breaks.adoc
+++ b/src/main/docs/guide/breaks.adoc
@@ -1,5 +1,13 @@
 This section documents breaking changes between Micronaut Serialization versions:
 
+=== Micronaut Serialization 3.2.0
+
+==== Deserialization
+
+- Which coercions the decoders perform is now configurable, see <<coercion>>. Every coercion stays enabled by default, so the shapes accepted for a given property are unchanged.
+
+- A property that is buffered before it is read, because a polymorphic discriminator or a creator argument appears later in the document, is now coerced exactly like a property that is read inline. Previously the buffered path rejected a string read into a numeric property, and a number read into a `String` property, while the inline path accepted them, so whether a document was accepted depended on the order of its properties.
+
 === Micronaut Serialization 3.0.0
 
 ==== Deserialization

--- a/src/main/docs/guide/coercion.adoc
+++ b/src/main/docs/guide/coercion.adoc
@@ -71,7 +71,7 @@ NOTE: `unwrap-single-value-arrays` is the opposite direction of `accept-single-v
 
 === Scope
 
-The setting applies to every format: JSON through Jackson, JSON-P, JSON-B, BSON and Oracle JDBC JSON all read it from the same configuration, and it holds however a value reaches a property, including values that are buffered first because a polymorphic discriminator or a creator argument appears later in the document.
+The setting applies to every format: JSON through Jackson, CBOR, JSON-P, JSON-B, BSON and Oracle JDBC JSON all read it from the same configuration, and it holds however a value reaches a property, including values that are buffered first because a polymorphic discriminator or a creator argument appears later in the document.
 
 XML is not affected, because every scalar in an XML document is textual and there is no shape to coerce from.
 

--- a/src/main/docs/guide/coercion.adoc
+++ b/src/main/docs/guide/coercion.adoc
@@ -1,0 +1,99 @@
+When a value in the document does not have the shape of the property it is read into, the decoders coerce it. A JSON string is read into an `int` property, a number is read into a `String` property, and a floating point number is truncated into an integer property:
+
+[source,json]
+----
+{"id": "1234", "name": 42, "count": 9.75}
+----
+
+[source,java]
+----
+@Serdeable
+record Item(int id, String name, int count) {} // id = 1234, name = "42", count = 9
+----
+
+This is the historical behaviour and remains the default, so that existing applications are unaffected. Applications that would rather reject input of the wrong shape, for example a public API that should answer `400` instead of silently truncating a value, can restrict which coercions are allowed.
+
+=== Rejecting All Coercions
+
+Set the coercion mode to `STRICT` to require every value to have the shape of the property it is read into:
+
+[configuration]
+----
+micronaut:
+  serde:
+    deserialization:
+      coercion-mode: STRICT
+----
+
+With the configuration above, all three properties in the document at the top are rejected with an `InvalidFormatException` naming the offending value, while `{"id": 1234, "name": "42", "count": 9}` still reads.
+
+=== Selecting Individual Coercions
+
+Each coercion can also be turned on or off on its own. An individual setting always wins over the mode, so a strict application can allow just the coercions it needs:
+
+[configuration]
+----
+micronaut:
+  serde:
+    deserialization:
+      coercion-mode: STRICT
+      accept-string-as-number: true
+----
+
+The available settings, all under `micronaut.serde.deserialization` and all enabled by default:
+
+|===
+|Property |Rejects when disabled
+
+|`accept-float-as-int`
+|`9.75` read into `int`, `long`, `short`, `byte`, `char` or `BigInteger`
+
+|`accept-string-as-number`
+|`"42"` read into any numeric type
+
+|`accept-boolean-as-number`
+|`true` read into any numeric type, as `1`
+
+|`accept-number-as-boolean`
+|`1` read into `boolean`, as any non-zero value
+
+|`accept-string-as-boolean`
+|`"true"` read into `boolean`
+
+|`accept-scalar-as-string`
+|`42` or `true` read into `String`
+
+|`unwrap-single-value-arrays`
+|`[42]` read into a single `int`
+|===
+
+NOTE: `unwrap-single-value-arrays` is the opposite direction of `accept-single-value-as-array`, which reads a single value into a collection property.
+
+=== Scope
+
+The setting applies to every format: JSON through Jackson, JSON-P, JSON-B, BSON and Oracle JDBC JSON all read it from the same configuration, and it holds however a value reaches a property, including values that are buffered first because a polymorphic discriminator or a creator argument appears later in the document.
+
+XML is not affected, because every scalar in an XML document is textual and there is no shape to coerce from.
+
+A custom api:serde.Decoder[] receives the resolved api:serde.config.CoercionPolicy[] the same way it receives the stream limits, and should consult it wherever it reads a value whose shape does not match the requested type:
+
+[source,java]
+----
+if (!coercionPolicy.isAllowed(CoercionPolicy.Coercion.STRING_AS_NUMBER)) {
+    throw createDeserializationException(CoercionPolicy.Coercion.STRING_AS_NUMBER.message(), text);
+}
+----
+
+For decoders that read many values, `CoercionPolicy` precalculates the set of shapes each target type accepts, so a check costs a single mask test:
+
+[source,java]
+----
+// once, when the decoder is created
+this.integerShapes = coercionPolicy.allowedShapes(CoercionPolicy.Target.INTEGER);
+// per value
+if ((integerShapes & shape.bit()) == 0) {
+    throw ...;
+}
+----
+
+A decoder that creates another decoder over the same data, in particular in `decodeBuffer()`, must pass its policy on, so that a document is accepted or rejected regardless of which decoder ends up reading a given value.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -20,6 +20,7 @@ jsonbAnnotations:
   extensionBeans: JSON-B Extension Beans
   programmaticConfiguration: Programmatic JSON-B Configuration
 bsonAnnotations: BSON Annotations
+coercion: Type Coercion
 serdes: Custom Serializers & Deserializers
 serdeImport: Enabling Serialization of External Classes
 keys: Custom Key Converters


### PR DESCRIPTION
Supersedes #1390, whose commits this branch builds on.

## Why not just the one flag

#1390 makes float-to-integer coercion configurable, which is the right thing to want. Generalising it is worth doing in the same change for three reasons.

**Float-to-int is one of seven coercions.** The decoders also read a string into a number, a boolean into a number, a number or boolean into a string, a string into a boolean, and a single element array into a scalar. Each would otherwise need its own constructor parameter threaded through every decoder.

**A single decoder is not enough.** With `accept-float-as-int: false` on #1390, this is rejected:

```json
{"type": "sub", "number": 42.5}
```

while this silently truncates to `42`:

```json
{"number": 42.5, "type": "sub"}
```

The second document buffers `number` until the discriminator resolves the subtype, and the buffer is read by `JsonNodeDecoder`, which #1390 does not touch. The same applies to creator arguments that appear after other properties. `Decoder#decodeBuffer` documents that `decoder.decodeX()` and `decoder.decodeBuffer().decodeX()` are equivalent.

**The decoders already disagree today.** On current `3.2.x`, with the default configuration, `{"type":"sub","number":"42"}` returns `42` but `{"number":"42","type":"sub"}` fails with `Not a number`, because `JsonNodeDecoder` is stricter than `JacksonDecoder` for string-to-number and scalar-to-string, and more lenient for float-to-int. Whether a document is accepted depends on the order of its properties. Both directions are fixed here.

## Configuration

```yaml
micronaut:
  serde:
    deserialization:
      coercion-mode: STRICT           # baseline: values must match the property shape
      accept-string-as-number: true   # except this one
```

The mode sets the baseline and an individual setting overrides it. All seven settings default to enabled, so behaviour is unchanged unless configured. `accept-float-as-int` keeps the name and semantics it has in #1390.

| Property | Rejects when disabled |
| --- | --- |
| `accept-float-as-int` | `9.75` into `int`, `long`, `short`, `byte`, `char`, `BigInteger` |
| `accept-string-as-number` | `"42"` into any numeric type |
| `accept-boolean-as-number` | `true` into any numeric type |
| `accept-number-as-boolean` | `1` into `boolean` |
| `accept-string-as-boolean` | `"true"` into `boolean` |
| `accept-scalar-as-string` | `42` or `true` into `String` |
| `unwrap-single-value-arrays` | `[42]` into a single `int` |

## Design

`CoercionPolicy` is resolved once from the configuration and passed to decoders the way `RemainingLimits` already is. When it is built it precalculates one bit set of acceptable value shapes per target type, so a decoder reads five ints when it is created and every check is an array lookup and a mask test rather than a re-derivation of which coercion a token would need. The `nextIntValue` / `nextStringValue` / `nextBooleanValue` fast paths in `JacksonDecoder` are untouched.

`JacksonDecoder`, `JsonNodeDecoder` and `AbstractStreamDecoder` all enforce it, so JSON, CBOR, JSON-B, BSON, JSON-P and Oracle JDBC JSON honour the same configuration. XML is deliberately unaffected: every scalar in an XML document is textual, there is no shape to coerce from.

`Decoder` gains a `getCoercionPolicy()` default method so a decoder that creates another over the same data passes its policy on, which is what makes the buffered and inline paths agree.

## Backwards compatibility

Every existing decoder constructor and factory is kept and defaults to `CoercionPolicy.LENIENT`. `Decoder#getCoercionPolicy()` and `AbstractStreamDecoder#isCurrentNumberFloat()` are both default methods, so a third party decoder compiles and behaves as before. A spec pins the whole historical coercion matrix under the default configuration.

One behaviour change, documented in the breaking changes page: a buffered property is now coerced exactly like an inline one, which is the order-dependence fix above.

`AbstractStreamDecoder#isCurrentNumberFloat()` is only called when floats are not allowed as integers. Its default implementation materialises the number, so a decoder whose parser consumes the value when it is read must override it. `BsonReaderDecoder`, `JsonParserDecoder` and `OracleJdbcJsonParserDecoder` do, answering from the token type.

## Tests

New specs for the coercion matrix, the strict mode end to end, both order-dependence fixes, and the policy reaching BSON and JSON-P. Full suite green across all modules.

## Performance

`PropertyValueKindBenchmark.deserialize`, generated deserializer, 10 scalar properties, against #1390 in a separate worktree. Four alternating A/B rounds so load drift cannot favour one side, compared on medians of the raw per-iteration data with a bootstrap confidence interval.

| valueKind | baseline | this branch | delta | 95% CI |
| --- | --- | --- | --- | --- |
| ALL_INT | 301.7 ns | 304.1 ns | +0.80% | [-0.03%, +1.81%] |
| ALL_STRING | 368.3 ns | 370.6 ns | +0.63% | [-0.74%, +1.48%] |

Both intervals include zero. Two of the four rounds were discarded because another workload on the machine drove the load average from 25 to 75 mid-run and the two sides then differed by up to 65% in a single round; those numbers are the machine, not the code. Worth re-running on CI or an idle machine before taking the point estimates as final.

`CoercionPolicyBenchmark` is added as a guard that strict and lenient cost the same, since with the precalculated masks they execute identical instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
