### PR TITLE
feat(serde): support strict builders when deserializing

### DIFF
--- a/doc-examples/example-java/src/main/java/example/ReleaseRequest.java
+++ b/doc-examples/example-java/src/main/java/example/ReleaseRequest.java
@@ -1,0 +1,61 @@
+package example;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+@Introspected(builder = @Introspected.IntrospectionBuilder(builderClass = ReleaseRequest.Builder.class))
+public class ReleaseRequest {
+
+    @JsonProperty(required = true) // <1>
+    private final String service;
+
+    @JsonProperty(defaultValue = "platform") // <2>
+    private final String owner;
+
+    private final String notes; // <3>
+
+    private ReleaseRequest(String service, String owner, String notes) {
+        this.service = service;
+        this.owner = owner;
+        this.notes = notes;
+    }
+
+    public String getService() {
+        return service;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public static final class Builder {
+        private String service;
+        private String owner;
+        private String notes;
+
+        public Builder service(String service) {
+            this.service = service;
+            return this;
+        }
+
+        public Builder owner(String owner) {
+            this.owner = owner;
+            return this;
+        }
+
+        public Builder notes(String notes) {
+            this.notes = notes;
+            return this;
+        }
+
+        public ReleaseRequest build() {
+            return new ReleaseRequest(service, owner, notes);
+        }
+    }
+}

--- a/doc-examples/example-java/src/test/java/example/StrictBuilderExampleTest.java
+++ b/doc-examples/example-java/src/test/java/example/StrictBuilderExampleTest.java
@@ -1,0 +1,40 @@
+package example;
+
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.ObjectMapper;
+import io.micronaut.serde.exceptions.SerdeException;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@MicronautTest
+public class StrictBuilderExampleTest {
+
+    @Test
+    void testDefaultValueIsAppliedForAMissingProperty(ObjectMapper objectMapper) throws IOException {
+        ReleaseRequest request = objectMapper.readValue(
+            "{\"service\":\"checkout\"}",
+            Argument.of(ReleaseRequest.class)
+        );
+
+        assertEquals("checkout", request.getService());
+        assertEquals("platform", request.getOwner());
+        assertNull(request.getNotes());
+    }
+
+    @Test
+    void testMissingRequiredPropertyIsRejected(ObjectMapper objectMapper) {
+        SerdeException e = assertThrows(SerdeException.class, () -> objectMapper.readValue(
+            "{\"owner\":\"growth\"}",
+            Argument.of(ReleaseRequest.class)
+        ));
+
+        assertTrue(e.getMessage().contains("Required property"));
+    }
+}

--- a/doc-examples/example-java/src/test/java/example/StrictBuilderExampleTest.java
+++ b/doc-examples/example-java/src/test/java/example/StrictBuilderExampleTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @MicronautTest
-public class StrictBuilderExampleTest {
+class StrictBuilderExampleTest {
 
     @Test
     void testDefaultValueIsAppliedForAMissingProperty(ObjectMapper objectMapper) throws IOException {

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/builder/StrictBuilderSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/builder/StrictBuilderSpec.groovy
@@ -1,0 +1,68 @@
+package io.micronaut.serde.jackson.builder
+
+import io.micronaut.serde.ObjectMapper
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+class StrictBuilderSpec extends Specification {
+    @Inject ObjectMapper objectMapper
+
+    void "test builder fails when a required property is missing"() {
+        when:
+        objectMapper.readValue('{"owner":"growth"}', TestBuildStrict)
+
+        then:
+        def e = thrown(Exception)
+        e.message.contains("Required property [String service] is not present in supplied data")
+    }
+
+    void "test builder fails when a required property is null"() {
+        when:
+        objectMapper.readValue('{"service":null}', TestBuildStrict)
+
+        then:
+        def e = thrown(Exception)
+        e.message.contains("Required property")
+    }
+
+    void "test builder applies declared default values for the properties missing from the input"() {
+        when:
+        def value = objectMapper.readValue('{"service":"checkout"}', TestBuildStrict)
+
+        then: "the declared default values are applied"
+        value.service == 'checkout'
+        value.owner == 'platform'
+        value.retries == 3
+
+        and: "a property without serialization metadata keeps the value assigned by the builder"
+        value.notes == 'none'
+    }
+
+    void "test builder keeps the supplied values over the declared default values"() {
+        when:
+        def value = objectMapper.readValue('{"service":"checkout","owner":"growth","retries":10,"notes":"rollback ready"}', TestBuildStrict)
+
+        then:
+        value.service == 'checkout'
+        value.owner == 'growth'
+        value.retries == 10
+        value.notes == 'rollback ready'
+    }
+
+    void "test builder required property declared on the builder method"() {
+        when:
+        objectMapper.readValue('{}', TestBuildStrictMethod)
+
+        then:
+        def e = thrown(Exception)
+        e.message.contains("Required property")
+
+        when:
+        def value = objectMapper.readValue('{"service":"checkout"}', TestBuildStrictMethod)
+
+        then:
+        value.service == 'checkout'
+    }
+}

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/builder/StrictBuilderSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/builder/StrictBuilderSpec.groovy
@@ -51,7 +51,16 @@ class StrictBuilderSpec extends Specification {
         value.notes == 'rollback ready'
     }
 
-    void "test builder required property declared on the builder method"() {
+    void "test builder does not apply declared defaults to explicit null values"() {
+        when:
+        def value = objectMapper.readValue('{"service":"checkout","owner":null}', TestBuildStrict)
+
+        then:
+        value.owner == null
+        value.retries == 3
+    }
+
+    void "test builder metadata declared on the builder method parameter"() {
         when:
         objectMapper.readValue('{}', TestBuildStrictMethod)
 
@@ -64,5 +73,6 @@ class StrictBuilderSpec extends Specification {
 
         then:
         value.service == 'checkout'
+        value.owner == 'platform'
     }
 }

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/SerdeableGeneratedSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/SerdeableGeneratedSpec.groovy
@@ -47,6 +47,31 @@ class SerdeableGeneratedSpec extends JsonCompileSpec {
         context.close()
     }
 
+    void 'test serdeable generated builder uses the runtime deserializer'() {
+        given:
+        def context = ApplicationContext.run()
+        jsonMapper = context.getBean(JsonMapper)
+        Argument argument = Argument.of(SourceGenBuilderShape)
+
+        when:
+        SourceGenBuilderShape decoded = jsonMapper.readValue('{"service":"checkout"}', argument)
+
+        then:
+        assertEligibility(context, SourceGenBuilderShape, false, false)
+        decoded.service == 'checkout'
+        decoded.owner == 'platform'
+
+        when:
+        jsonMapper.readValue('{}', argument)
+
+        then:
+        def e = thrown(Exception)
+        e.message.contains('Required property')
+
+        cleanup:
+        context.close()
+    }
+
     void 'test serdeable generated required false allows sourcegen fallback without generated classes'() {
         given:
         def context = ApplicationContext.run()

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/builder/TestBuildStrict.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/builder/TestBuildStrict.java
@@ -1,0 +1,69 @@
+package io.micronaut.serde.jackson.builder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import tools.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize(builder = TestBuildStrict.Builder.class)
+public class TestBuildStrict {
+    @JsonProperty(required = true)
+    private final String service;
+    @JsonProperty(defaultValue = "platform")
+    private final String owner;
+    @JsonProperty(defaultValue = "3")
+    private final int retries;
+    private final String notes;
+
+    private TestBuildStrict(String service, String owner, int retries, String notes) {
+        this.service = service;
+        this.owner = owner;
+        this.retries = retries;
+        this.notes = notes;
+    }
+
+    public String getService() {
+        return service;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public int getRetries() {
+        return retries;
+    }
+
+    public String getNotes() {
+        return notes;
+    }
+
+    public static final class Builder {
+        private String service;
+        private String owner;
+        private int retries;
+        private String notes = "none";
+
+        public Builder service(String service) {
+            this.service = service;
+            return this;
+        }
+
+        public Builder owner(String owner) {
+            this.owner = owner;
+            return this;
+        }
+
+        public Builder retries(int retries) {
+            this.retries = retries;
+            return this;
+        }
+
+        public Builder notes(String notes) {
+            this.notes = notes;
+            return this;
+        }
+
+        public TestBuildStrict build() {
+            return new TestBuildStrict(service, owner, retries, notes);
+        }
+    }
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/builder/TestBuildStrict.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/builder/TestBuildStrict.java
@@ -1,6 +1,7 @@
 package io.micronaut.serde.jackson.builder;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(builder = TestBuildStrict.Builder.class)
@@ -8,6 +9,7 @@ public class TestBuildStrict {
     @JsonProperty(required = true)
     private final String service;
     @JsonProperty(defaultValue = "platform")
+    @Nullable
     private final String owner;
     @JsonProperty(defaultValue = "3")
     private final int retries;

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/builder/TestBuildStrictMethod.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/builder/TestBuildStrictMethod.java
@@ -1,0 +1,30 @@
+package io.micronaut.serde.jackson.builder;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import tools.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize(builder = TestBuildStrictMethod.Builder.class)
+public class TestBuildStrictMethod {
+    private final String service;
+
+    private TestBuildStrictMethod(String service) {
+        this.service = service;
+    }
+
+    public String getService() {
+        return service;
+    }
+
+    public static final class Builder {
+        private String service;
+
+        public Builder service(@JsonProperty(required = true) String service) {
+            this.service = service;
+            return this;
+        }
+
+        public TestBuildStrictMethod build() {
+            return new TestBuildStrictMethod(service);
+        }
+    }
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenBuilderShape.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenBuilderShape.java
@@ -1,14 +1,18 @@
-package io.micronaut.serde.jackson.builder;
+package io.micronaut.serde.jackson.compiletime;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.serde.annotation.SerdeableGenerated;
 import tools.jackson.databind.annotation.JsonDeserialize;
 
-@JsonDeserialize(builder = TestBuildStrictMethod.Builder.class)
-public class TestBuildStrictMethod {
+@SerdeableGenerated(required = false)
+@JsonDeserialize(builder = SourceGenBuilderShape.Builder.class)
+public final class SourceGenBuilderShape {
+    @JsonProperty(required = true)
     private final String service;
+    @JsonProperty(defaultValue = "platform")
     private final String owner;
 
-    private TestBuildStrictMethod(String service, String owner) {
+    private SourceGenBuilderShape(String service, String owner) {
         this.service = service;
         this.owner = owner;
     }
@@ -25,18 +29,18 @@ public class TestBuildStrictMethod {
         private String service;
         private String owner;
 
-        public Builder service(@JsonProperty(required = true) String service) {
+        public Builder service(String service) {
             this.service = service;
             return this;
         }
 
-        public Builder owner(@JsonProperty(defaultValue = "platform") String owner) {
+        public Builder owner(String owner) {
             this.owner = owner;
             return this;
         }
 
-        public TestBuildStrictMethod build() {
-            return new TestBuildStrictMethod(service, owner);
+        public SourceGenBuilderShape build() {
+            return new SourceGenBuilderShape(service, owner);
         }
     }
 }

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/SimpleSerdeShapeAnalyzer.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/SimpleSerdeShapeAnalyzer.java
@@ -16,7 +16,9 @@
 package io.micronaut.serde.processor.sourcegen;
 
 import io.micronaut.core.annotation.AnnotationMetadata;
+import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.core.annotation.Creator;
+import io.micronaut.core.annotation.Introspected;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.Element;
 import io.micronaut.inject.ast.ElementQuery;
@@ -121,6 +123,14 @@ public final class SimpleSerdeShapeAnalyzer {
         }
         if (deserializerReasons.isEmpty() && hasAnnotation(element, SerdeConfig.SerAnySetter.class)) {
             failDeserializer(deserializerReasons, SimpleSerdeShapeDecision.FallbackReason.ANY_SETTER);
+            if (isBothFailed(serializerReasons, deserializerReasons)) {
+                return decision(shapeKind, serializerReasons, deserializerReasons);
+            }
+        }
+        // A type deserialized through a builder is handled by the introspection-backed deserializer,
+        // which owns the builder semantics such as required properties and declared default values.
+        if (deserializerReasons.isEmpty() && hasIntrospectionBuilder(element)) {
+            failDeserializer(deserializerReasons, SimpleSerdeShapeDecision.FallbackReason.UNSUPPORTED_SHAPE);
             if (isBothFailed(serializerReasons, deserializerReasons)) {
                 return decision(shapeKind, serializerReasons, deserializerReasons);
             }
@@ -481,6 +491,17 @@ public final class SimpleSerdeShapeAnalyzer {
             collectJacksonAnnotationsInTypeHierarchy(interfaceElement, annotations, visited);
         }
         classElement.getSuperType().ifPresent(superType -> collectJacksonAnnotationsInTypeHierarchy(superType, annotations, visited));
+    }
+
+    private static boolean hasIntrospectionBuilder(ClassElement element) {
+        AnnotationValue<Introspected> introspected = element.getAnnotation(Introspected.class);
+        if (introspected == null) {
+            return false;
+        }
+        return introspected.annotationClassValue("builderClass").isPresent()
+            || introspected.getAnnotation("builder", Introspected.IntrospectionBuilder.class)
+            .flatMap(builder -> builder.annotationClassValue("builderClass"))
+            .isPresent();
     }
 
     private SimpleSerdeShapeDecision.ShapeKind resolveShapeKind(ClassElement element) {

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBean.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/DeserBean.java
@@ -119,6 +119,11 @@ final class DeserBean<T> {
     public final boolean acceptCaseInsensitiveProperties;
 
     public final boolean hasBuilder;
+    /**
+     * Whether builder-backed deserialization has to finalize the properties that are missing from the
+     * input, which is the case when a builder property is required or declares a default value.
+     */
+    public final boolean finalizeBuilderProperties;
     public final ConversionService conversionService;
     public final Keys propertyKeys;
 
@@ -448,6 +453,7 @@ final class DeserBean<T> {
             }
         }
         this.injectPropertiesSize = injectProperties == null ? 0 : injectProperties.getDerProperties().size();
+        this.finalizeBuilderProperties = hasBuilder && requiresBuilderFinalization(injectProperties);
         this.wrapperProperty = introspection.stringValue(SerdeConfig.class, SerdeConfig.WRAPPER_PROPERTY).orElse(null);
 
         this.anySetter = anySetterValue;
@@ -1310,6 +1316,27 @@ final class DeserBean<T> {
             }
         }
 
+        /**
+         * Finalizes a builder property that is missing from the input.
+         *
+         * <p>Builders are treated as strict: a property marked as required has to be present in the
+         * input, and a property that declares a default value is initialized with it so that the
+         * builder sees the same value a constructor or a setter would.</p>
+         *
+         * @param builder The builder to initialize
+         * @throws SerdeException If the property is required and not present in the input
+         */
+        public void setDefaultBuilderValue(BeanIntrospection.Builder<B> builder) throws SerdeException {
+            if (explicitlyRequired) {
+                throw new SerdeException("Unable to deserialize type [" + introspection.getBeanType().getName() + "]. Required property [" + argument +
+                    "] is not present in supplied data");
+            }
+            P value = defaultValue;
+            if (value != null) {
+                builder.with(index, argument, value);
+            }
+        }
+
         public void setDefaultConstructorValue(Deserializer.DecoderContext decoderContext, Object[] params) throws SerdeException {
             decoderContext = resolveFeatures(decoderContext);
             params[index] = provideDefaultConstructorValue(decoderContext);
@@ -1814,6 +1841,18 @@ final class DeserBean<T> {
             return convertException(e, false);
         }
 
+    }
+
+    private static boolean requiresBuilderFinalization(@Nullable PropertiesBag<?> injectProperties) {
+        if (injectProperties == null) {
+            return false;
+        }
+        for (DerProperty<?, Object> property : injectProperties.getDerProperties()) {
+            if (property.explicitlyRequired || property.defaultValue != null) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static <B, P> AnnotationMetadata resolveArgumentMetadata(BeanIntrospection<B> introspection, Argument<P> argument, AnnotationMetadata annotationMetadata) {

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SpecificObjectDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SpecificObjectDeserializer.java
@@ -1711,13 +1711,17 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
 
         private final Conf conf;
         private final BeanIntrospection<Object> introspection;
+        private final PropertiesBag<? super Object> properties;
         private final PropertiesBag<? super Object>.Consumer propertiesConsumer;
+        private final boolean hasPropertiesToFinalize;
         private BeanIntrospection.@Nullable Builder<? super Object> builder;
 
         BuilderDeserializer(DeserBean<? super Object> db, Conf conf) {
             this.introspection = db.introspection;
             this.conf = conf;
-            this.propertiesConsumer = Objects.requireNonNull(db.injectProperties).newConsumer();
+            this.properties = Objects.requireNonNull(db.injectProperties);
+            this.propertiesConsumer = properties.newConsumer();
+            this.hasPropertiesToFinalize = db.finalizeBuilderProperties;
         }
 
         @Override
@@ -1754,10 +1758,34 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
 
         @Override
         public Object provideInstance(Argument<? super Object> objectArgument, DecoderContext decoderContext) throws IOException {
+            BeanIntrospection.Builder<? super Object> beanBuilder = Objects.requireNonNull(builder);
+            if (hasPropertiesToFinalize && !propertiesConsumer.isAllConsumed()) {
+                finalizeMissingProperties(decoderContext, beanBuilder);
+            }
             try {
-                return Objects.requireNonNull(builder).build();
+                return beanBuilder.build();
             } catch (InstantiationException e) {
                 throw new SerdeException(PREFIX_UNABLE_TO_DESERIALIZE_TYPE + introspection.getBeanType() + "]: " + e.getMessage(), e);
+            }
+        }
+
+        /**
+         * Applies the strict builder semantics to the properties that are missing from the input:
+         * a required property fails the deserialization and a property with a declared default value
+         * initializes the builder with that value.
+         */
+        private void finalizeMissingProperties(DecoderContext decoderContext,
+                                               BeanIntrospection.Builder<? super Object> beanBuilder) throws SerdeException {
+            DeserBean.DerProperty<Object, Object>[] propertiesArray = properties.getPropertiesArray();
+            for (int i = 0; i < propertiesArray.length; i++) {
+                if (propertiesConsumer.isConsumed(i)) {
+                    continue;
+                }
+                DeserBean.DerProperty<Object, Object> property = propertiesArray[i];
+                if (property.views != null && !decoderContext.hasView(property.views)) {
+                    continue;
+                }
+                property.setDefaultBuilderValue(beanBuilder);
             }
         }
     }

--- a/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SpecificObjectDeserializer.java
+++ b/serde-support/src/main/java/io/micronaut/serde/support/deserializers/SpecificObjectDeserializer.java
@@ -1778,14 +1778,11 @@ final class SpecificObjectDeserializer implements UpdatingDeserializer<Object> {
                                                BeanIntrospection.Builder<? super Object> beanBuilder) throws SerdeException {
             DeserBean.DerProperty<Object, Object>[] propertiesArray = properties.getPropertiesArray();
             for (int i = 0; i < propertiesArray.length; i++) {
-                if (propertiesConsumer.isConsumed(i)) {
-                    continue;
-                }
                 DeserBean.DerProperty<Object, Object> property = propertiesArray[i];
-                if (property.views != null && !decoderContext.hasView(property.views)) {
-                    continue;
+                if (!propertiesConsumer.isConsumed(i)
+                    && (property.views == null || decoderContext.hasView(property.views))) {
+                    property.setDefaultBuilderValue(beanBuilder);
                 }
-                property.setDefaultBuilderValue(beanBuilder);
             }
         }
     }

--- a/src/main/docs/guide/builders.adoc
+++ b/src/main/docs/guide/builders.adoc
@@ -1,0 +1,26 @@
+Micronaut Serialization can deserialize immutable types through a builder instead of a constructor or setters.
+A builder is used when the type declares one with `@Introspected(builder = ...)`, or with the `jackson-databind`
+`@JsonDeserialize(builder = ...)` annotation which is mapped to the same build-time metadata.
+
+Builders are treated as strict: every property of the builder participates in the same required and default value
+rules as a property that is populated through a constructor parameter or a setter. Before the build method is called,
+the properties that are missing from the input are finalized:
+
+* a property declared as required with `@JsonProperty(required = true)` fails the deserialization when it is absent from the input, or when it is present but `null`,
+* a property declaring a default value with `@JsonProperty(defaultValue = "...")` (or `@Bindable(defaultValue = "...")`) initializes the builder with that value,
+* every other property is left untouched so the defaults of the builder itself are preserved.
+
+The following builder-backed type declares one required property and one property with a default value:
+
+snippet::example.ReleaseRequest[project-base="doc-examples/example", source="main"]
+
+<1> `service` has to be present in the input
+<2> `owner` falls back to the declared default value when it is absent from the input
+<3> `notes` has no serialization metadata, so the builder decides its value
+
+Deserialization then rejects input that omits `service`, and applies the declared default value of `owner`:
+
+snippet::example.StrictBuilderExampleTest[project-base="doc-examples/example"]
+
+NOTE: A property that is absent from the input and has neither a required nor a default value declaration never calls
+the builder, which keeps the values a builder assigns itself, such as a Lombok `@Builder.Default` field.

--- a/src/main/docs/guide/toc.yml
+++ b/src/main/docs/guide/toc.yml
@@ -22,6 +22,7 @@ jsonbAnnotations:
   programmaticConfiguration: Programmatic JSON-B Configuration
 bsonAnnotations: BSON Annotations
 coercion: Type Coercion
+builders: Builders
 serdes: Custom Serializers & Deserializers
 serdeImport: Enabling Serialization of External Classes
 keys: Custom Key Converters


### PR DESCRIPTION
Implements strict builder semantics for builder-backed deserialization, following the strict builder behaviour requested in micronaut-projects/micronaut-sourcegen#197 (required attributes must be initialized before the object is built).

## Problem

Micronaut Serialization deserializes immutable types through a `BeanIntrospection.Builder` when the type declares one with `@Introspected(builder = ...)` or with the `jackson-databind` `@JsonDeserialize(builder = ...)` annotation.

That path called `build()` directly and never looked at the properties that were absent from the input, so builder-backed types silently dropped two rules that constructor- and setter-backed deserialization already honour:

- `@JsonProperty(required = true)` was accepted when the property was missing from the input
- `@JsonProperty(defaultValue = "...")` / `@Bindable(defaultValue = ...)` was never applied

## Changes

**`serde-support`**

- `DeserBean.DerProperty.setDefaultBuilderValue(...)` finalizes a builder property that is missing from the input: a required property fails the deserialization, and a property with a declared default value initializes the builder with that value.
- `DeserBean` precomputes a `finalizeBuilderProperties` flag per bean, so a builder whose properties declare neither `required` nor a default value keeps the previous code path and does not pay for the scan.
- `SpecificObjectDeserializer.BuilderDeserializer` walks the not-consumed properties before `build()`, only when that flag is set and something is actually unconsumed. Properties filtered out by the active `@JsonView` are skipped, and properties without required or default value metadata are left untouched so the defaults assigned by the builder itself (for example a Lombok `@Builder.Default` field) are preserved.

**`serde-processor`**

- `SimpleSerdeShapeAnalyzer` now falls back to the introspection-backed deserializer for a type that declares an introspection builder. Source-generated deserializers do not model builders, so the generated path could not express these semantics; this keeps generated and runtime deserialization aligned. Serializer generation is unaffected.

**Documentation**

- New `src/main/docs/guide/builders.adoc` guide page, added to `toc.yml`, describing builder-backed deserialization and the strict rules.
- Runnable example `ReleaseRequest` plus `StrictBuilderExampleTest` in `doc-examples/example-java`, referenced from the guide with `snippet::`.

**Tests**

- `StrictBuilderSpec` with the `TestBuildStrict` and `TestBuildStrictMethod` fixtures covers a missing required property, an explicitly `null` required property, declared default values applied for absent properties, supplied values winning over declared defaults, a property without metadata keeping the builder-assigned default, and `required` declared on a builder method parameter.

## Compatibility

A builder-backed type that declares `@JsonProperty(required = true)` now fails deserialization when that property is absent, where it previously built the object with the property unset. This aligns builder deserialization with the constructor and setter paths and is the point of the change. Types without required or default value metadata on their builder properties are unaffected.

No public API signatures changed: `DeserBean` is package-private and `@Internal`, and the `serde-processor` change adds a private static method.

## Verification

Run on JDK 25.

| Command | Result |
| --- | --- |
| `./gradlew :micronaut-serde-jackson:test` | pass (10/10 in `io.micronaut.serde.jackson.builder.*`) |
| `./gradlew :micronaut-serde-support:test` | pass |
| `./gradlew :micronaut-serde-processor:test` | pass |
| `./gradlew :micronaut-serde-bson:test` | pass (380 tests) |
| `./gradlew :micronaut-serde-oracle-jdbc-json:test` | pass (192 tests) |
| `./gradlew :test-suite-tck-serde:test` | pass |
| `./gradlew :test-suite-tck-jackson-databind:test` | pass |
| `./gradlew :micronaut-doc-examples:micronaut-example-java:test` | pass |
| `./gradlew -q cM spotlessCheck` | pass |
| `./gradlew -q docs` | pass |

`japiCmp` was not run because no public signature changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K6Sjc2DnKvse8EjT1Rsv2t

---
_Generated by [Claude Code](https://claude.ai/code/session_01K6Sjc2DnKvse8EjT1Rsv2t)_