### PR TITLE
Fix custom serde detection to include inherited annotations

### DIFF
--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeSourceGenEligibilitySpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeSourceGenEligibilitySpec.groovy
@@ -489,6 +489,140 @@ record XmlWrapperRecord(
         context.close()
     }
 
+    void 'test custom serializer and deserializer declared on the type are not sourcegen eligible'() {
+        given:
+        def context = buildContext('test.CustomSerdePayload', '''
+package test;
+
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.Serializer;
+import io.micronaut.serde.annotation.Serdeable;
+import io.micronaut.core.annotation.Introspected;
+import jakarta.inject.Singleton;
+import java.io.IOException;
+
+@Serdeable
+@Introspected
+@Serdeable.Serializable(using = CustomSerde.class)
+@Serdeable.Deserializable(using = CustomSerde.class)
+class CustomSerdePayload {
+    private String value;
+
+    public CustomSerdePayload() {
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}
+
+@Singleton
+class CustomSerde implements Serializer<CustomSerdePayload>, Deserializer<CustomSerdePayload> {
+    @Override
+    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends CustomSerdePayload> type, CustomSerdePayload value) throws IOException {
+        encoder.encodeString("custom");
+    }
+
+    @Override
+    public CustomSerdePayload deserialize(Decoder decoder, DecoderContext context, Argument<? super CustomSerdePayload> type) throws IOException {
+        decoder.skipValue();
+        CustomSerdePayload payload = new CustomSerdePayload();
+        payload.setValue("custom");
+        return payload;
+    }
+}
+''')
+
+        expect:
+        assertRegistrySelection(context, 'test.CustomSerdePayload', false, false)
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test custom serializer and deserializer inherited from an interface are not sourcegen eligible'() {
+        given:
+        def context = buildContext('test.VersionedPayload', '''
+package test;
+
+import io.micronaut.core.type.Argument;
+import io.micronaut.serde.Decoder;
+import io.micronaut.serde.Deserializer;
+import io.micronaut.serde.Encoder;
+import io.micronaut.serde.Serializer;
+import io.micronaut.serde.annotation.Serdeable;
+import io.micronaut.core.annotation.Introspected;
+import jakarta.inject.Singleton;
+import java.io.IOException;
+
+@Serdeable
+@Serdeable.Serializable(using = VersionedSerde.class)
+@Serdeable.Deserializable(using = VersionedSerde.class)
+interface Versioned {
+    String getValue();
+}
+
+@Serdeable
+@Introspected
+class VersionedPayload implements Versioned {
+    private String value;
+
+    public VersionedPayload() {
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}
+
+@Singleton
+class VersionedSerde<T extends Versioned> implements Serializer<T>, Deserializer<T> {
+    @Override
+    public void serialize(Encoder encoder, EncoderContext context, Argument<? extends T> type, T value) throws IOException {
+        encoder.encodeString("custom");
+    }
+
+    @Override
+    public T deserialize(Decoder decoder, DecoderContext context, Argument<? super T> type) throws IOException {
+        decoder.skipValue();
+        VersionedPayload payload = new VersionedPayload();
+        payload.setValue("custom");
+        return (T) payload;
+    }
+}
+''')
+
+        expect:
+        assertRegistrySelection(context, 'test.VersionedPayload', false, false)
+
+        when: 'the custom serde declared on the interface is applied to the implementation'
+        def customSerde = context.classLoader.loadClass('test.VersionedSerde')
+        Class<?> beanType = context.classLoader.loadClass('test.VersionedPayload')
+        Argument argument = Argument.of(beanType)
+        SerdeRegistry registry = context.getBean(SerdeRegistry)
+        Serializer serializer = registry.findSerializer(argument).createSpecific(registry.newEncoderContext(Object), argument)
+        Deserializer deserializer = registry.findDeserializer(argument).createSpecific(registry.newDecoderContext(Object), argument)
+
+        then:
+        customSerde.isInstance(serializer)
+        customSerde.isInstance(deserializer)
+
+        cleanup:
+        context.close()
+    }
+
     private static void assertRegistrySelection(def context,
                                                 String className,
                                                 boolean serializerGenerated,

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/SimpleSerdeShapeAnalyzer.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/SimpleSerdeShapeAnalyzer.java
@@ -27,7 +27,9 @@ import io.micronaut.inject.ast.EnumElement;
 import io.micronaut.inject.ast.MethodElement;
 import io.micronaut.inject.ast.ParameterElement;
 import io.micronaut.inject.ast.PropertyElement;
+import io.micronaut.serde.Deserializer;
 import io.micronaut.serde.FormatConfiguration;
+import io.micronaut.serde.Serializer;
 import io.micronaut.serde.annotation.Serdeable;
 import io.micronaut.serde.annotation.SerdeableGenerated;
 import io.micronaut.serde.config.annotation.SerdeConfig;
@@ -35,6 +37,7 @@ import io.micronaut.serde.config.naming.PropertyNamingStrategy;
 import io.micronaut.serde.util.SerdePropertyAccess;
 
 import java.lang.annotation.Annotation;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +50,8 @@ import java.util.function.Predicate;
 public final class SimpleSerdeShapeAnalyzer {
     private static final String SERDEABLE_SERIALIZABLE = Serdeable.Serializable.class.getName();
     private static final String SERDEABLE_DESERIALIZABLE = Serdeable.Deserializable.class.getName();
+    private static final String DEFAULT_SERIALIZER_CLASS = Serializer.class.getName();
+    private static final String DEFAULT_DESERIALIZER_CLASS = Deserializer.class.getName();
     private static final String JACKSON_ANNOTATION_PREFIX = "com.fasterxml.jackson.annotation.";
     private static final String BSON_REPRESENTATION = "org.bson.codecs.pojo.annotations.BsonRepresentation";
     private static final String JACKSON_DATAFORMAT = "tools.jackson.dataformat.";
@@ -778,9 +783,28 @@ public final class SimpleSerdeShapeAnalyzer {
     }
 
     private boolean hasCustomSerdeClassOverride(ClassElement element) {
-        AnnotationMetadata annotationMetadata = element.getAnnotationMetadata();
-        return annotationMetadata.classValue(SerdeConfig.class, SerdeConfig.SERIALIZER_CLASS).isPresent()
-            || annotationMetadata.classValue(SerdeConfig.class, SerdeConfig.DESERIALIZER_CLASS).isPresent();
+        return hasCustomSerdeClass(element.getAnnotationMetadata());
+    }
+
+    /**
+     * Checks whether a custom {@link Serializer} or {@link Deserializer} is configured, including
+     * configuration inherited from a supertype or interface.
+     *
+     * <p>The configured type is resolved by name because during annotation processing the referenced
+     * serializer or deserializer is often part of the same compilation round and therefore cannot be
+     * loaded as a {@link Class}.</p>
+     *
+     * @param annotationMetadata The annotation metadata
+     * @return Whether a custom serializer or deserializer is configured
+     */
+    private boolean hasCustomSerdeClass(AnnotationMetadata annotationMetadata) {
+        return hasCustomSerdeClass(annotationMetadata, SerdeConfig.SERIALIZER_CLASS, DEFAULT_SERIALIZER_CLASS)
+            || hasCustomSerdeClass(annotationMetadata, SerdeConfig.DESERIALIZER_CLASS, DEFAULT_DESERIALIZER_CLASS);
+    }
+
+    private boolean hasCustomSerdeClass(AnnotationMetadata annotationMetadata, String member, String defaultType) {
+        return annotationMetadata.stringValue(SerdeConfig.class, member).filter(type -> !type.equals(defaultType)).isPresent()
+            || Arrays.stream(annotationMetadata.stringValues(SerdeConfig.class, member)).anyMatch(type -> !type.equals(defaultType));
     }
 
     private boolean hasPotentialGlobalNamingConflict(ClassElement element) {
@@ -860,8 +884,7 @@ public final class SimpleSerdeShapeAnalyzer {
             || hasSerializeAsOverride(element)
             || hasDeserializeAsOverride(element)
             || hasCustomNaming(element)
-            || element.classValue(SerdeConfig.class, SerdeConfig.SERIALIZER_CLASS).isPresent()
-            || element.classValue(SerdeConfig.class, SerdeConfig.DESERIALIZER_CLASS).isPresent();
+            || hasCustomSerdeClass(element.getAnnotationMetadata());
     }
 
     private boolean hasUnsupportedSerdeConfigMetadata(AnnotationMetadata annotationMetadata) {
@@ -879,8 +902,7 @@ public final class SimpleSerdeShapeAnalyzer {
             || hasSerializeAsOverride(annotationMetadata)
             || hasDeserializeAsOverride(annotationMetadata)
             || hasCustomNaming(annotationMetadata)
-            || annotationMetadata.classValue(SerdeConfig.class, SerdeConfig.SERIALIZER_CLASS).isPresent()
-            || annotationMetadata.classValue(SerdeConfig.class, SerdeConfig.DESERIALIZER_CLASS).isPresent();
+            || hasCustomSerdeClass(annotationMetadata);
     }
 
     private boolean hasFeatureOverrides(AnnotationMetadata annotationMetadata) {


### PR DESCRIPTION
## Summary
This change fixes the detection of custom serializers and deserializers to properly account for annotations inherited from interfaces and supertypes, preventing source code generation when custom serde implementations are declared on parent types.

## Key Changes
- **Enhanced custom serde detection**: Modified `hasCustomSerdeClassOverride()` to use a new `hasCustomSerdeClass()` method that checks annotation metadata more thoroughly
- **Inheritance-aware checking**: Implemented `hasCustomSerdeClass(AnnotationMetadata)` that resolves custom serializer/deserializer types by name rather than by class, allowing detection of annotations inherited from interfaces and supertypes
- **Type resolution by name**: Changed from `classValue()` to `stringValue()` and `stringValues()` to handle cases where referenced serializers/deserializers are part of the same compilation round and cannot be loaded as classes
- **Consistent validation**: Updated `hasUnsupportedSerdeConfig()` and `hasUnsupportedSerdeConfigMetadata()` to use the new detection method for consistency

## Implementation Details
- The new `hasCustomSerdeClass(AnnotationMetadata, String, String)` method filters out default type names to only flag actual custom implementations
- Added test cases covering both direct custom serde declarations on types and inherited declarations from interfaces
- The fix ensures that types with custom serializers/deserializers (whether declared directly or inherited) are correctly marked as ineligible for source code generation

https://claude.ai/code/session_01KCcLNL421vDj1MX5NRQNsW