### PR TITLE
test: cover remaining collection-interface properties in the basic serde TCK

### DIFF
--- a/serde-tck/src/main/groovy/io/micronaut/serde/AbstractBasicSerdeCompileSpec.groovy
+++ b/serde-tck/src/main/groovy/io/micronaut/serde/AbstractBasicSerdeCompileSpec.groovy
@@ -383,9 +383,17 @@ class Test {
         "Iterable<Boolean>"            | [value: [true]]                    | '{"value":[true]}'
         "Set<String>"                  | [value: ["Test"] as Set]           | '{"value":["Test"]}'
         "Set<Boolean>"                 | [value: [true] as Set]             | '{"value":[true]}'
+        "Set<Integer>"                 | [value: [10] as Set]               | '{"value":[10]}'
+        "SortedSet<String>"            | [value: new TreeSet<>(["Test"])]   | '{"value":["Test"]}'
+        "NavigableSet<String>"         | [value: new TreeSet<>(["Test"])]   | '{"value":["Test"]}'
+        "LinkedHashSet<String>"        | [value: ["Test"] as Set]           | '{"value":["Test"]}'
+        "HashSet<String>"              | [value: ["Test"] as Set]           | '{"value":["Test"]}'
+        "TreeSet<String>"              | [value: ["Test"] as Set]           | '{"value":["Test"]}'
         "Collection<String>"           | [value: ["Test"]]                  | '{"value":["Test"]}'
         "Collection<Boolean>"          | [value: [true]]                    | '{"value":[true]}'
         "Map<String, Boolean>"         | [value: [foo: true]]               | '{"value":{"foo":true}}'
+        "Map<String, Set<String>>"     | [value: [foo: ["Test"] as Set]]    | '{"value":{"foo":["Test"]}}'
+        "List<Set<String>>"            | [value: [["Test"] as Set]]         | '{"value":[["Test"]]}'
         "EnumSet<HttpStatus>"          | [value: EnumSet.of(HttpStatus.OK)] | '{"value":["OK"]}'
     }
 


### PR DESCRIPTION
## Background

This started as an investigation into a report that deserializing a bean property declared as `java.util.Set` fails with `java.lang.ClassCastException: class java.util.ArrayList cannot be cast to class java.util.Set` on every format, in both the generated and runtime deserializers.

**The bug does not reproduce on `3.1.x`.** No production change is included here — only the test coverage that turned out to be genuinely missing.

## What was verified

Reproduced against a compiled `@Serdeable record Holder(Set<String> values)` in `serde-jackson`, confirming the annotation processor emitted a generated deserializer, then ran a 34-case matrix over both `readValue` and `writeValueToTree` / `readValueFromTree`:

- Element types `String`, `Integer`, `Double`, `Boolean`, `byte[]`, and a nested bean
- Declarations `Set`, `SortedSet`, `NavigableSet`, `LinkedHashSet`, `Collection`, `List`, `Iterable`, `Set<? extends String>`, `Map<String, Set<String>>`, `List<Set<String>>`
- Record and mutable-setter bean shapes
- Both the generated deserializer and the runtime one (`micronaut.serde.deserialization.disable-generated-deserializer=true`)

All 34 passed. Probing the registry directly shows the resolution is correct:

```
Set          -> LinkedHashSetDeserializer
SortedSet    -> TreeSetDeserializer
NavigableSet -> TreeSetDeserializer
Collection   -> StringListDeserializer
List         -> StringListDeserializer
```

The covariant qualifier in `DefaultSerdeRegistry#findDeserializer` excludes the list deserializers for `Set`, so `ArrayListDeserializer` is never a candidate. The `resolveLookupType` / `normalizeArgumentType` helpers in the sourcegen code only rewrite `Iterable` to `Collection` and leave `Set` untouched.

The accompanying claim that `Set` bean properties were untested was also inaccurate: `AbstractBasicSerdeCompileSpec` already round-tripped `Set<String>` and `Set<Boolean>`, and `SerdeJsonEnumSpec` covers `Set<MyEnum>`. A grep confined to `serde-jackson/src/test` misses the TCK rows.

## What changed

Real gaps did exist for the other collection interfaces, so this adds 8 rows to the shared `test basic collection type` table in `AbstractBasicSerdeCompileSpec`:

`Set<Integer>`, `SortedSet<String>`, `NavigableSet<String>`, `LinkedHashSet<String>`, `HashSet<String>`, `TreeSet<String>`, `Map<String, Set<String>>`, `List<Set<String>>`

The bean generated for each row types its setter to the declared property type, so a checkcast runs on assignment — these rows would fail loudly if a deserializer ever did hand back an `ArrayList` for a `Set` property, which is exactly the reported failure mode.

## Notes for reviewers

- The `SortedSet` and `NavigableSet` rows seed their data with an explicit `new TreeSet<>([...])` rather than `[...] as Set`. That is a Groovy coercion limit in how the harness constructs the bean under test (`LinkedHashSet` has no `SortedSet` conversion), not a serde behaviour.
- `Deque` was deliberately left out: `ArrayDeque` does not implement `equals`, so the spec's `read.value == data.value` assertion cannot express it.

## Verification

Green across every module that inherits this spec — 133 tests each, 0 failures:

- `JacksonBasicSerdeCompileSpec`
- `BsonBinaryBasicSerdeCompileSpec`
- `BsonJsonBasicSerdeCompileSpec`
- `JsonpJsonBasicSerdeCompileSpec`
- `OracleJdbcJsonTextBasicSerdeCompileSpec`

🤖 Generated with [Claude Code](https://claude.com/claude-code)