### PR TITLE
fix(processor): generate correct Argument for multidimensional arrays

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/util/SerdeArgumentConstants.java
+++ b/serde-api/src/main/java/io/micronaut/serde/util/SerdeArgumentConstants.java
@@ -22,7 +22,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 /**
- * Reusable {@link Argument} constants for generated and runtime serde code.
+ * Reusable {@link Argument} constants and type helpers for generated and runtime serde code.
  */
 @Internal
 public final class SerdeArgumentConstants {
@@ -69,5 +69,20 @@ public final class SerdeArgumentConstants {
     public static final Argument<BigDecimal> BIG_DECIMAL = Argument.of(BigDecimal.class);
 
     private SerdeArgumentConstants() {
+    }
+
+    /**
+     * Resolves the array {@link Class} for the given component type and number of dimensions.
+     *
+     * @param componentType The array component type
+     * @param dimensions    The number of array dimensions
+     * @return The array class
+     */
+    public static Class<?> arrayType(Class<?> componentType, int dimensions) {
+        Class<?> arrayType = componentType;
+        for (int i = 0; i < dimensions; i++) {
+            arrayType = arrayType.arrayType();
+        }
+        return arrayType;
     }
 }

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanSerdeSourceGenUtils.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanSerdeSourceGenUtils.java
@@ -19,6 +19,7 @@ import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.WildcardElement;
+import io.micronaut.serde.util.SerdeArgumentConstants;
 import io.micronaut.sourcegen.model.ClassTypeDef;
 import io.micronaut.sourcegen.model.ExpressionDef;
 import io.micronaut.sourcegen.model.TypeDef;
@@ -45,6 +46,7 @@ final class BeanSerdeSourceGenUtils {
     private static final ClassTypeDef SERDE_ARGUMENT_CONSTANTS = ClassTypeDef.of("io.micronaut.serde.util.SerdeArgumentConstants");
 
     private static final Method ARGUMENT_OF_METHOD = ReflectionUtils.getRequiredMethod(Argument.class, "of", Class.class);
+    private static final Method ARRAY_TYPE_METHOD = ReflectionUtils.getRequiredMethod(SerdeArgumentConstants.class, "arrayType", Class.class, int.class);
     private static final Method ARGUMENT_OF_WITH_TYPE_PARAMETERS_METHOD = ReflectionUtils.getRequiredMethod(Argument.class, "of", Class.class, Argument[].class);
     private static final Method ARGUMENT_WITH_NAME_METHOD = ReflectionUtils.getRequiredMethod(Argument.class, "withName", String.class);
     private static final Method OPTIONAL_EMPTY_METHOD = ReflectionUtils.getRequiredMethod(Optional.class, EMPTY_METHOD);
@@ -66,7 +68,7 @@ final class BeanSerdeSourceGenUtils {
             return ClassTypeDef.of(Argument.class)
                 .invokeStatic(
                     ARGUMENT_OF_WITH_TYPE_PARAMETERS_METHOD,
-                    ExpressionDef.constant(TypeDef.erasure(argumentType)),
+                    classExpression(argumentType),
                     typeArgumentArray
                 );
         }
@@ -75,12 +77,35 @@ final class BeanSerdeSourceGenUtils {
             return constantArgumentExpression;
         }
         return ClassTypeDef.of(Argument.class)
-            .invokeStatic(ARGUMENT_OF_METHOD, ExpressionDef.constant(TypeDef.erasure(argumentType)));
+            .invokeStatic(ARGUMENT_OF_METHOD, classExpression(argumentType));
     }
 
     static ExpressionDef argumentExpression(ClassElement classElement, ExpressionDef name) {
         return argumentExpression(classElement)
             .invoke(ARGUMENT_WITH_NAME_METHOD, name);
+    }
+
+    /**
+     * Renders the {@link Class} literal used to build the {@link Argument} of the given type.
+     *
+     * <p>Multidimensional arrays cannot be rendered as a plain class literal constant: the Java
+     * source writer collapses every {@code TypeDef.Array} to a single dimension, which would turn
+     * {@code byte[][]} into {@code byte[].class} and select the {@code byte[]} serde for the outer
+     * array. Build the array class explicitly instead.</p>
+     *
+     * @param argumentType The argument type
+     * @return The class expression
+     */
+    private static ExpressionDef classExpression(ClassElement argumentType) {
+        TypeDef typeDef = TypeDef.erasure(argumentType);
+        if (typeDef instanceof TypeDef.Array arrayTypeDef && arrayTypeDef.dimensions() > 1) {
+            return SERDE_ARGUMENT_CONSTANTS.invokeStatic(
+                ARRAY_TYPE_METHOD,
+                ExpressionDef.constant(arrayTypeDef.componentType()),
+                ExpressionDef.constant(arrayTypeDef.dimensions())
+            );
+        }
+        return ExpressionDef.constant(typeDef);
     }
 
     private static @Nullable ExpressionDef simpleArgumentConstantExpression(ClassElement argumentType) {

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerdeSourceGenUtils.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerdeSourceGenUtils.java
@@ -19,6 +19,7 @@ import io.micronaut.core.reflect.ReflectionUtils;
 import io.micronaut.core.type.Argument;
 import io.micronaut.inject.ast.ClassElement;
 import io.micronaut.inject.ast.WildcardElement;
+import io.micronaut.serde.util.SerdeArgumentConstants;
 import io.micronaut.sourcegen.model.ClassTypeDef;
 import io.micronaut.sourcegen.model.ExpressionDef;
 import io.micronaut.sourcegen.model.TypeDef;
@@ -45,6 +46,7 @@ final class RecordSerdeSourceGenUtils {
     private static final ClassTypeDef SERDE_ARGUMENT_CONSTANTS = ClassTypeDef.of("io.micronaut.serde.util.SerdeArgumentConstants");
 
     private static final Method ARGUMENT_OF_METHOD = ReflectionUtils.getRequiredMethod(Argument.class, "of", Class.class);
+    private static final Method ARRAY_TYPE_METHOD = ReflectionUtils.getRequiredMethod(SerdeArgumentConstants.class, "arrayType", Class.class, int.class);
     private static final Method ARGUMENT_OF_WITH_TYPE_PARAMETERS_METHOD = ReflectionUtils.getRequiredMethod(Argument.class, "of", Class.class, Argument[].class);
     private static final Method ARGUMENT_WITH_NAME_METHOD = ReflectionUtils.getRequiredMethod(Argument.class, "withName", String.class);
     private static final Method OPTIONAL_EMPTY_METHOD = ReflectionUtils.getRequiredMethod(Optional.class, EMPTY_METHOD);
@@ -66,7 +68,7 @@ final class RecordSerdeSourceGenUtils {
             return ClassTypeDef.of(Argument.class)
                 .invokeStatic(
                     ARGUMENT_OF_WITH_TYPE_PARAMETERS_METHOD,
-                    ExpressionDef.constant(TypeDef.erasure(argumentType)),
+                    classExpression(argumentType),
                     typeArgumentArray
                 );
         }
@@ -75,12 +77,35 @@ final class RecordSerdeSourceGenUtils {
             return constantArgumentExpression;
         }
         return ClassTypeDef.of(Argument.class)
-            .invokeStatic(ARGUMENT_OF_METHOD, ExpressionDef.constant(TypeDef.erasure(argumentType)));
+            .invokeStatic(ARGUMENT_OF_METHOD, classExpression(argumentType));
     }
 
     static ExpressionDef argumentExpression(ClassElement classElement, ExpressionDef name) {
         return argumentExpression(classElement)
             .invoke(ARGUMENT_WITH_NAME_METHOD, name);
+    }
+
+    /**
+     * Renders the {@link Class} literal used to build the {@link Argument} of the given type.
+     *
+     * <p>Multidimensional arrays cannot be rendered as a plain class literal constant: the Java
+     * source writer collapses every {@code TypeDef.Array} to a single dimension, which would turn
+     * {@code byte[][]} into {@code byte[].class} and select the {@code byte[]} serde for the outer
+     * array. Build the array class explicitly instead.</p>
+     *
+     * @param argumentType The argument type
+     * @return The class expression
+     */
+    private static ExpressionDef classExpression(ClassElement argumentType) {
+        TypeDef typeDef = TypeDef.erasure(argumentType);
+        if (typeDef instanceof TypeDef.Array arrayTypeDef && arrayTypeDef.dimensions() > 1) {
+            return SERDE_ARGUMENT_CONSTANTS.invokeStatic(
+                ARRAY_TYPE_METHOD,
+                ExpressionDef.constant(arrayTypeDef.componentType()),
+                ExpressionDef.constant(arrayTypeDef.dimensions())
+            );
+        }
+        return ExpressionDef.constant(typeDef);
     }
 
     private static @Nullable ExpressionDef simpleArgumentConstantExpression(ClassElement argumentType) {

--- a/serde-tck/src/main/groovy/io/micronaut/serde/AbstractBasicSerdeCompileSpec.groovy
+++ b/serde-tck/src/main/groovy/io/micronaut/serde/AbstractBasicSerdeCompileSpec.groovy
@@ -303,6 +303,83 @@ class Test {
     }
 
     @Unroll
+    void "test nested array type #type"() {
+        given:
+        def context = buildContext("""
+package test;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+class Test {
+    private $type value;
+    public void setValue($type value) {
+        this.value = value;
+    }
+    public $type getValue() {
+        return value;
+    }
+}
+""")
+        def bean = newInstance(context, 'test.Test', [:])
+        bean.value = data
+
+        when:
+        def bytes = jsonMapper.writeValueAsBytes(bean)
+        def read = jsonMapper.readValue(bytes, argumentOf(context, 'test.Test'))
+
+        then:
+        read.value == data
+
+        cleanup:
+        context.close()
+
+        where:
+        type          | data
+        'byte[][]'    | [[1, 2] as byte[], [3] as byte[]] as byte[][]
+        'String[][]'  | [["a", "b"] as String[], ["c"] as String[]] as String[][]
+        'int[][]'     | [[1, 2] as int[], [3] as int[]] as int[][]
+        'long[][]'    | [[1L, 2L] as long[], [3L] as long[]] as long[][]
+        'double[][]'  | [[1.5d] as double[], [2.5d] as double[]] as double[][]
+        'boolean[][]' | [[true, false] as boolean[], [true] as boolean[]] as boolean[][]
+        'Integer[][]' | [[1, 2] as Integer[], [3] as Integer[]] as Integer[][]
+        'byte[][][]'  | [[[1, 2] as byte[]] as byte[][], [[3] as byte[]] as byte[][]] as byte[][][]
+    }
+
+    @Unroll
+    void "test nested array record type #type"() {
+        given:
+        def context = buildContext("""
+package test;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+record Test($type value) {
+}
+""")
+        def bean = newInstance(context, 'test.Test', [data] as Object[])
+
+        when:
+        def bytes = jsonMapper.writeValueAsBytes(bean)
+        def read = jsonMapper.readValue(bytes, argumentOf(context, 'test.Test'))
+
+        then:
+        read.value == data
+
+        cleanup:
+        context.close()
+
+        where:
+        type          | data
+        'byte[][]'    | [[1, 2] as byte[], [3] as byte[]] as byte[][]
+        'String[][]'  | [["a", "b"] as String[], ["c"] as String[]] as String[][]
+        'int[][]'     | [[1, 2] as int[], [3] as int[]] as int[][]
+        'Integer[][]' | [[1, 2] as Integer[], [3] as Integer[]] as Integer[][]
+        'byte[][][]'  | [[[1, 2] as byte[]] as byte[][], [[3] as byte[]] as byte[][]] as byte[][][]
+    }
+
+    @Unroll
     void "test basic array type #type with arrays and null values"() {
         given:
         def context = buildContext("""


### PR DESCRIPTION
## Problem

A property whose type is a nested array fails to serialize on any format:

```java
@Serdeable
record ByteMatrix(byte[][] blobs) {
}
```

```
io.micronaut.serde.exceptions.SerdeException: Error processing property [blobs] of type [ByteMatrix]:
class [[B cannot be cast to class [B ([[B and [B are in module java.base of loader 'bootstrap')
  at io.micronaut.serde.util.GeneratedSerdeExceptionUtil.withPropertyPath(GeneratedSerdeExceptionUtil.java:212)
  at ...$ByteMatrixSerializer.serializeInto(...)
```

## Root cause

Not serializer selection — the generated `Argument` is wrong before selection ever runs. The generated serde contained:

```java
private static final Argument ARGUMENT_0 = Argument.of(byte[].class).withName(KEY_0);
```

One array dimension had been dropped, so `findSerializer` was correctly asked for a `byte[]` serializer and correctly returned `ByteArraySerde`, which then received a `byte[][]`.

The dimension is lost in the micronaut-sourcegen Java source writer. `TypeDef.Array` stores the *base* component type plus a total dimension count (`Array(byte, dimensions=2)`), but `JavaPoetSourceGenerator#getClassName` renders it as `getClassName(componentType) + "[]"`, ignoring `dimensions()`. Every array class literal therefore came out one-dimensional: `byte[][]` → `byte[].class`, `int[][][]` → `int[].class`. The bytecode writer (`TypeUtils#getType`) handles dimensions correctly, so only the Java source-generation path is affected.

This also explains why the failure is not format-specific — the wrong serializer is chosen before any encoder is reached — and why `List<byte[]>` works, since its element argument is a genuine one-dimensional array.

## Scope

Affects **all** nested array types (`byte[][]`, `String[][]`, `int[][][]`, …), on **both** serialization and deserialization, for **records and beans**.

The runtime (non-generated) path is **not** affected: `registry.findSerializer(Argument.of(byte[][].class))` returns `ObjectArraySerde`, which resolves the component type via `Class#getComponentType()` and round-trips correctly. This is covered by a test as well.

## Fix

Since the defect is upstream in micronaut-sourcegen, this works around it in the processor rather than depending on a sourcegen release:

- `SerdeArgumentConstants` — new `@Internal` helper `arrayType(Class<?>, int)` that builds the array class via `Class#arrayType()`.
- `RecordSerdeSourceGenUtils` / `BeanSerdeSourceGenUtils` — a shared `classExpression(...)` that routes arrays with `dimensions() > 1` through that helper instead of a class-literal constant, with a comment naming the writer limitation.

Single-dimension arrays and all other types keep the plain class literal, so existing generated output is unchanged. Generated code is now:

```java
private static final Argument ARGUMENT_0 = Argument.of(SerdeArgumentConstants.arrayType(byte.class, 2)).withName(KEY_0);
```

This is writer-agnostic, so it stays correct on the bytecode path and after any upstream sourcegen fix.

## Tests

Added nested-array round-trip coverage (bean and record shapes) to `AbstractBasicSerdeCompileSpec`, so it runs across every format that extends the TCK: Jackson, BSON (JSON + binary), JSON-P, and Oracle JDBC JSON.

Full suite green: 1589 tests, 0 failures. Checkstyle clean.

## Notes for reviewers

- The underlying bug is in `micronaut-sourcegen` (`JavaPoetSourceGenerator#getClassName` should append `"[]".repeat(array.dimensions())`). Worth reporting upstream; this change remains correct either way.
- `SerdeArgumentConstants` is `@Internal` and referenced only by generated code, so the new method adds no public API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)