### PR TITLE
fix(processor): use assignable defaults for non-null collection record components

### DIFF
--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeSourceGenRecordSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeSourceGenRecordSpec.groovy
@@ -183,6 +183,158 @@ public record MultiPoint(List<Point> points) {
         context.close()
     }
 
+    void 'test record generated deserializer defaults non null collections to assignable implementations'() {
+        given:
+        def context = buildContext('test.CollectionsRecord', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.serde.annotation.Serdeable;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+import java.util.Collection;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+
+@Serdeable
+@SerdeableGenerated
+@Introspected
+public record CollectionsRecord(
+    @NonNull String name,
+    @NonNull List<String> list,
+    @NonNull Collection<String> collection,
+    @NonNull Set<String> set,
+    @NonNull SortedSet<String> sortedSet,
+    @NonNull Deque<String> deque,
+    @NonNull LinkedList<String> linkedList,
+    @NonNull Map<String, String> map,
+    @NonNull SortedMap<String, String> sortedMap
+) {}
+''')
+        Class<?> recordType = context.classLoader.loadClass('test.CollectionsRecord')
+        def registry = context.getBean(SerdeRegistry)
+        def type = Argument.of(recordType)
+
+        when:
+        def fromEmpty = jsonMapper.readValue('{}', type)
+
+        then:
+        assertGeneratedDeserializer(registry, type)
+        fromEmpty.name() == null
+        fromEmpty.list() instanceof ArrayList
+        fromEmpty.list().isEmpty()
+        fromEmpty.collection() instanceof ArrayList
+        fromEmpty.set() instanceof LinkedHashSet
+        fromEmpty.set().isEmpty()
+        fromEmpty.sortedSet() instanceof TreeSet
+        fromEmpty.deque() instanceof ArrayDeque
+        fromEmpty.linkedList() instanceof LinkedList
+        fromEmpty.map() instanceof LinkedHashMap
+        fromEmpty.map().isEmpty()
+        fromEmpty.sortedMap() instanceof TreeMap
+
+        when:
+        def fromValues = jsonMapper.readValue(
+            '{"name":"Ada","list":["a"],"collection":["b"],"set":["c","c"],"sortedSet":["e","d"],' +
+                '"deque":["f"],"linkedList":["g"],"map":{"k":"v"},"sortedMap":{"k2":"v2"}}',
+            type
+        )
+
+        then:
+        fromValues.name() == 'Ada'
+        fromValues.list() == ['a']
+        fromValues.collection().toList() == ['b']
+        fromValues.set() == ['c'] as Set
+        fromValues.sortedSet().toList() == ['d', 'e']
+        fromValues.deque().toList() == ['f']
+        fromValues.linkedList() == ['g']
+        fromValues.map() == [k: 'v']
+        fromValues.sortedMap() == [k2: 'v2']
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test record generated deserializer defaults null marked collections to assignable implementations'() {
+        given:
+        def context = buildContext('test.NullMarkedCollectionsRecord', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.Serdeable;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.Map;
+import java.util.Set;
+
+@NullMarked
+@Serdeable
+@SerdeableGenerated
+@Introspected
+public record NullMarkedCollectionsRecord(String name, Set<String> set, Map<String, String> map) {}
+''')
+        Class<?> recordType = context.classLoader.loadClass('test.NullMarkedCollectionsRecord')
+        def registry = context.getBean(SerdeRegistry)
+        def type = Argument.of(recordType)
+
+        when:
+        def decoded = jsonMapper.readValue('{"name":"Ada"}', type)
+
+        then:
+        assertGeneratedDeserializer(registry, type)
+        decoded.name() == 'Ada'
+        decoded.set() instanceof LinkedHashSet
+        decoded.set().isEmpty()
+        decoded.map() instanceof LinkedHashMap
+        decoded.map().isEmpty()
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test record generated deserializer leaves collections without an assignable default null'() {
+        given:
+        def context = buildContext('test.EnumSetRecord', '''
+package test;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.serde.annotation.Serdeable;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+import java.util.EnumSet;
+
+@Serdeable
+@SerdeableGenerated
+@Introspected
+public record EnumSetRecord(@NonNull EnumSet<EnumSetRecord.Color> colors) {
+    public enum Color { RED, GREEN }
+}
+''')
+        Class<?> recordType = context.classLoader.loadClass('test.EnumSetRecord')
+        def registry = context.getBean(SerdeRegistry)
+        def type = Argument.of(recordType)
+
+        when:
+        def decoded = jsonMapper.readValue('{"colors":["RED"]}', type)
+        def fromEmpty = jsonMapper.readValue('{}', type)
+
+        then:
+        assertGeneratedDeserializer(registry, type)
+        decoded.colors()*.name() == ['RED']
+        fromEmpty.colors() == null
+
+        cleanup:
+        context.close()
+    }
+
     private static void assertGeneratedSerializer(SerdeRegistry registry, Argument argument) {
         Serializer serializer = registry.findSerializer(argument).createSpecific(registry.newEncoderContext(Object), argument)
         assert serializer.class.name == generatedClassName(argument.type, 'Serializer')

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeDeserializerBehaviorSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeDeserializerBehaviorSpec.groovy
@@ -421,6 +421,113 @@ class CompileTimeDeserializerBehaviorSpec extends JsonCompileSpec {
         'invalid int'    | '{"count":{"nested":true}}' | null                      | '["count"]'
     }
 
+    void 'test generated record deserializer defaults non null collections to assignable implementations'() {
+        given:
+        def context = ApplicationContext.run()
+        jsonMapper = context.getBean(JsonMapper)
+        def registry = context.getBean(SerdeRegistry)
+
+        when:
+        SourceGenNonNullCollectionsRecord decoded = jsonMapper.readValue(
+            '{}',
+            Argument.of(SourceGenNonNullCollectionsRecord)
+        )
+
+        then:
+        assertGeneratedDeserializer(registry, SourceGenNonNullCollectionsRecord.class)
+        decoded.list() instanceof ArrayList
+        decoded.list().isEmpty()
+        decoded.collection() instanceof ArrayList
+        decoded.collection().isEmpty()
+        decoded.set() instanceof LinkedHashSet
+        decoded.set().isEmpty()
+        decoded.sortedSet() instanceof TreeSet
+        decoded.sortedSet().isEmpty()
+        decoded.deque() instanceof ArrayDeque
+        decoded.deque().isEmpty()
+        decoded.linkedList() instanceof LinkedList
+        decoded.linkedList().isEmpty()
+        decoded.map() instanceof LinkedHashMap
+        decoded.map().isEmpty()
+        decoded.sortedMap() instanceof TreeMap
+        decoded.sortedMap().isEmpty()
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test generated record deserializer reads non null collection values'() {
+        given:
+        def context = ApplicationContext.run()
+        jsonMapper = context.getBean(JsonMapper)
+
+        when:
+        SourceGenNonNullCollectionsRecord decoded = jsonMapper.readValue(
+            '{"list":["a"],"collection":["b"],"set":["d","d"],"sortedSet":["f","e"],"deque":["g"],"linkedList":["h"],"map":{"k":"v"},"sortedMap":{"k2":"v2"}}',
+            Argument.of(SourceGenNonNullCollectionsRecord)
+        )
+
+        then:
+        decoded.list() == ['a']
+        decoded.collection().toList() == ['b']
+        decoded.set() == ['d'] as Set
+        decoded.sortedSet().toList() == ['e', 'f']
+        decoded.deque().toList() == ['g']
+        decoded.linkedList() == ['h']
+        decoded.map() == [k: 'v']
+        decoded.sortedMap() == [k2: 'v2']
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test generated record deserializer source creates collection defaults assignable to the declared type'() {
+        given:
+        def context = ApplicationContext.run()
+        def introspections = context.getBean(SerdeIntrospections)
+        def generatedMetadata = introspections.getDeserializableIntrospection(Argument.of(SourceGenNonNullCollectionsRecord)).annotationMetadata
+        String deserializerClassName = generatedMetadata.stringValue(SerdeConfig, SerdeConfig.SOURCEGEN_DESERIALIZER_CLASS).orElseThrow()
+        String deserializerSource = generatedTestSource(deserializerClassName)
+
+        expect:
+        deserializerSource.contains('ArrayList()')
+        deserializerSource.contains('LinkedHashSet()')
+        deserializerSource.contains('TreeSet()')
+        deserializerSource.contains('ArrayDeque()')
+        deserializerSource.contains('LinkedList()')
+        deserializerSource.contains('LinkedHashMap()')
+        deserializerSource.contains('TreeMap()')
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test generated record deserializer defaults null marked collections to assignable implementations'() {
+        given:
+        def context = ApplicationContext.run()
+        jsonMapper = context.getBean(JsonMapper)
+        def registry = context.getBean(SerdeRegistry)
+
+        when:
+        SourceGenNullMarkedCollectionsRecord decoded = jsonMapper.readValue(
+            '{"name":"Ada"}',
+            Argument.of(SourceGenNullMarkedCollectionsRecord)
+        )
+
+        then:
+        assertGeneratedDeserializer(registry, SourceGenNullMarkedCollectionsRecord.class)
+        decoded.name() == 'Ada'
+        decoded.list() instanceof ArrayList
+        decoded.list().isEmpty()
+        decoded.set() instanceof LinkedHashSet
+        decoded.set().isEmpty()
+        decoded.map() instanceof LinkedHashMap
+        decoded.map().isEmpty()
+
+        cleanup:
+        context.close()
+    }
+
     void 'test generated dispatch bean deserializer covers primitive null defaults and unknown skip'() {
         given:
         def context = ApplicationContext.run([

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenNonNullCollectionsRecord.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenNonNullCollectionsRecord.java
@@ -1,0 +1,28 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+import java.util.Collection;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.SortedSet;
+
+@SerdeableGenerated
+@Introspected
+public record SourceGenNonNullCollectionsRecord(
+    @NonNull List<String> list,
+    @NonNull Collection<String> collection,
+    @NonNull Set<String> set,
+    @NonNull SortedSet<String> sortedSet,
+    @NonNull Deque<String> deque,
+    @NonNull LinkedList<String> linkedList,
+    @NonNull Map<String, String> map,
+    @NonNull SortedMap<String, String> sortedMap
+) {
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenNullMarkedCollectionsRecord.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenNullMarkedCollectionsRecord.java
@@ -1,0 +1,20 @@
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@NullMarked
+@SerdeableGenerated
+@Introspected
+public record SourceGenNullMarkedCollectionsRecord(
+    String name,
+    List<String> list,
+    Set<String> set,
+    Map<String, String> map
+) {
+}

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerdeSourceGenUtils.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerdeSourceGenUtils.java
@@ -182,9 +182,6 @@ final class RecordSerdeSourceGenUtils {
      * @return The expression creating an empty collection or {@code null} if the type is not a supported collection
      */
     private static @Nullable ExpressionDef emptyCollectionExpression(ClassElement classElement) {
-        if (classElement.isPrimitive() || classElement.isArray()) {
-            return null;
-        }
         if (!classElement.isAssignable(Iterable.class) && !classElement.isAssignable(Map.class)) {
             return null;
         }

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerdeSourceGenUtils.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerdeSourceGenUtils.java
@@ -27,14 +27,20 @@ import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
+import java.util.TreeMap;
+import java.util.TreeSet;
 
 final class RecordSerdeSourceGenUtils {
     private static final String EMPTY_METHOD = "empty";
@@ -46,6 +52,20 @@ final class RecordSerdeSourceGenUtils {
     private static final TypeDef ARGUMENT_TYPE = TypeDef.of(Argument.class);
     private static final ClassTypeDef SERDE_ARGUMENT_CONSTANTS = ClassTypeDef.of("io.micronaut.serde.util.SerdeArgumentConstants");
     private static final ClassTypeDef SERDE_CONFIG_TYPE = ClassTypeDef.of(SerdeConfig.class);
+
+    /**
+     * The default implementations used for non-null collection and map properties, ordered from the
+     * most generic to the most specific implementation.
+     */
+    private static final List<Class<?>> DEFAULT_COLLECTION_IMPLEMENTATIONS = List.of(
+        ArrayList.class,
+        LinkedHashSet.class,
+        TreeSet.class,
+        ArrayDeque.class,
+        LinkedList.class,
+        LinkedHashMap.class,
+        TreeMap.class
+    );
 
     private static final Method ARGUMENT_OF_METHOD = ReflectionUtils.getRequiredMethod(Argument.class, "of", Class.class);
     private static final Method ARGUMENT_OF_WITH_TYPE_PARAMETERS_METHOD = ReflectionUtils.getRequiredMethod(Argument.class, "of", Class.class, Argument[].class);
@@ -132,14 +152,9 @@ final class RecordSerdeSourceGenUtils {
             default:
         }
         if (nonNullCollectionDefault) {
-            if (classElement.isAssignable(List.class) || classElement.isAssignable(Collection.class)) {
-                return ClassTypeDef.of(ArrayList.class).instantiate().cast(TypeDef.erasure(classElement));
-            }
-            if (classElement.isAssignable(java.util.Set.class)) {
-                return ClassTypeDef.of(java.util.LinkedHashSet.class).instantiate().cast(TypeDef.erasure(classElement));
-            }
-            if (classElement.isAssignable(Map.class)) {
-                return ClassTypeDef.of(java.util.LinkedHashMap.class).instantiate().cast(TypeDef.erasure(classElement));
+            ExpressionDef emptyCollection = emptyCollectionExpression(classElement);
+            if (emptyCollection != null) {
+                return emptyCollection;
             }
         }
         if (!classElement.isPrimitive() || classElement.isArray()) {
@@ -155,6 +170,44 @@ final class RecordSerdeSourceGenUtils {
             case "byte", SHORT_TYPE, "int" -> ExpressionDef.constant(0).cast(TypeDef.erasure(classElement));
             default -> ExpressionDef.constant(0).cast(TypeDef.erasure(classElement));
         };
+    }
+
+    /**
+     * Resolves an empty collection or map instance that can be assigned to the given type.
+     *
+     * <p>The chosen implementation must be a subtype of the declared type, otherwise the generated
+     * default would fail with a {@link ClassCastException} at runtime.</p>
+     *
+     * @param classElement The declared type
+     * @return The expression creating an empty collection or {@code null} if the type is not a supported collection
+     */
+    private static @Nullable ExpressionDef emptyCollectionExpression(ClassElement classElement) {
+        if (classElement.isPrimitive() || classElement.isArray()) {
+            return null;
+        }
+        if (!classElement.isAssignable(Iterable.class) && !classElement.isAssignable(Map.class)) {
+            return null;
+        }
+        String declaredTypeName = classElement.getName();
+        for (Class<?> implementationType : DEFAULT_COLLECTION_IMPLEMENTATIONS) {
+            if (isSubtypeOf(implementationType, declaredTypeName)) {
+                return ClassTypeDef.of(implementationType).instantiate().cast(TypeDef.erasure(classElement));
+            }
+        }
+        return null;
+    }
+
+    private static boolean isSubtypeOf(Class<?> type, String supertypeName) {
+        if (type.getName().equals(supertypeName)) {
+            return true;
+        }
+        for (Class<?> anInterface : type.getInterfaces()) {
+            if (isSubtypeOf(anInterface, supertypeName)) {
+                return true;
+            }
+        }
+        Class<?> superclass = type.getSuperclass();
+        return superclass != null && isSubtypeOf(superclass, supertypeName);
     }
 
     static TypeDef deserializedCastType(ClassElement classElement) {


### PR DESCRIPTION
Fixes #1359

## Problem

The generated record deserializer initialises non-null collection and map components with an empty collection, so an absent property does not produce a `null` value. The implementation was picked by testing `List`/`Collection` first:

```java
if (classElement.isAssignable(List.class) || classElement.isAssignable(Collection.class)) {
    return ClassTypeDef.of(ArrayList.class).instantiate().cast(TypeDef.erasure(classElement));
}
if (classElement.isAssignable(Set.class)) { ... }
```

Every `Collection` subtype — `Set`, `SortedSet`, `Queue`, `Deque` — matches that first branch, so the `Set` branch was unreachable and the generated source was:

```java
Set<AccessRole> propertyValue2 = (Set<AccessRole>) new java.util.ArrayList();
```

which throws as soon as the deserializer runs, whether or not the property is present in the payload:

```
java.lang.ClassCastException: class java.util.ArrayList cannot be cast to class java.util.Set
```

`SortedMap`/`NavigableMap` had the same problem through the `Map` branch (`LinkedHashMap` is not a `SortedMap`). Any record with such a component is affected, both when the component is annotated `@NonNull` and when the type is `@NullMarked`, which is what makes it show up on every collection in a null-marked package.

## Fix

`RecordSerdeSourceGenUtils` now picks a default implementation only when that implementation is genuinely a subtype of the declared component type, verified against the implementation class' own type hierarchy rather than by assignability of the declared type:

| Declared component type | Generated default |
| --- | --- |
| `Iterable`, `Collection`, `List`, `ArrayList` | `ArrayList` |
| `Set`, `HashSet`, `LinkedHashSet` | `LinkedHashSet` |
| `SortedSet`, `NavigableSet`, `TreeSet` | `TreeSet` |
| `Queue`, `Deque`, `ArrayDeque` | `ArrayDeque` |
| `LinkedList` | `LinkedList` |
| `Map`, `HashMap`, `LinkedHashMap` | `LinkedHashMap` |
| `SortedMap`, `NavigableMap`, `TreeMap` | `TreeMap` |

A collection type with no assignable default (for example `EnumSet`, or a custom collection interface) now falls back to the `null` default instead of an incompatible instance, so an unsupported type can no longer produce a `ClassCastException`.

## Tests

Pre-compiled fixtures under `serde-jackson/src/test/java/.../compiletime` — one record with explicit `@NonNull` components across the collection kinds above, one `@NullMarked` record — drive four specs in `CompileTimeDeserializerBehaviorSpec`:

- missing properties default to empty collections of the declared kind (`LinkedHashSet`, `TreeSet`, `ArrayDeque`, `LinkedList`, `LinkedHashMap`, `TreeMap`),
- a full payload deserialises into the right values,
- the generated source creates each default from a type assignable to the declared type,
- the same holds for a `@NullMarked` record.

All four fail on `3.2.x` without the processor change, three of them with exactly the `ClassCastException` from the issue.

`SerdeSourceGenRecordSpec` adds three more specs that compile equivalent records **in-process** (`buildContext`), covering the same defaults, the `@NullMarked` case, and the `EnumSet` null fallback. Running the processor inside the test JVM is also what makes the new processor code visible to JaCoCo — `serde-processor` has no test sources of its own, so coverage of sourcegen code comes from compile-time specs rather than from fixtures compiled by Gradle.

Verification (JDK 25): `:micronaut-serde-jackson:test` — 1655 tests, 0 failures; `:micronaut-serde-processor:checkstyleMain` and `spotlessCheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TbQgGYCKounbSRax83nqXD