### PR TITLE
Support @JsonValue and @JsonKey on record components

### DIFF
--- a/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonKeySpec.groovy
+++ b/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonKeySpec.groovy
@@ -377,4 +377,41 @@ class ValueOnlyCatalogEntry {
         cleanup:
             context.close()
     }
+
+    void "JsonKey on a record component is used for map keys"() {
+        given:
+            def context = buildContext('''
+package example;
+
+import com.fasterxml.jackson.annotation.JsonKey;
+import io.micronaut.serde.annotation.Serdeable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Serdeable
+class Basket {
+    private Map<Fruit, Integer> fruits = new LinkedHashMap<>();
+
+    public Map<Fruit, Integer> getFruits() {
+        return fruits;
+    }
+
+    public void setFruits(Map<Fruit, Integer> fruits) {
+        this.fruits = fruits;
+    }
+}
+
+@Serdeable
+record Fruit(@JsonKey String name) {}
+''')
+            def fruit = newInstance(context, 'example.Fruit', 'Mango')
+            def basket = newInstance(context, 'example.Basket')
+            basket.fruits.put(fruit, 1)
+
+        expect:
+            writeJson(jsonMapper, basket) == '{"fruits":{"Mango":1}}'
+
+        cleanup:
+            context.close()
+    }
 }

--- a/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonValueSpec.groovy
+++ b/serde-jackson-tck/src/main/groovy/io/micronaut/serde/jackson/JsonValueSpec.groovy
@@ -561,4 +561,74 @@ enum MyEnum {
         foo.myEnum == enumValue2
     }
 
+    void "@JsonValue on record constructor parameter"() {
+        given:
+        def context = buildContext('example.Name', '''
+package example;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Introspected
+@Serdeable
+public record Name(@JsonValue String value) {}
+''')
+        def testBean = newInstance(context, 'example.Name', 'John')
+
+        when:
+        def json = writeJson(jsonMapper, testBean)
+
+        then:
+        json == '"John"'
+
+        when:
+        def deserialized = jsonMapper.readValue('"John"', context.classLoader.loadClass('example.Name'))
+
+        then:
+        deserialized.value() == 'John'
+
+        cleanup:
+        context.close()
+    }
+
+    void "@JsonValue on two record components is still rejected"() {
+        when:
+        buildContext('example.Name', '''
+package example;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public record Name(@JsonValue String first, @JsonValue String last) {}
+''')
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains("A JsonValue field is already defined")
+    }
+
+    void "@JsonValue on a record component and on another method is still rejected"() {
+        when:
+        buildContext('example.Name', '''
+package example;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public record Name(@JsonValue String value) {
+    @JsonValue
+    public String display() {
+        return value;
+    }
+}
+''')
+
+        then:
+        def e = thrown(RuntimeException)
+        e.message.contains("A JsonValue field is already defined")
+    }
+
 }

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/SerdeAnnotationVisitor.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/SerdeAnnotationVisitor.java
@@ -182,7 +182,7 @@ public class SerdeAnnotationVisitor implements TypeElementVisitor<SerdeConfig, S
         } else if (element.hasDeclaredAnnotation(SerdeConfig.SerValue.class)) {
             if (jsonValueField != null) {
                 throw new ProcessingException(element, "A JsonValue field is already defined: " + jsonValueField);
-            } else if (jsonValueMethod != null) {
+            } else if (jsonValueMethod != null && !isSameRecordComponent(jsonValueMethod, element)) {
                 throw new ProcessingException(element, "A JsonValue method is already defined: " + jsonValueMethod);
             } else {
                 this.jsonValueField = element;
@@ -191,12 +191,28 @@ public class SerdeAnnotationVisitor implements TypeElementVisitor<SerdeConfig, S
         if (element.hasDeclaredAnnotation(SerdeConfig.SerKey.class)) {
             if (jsonKeyField != null) {
                 throw new ProcessingException(element, "A JsonKey field is already defined: " + jsonKeyField);
-            } else if (jsonKeyMethod != null) {
+            } else if (jsonKeyMethod != null && !isSameRecordComponent(jsonKeyMethod, element)) {
                 throw new ProcessingException(element, "A JsonKey method is already defined: " + jsonKeyMethod);
             } else {
                 this.jsonKeyField = element;
             }
         }
+    }
+
+    /**
+     * Checks whether a method and a field are the accessor and the backing field of the same record component.
+     * An annotation declared on a record component is propagated to the component's field, accessor and
+     * constructor parameter, so seeing it on both the field and the accessor is not a duplicate declaration.
+     *
+     * @param method The method
+     * @param field  The field
+     * @return true if both elements represent the same record component
+     */
+    private boolean isSameRecordComponent(MethodElement method, FieldElement field) {
+        return currentClass().isRecord()
+            && !method.hasParameters()
+            && !method.isStatic()
+            && method.getName().equals(field.getName());
     }
 
     @Override
@@ -283,7 +299,9 @@ public class SerdeAnnotationVisitor implements TypeElementVisitor<SerdeConfig, S
             }
         } else if (methodMetadata.hasDeclaredAnnotation(SerdeConfig.SerValue.class)) {
             if (jsonValueField != null) {
-                throw new ProcessingException(element, "A JsonValue field is already defined: " + jsonValueField);
+                if (!isSameRecordComponent(element, jsonValueField)) {
+                    throw new ProcessingException(element, "A JsonValue field is already defined: " + jsonValueField);
+                }
             } else if (jsonValueMethod != null) {
                 throw new ProcessingException(element, "A JsonValue method is already defined: " + jsonValueMethod);
             } else {
@@ -298,7 +316,9 @@ public class SerdeAnnotationVisitor implements TypeElementVisitor<SerdeConfig, S
             } else if (element.hasParameters()) {
                 throw new ProcessingException(element, "A JsonKey method cannot define arguments");
             } else if (jsonKeyField != null) {
-                throw new ProcessingException(element, "A JsonKey field is already defined: " + jsonKeyField);
+                if (!isSameRecordComponent(element, jsonKeyField)) {
+                    throw new ProcessingException(element, "A JsonKey field is already defined: " + jsonKeyField);
+                }
             } else if (jsonKeyMethod != null) {
                 throw new ProcessingException(element, "A JsonKey method is already defined: " + jsonKeyMethod);
             } else {


### PR DESCRIPTION
## Summary
This change adds support for `@JsonValue` and `@JsonKey` annotations on record component parameters, allowing records to be serialized as single values or used as map keys respectively.

## Key Changes
- **Record component annotation support**: `@JsonValue` and `@JsonKey` annotations declared on record components are now properly recognized and processed during serialization/deserialization
- **Duplicate detection refinement**: Updated validation logic to distinguish between legitimate record component annotations (which appear on both the field and accessor) and actual duplicate declarations
- **New helper method**: Added `isSameRecordComponent()` to detect when a method and field represent the same record component, preventing false-positive duplicate annotation errors
- **Test coverage**: Added comprehensive test cases covering:
  - `@JsonValue` on record constructor parameters for single-value serialization
  - Rejection of multiple `@JsonValue` annotations on different record components
  - Rejection of conflicting `@JsonValue` annotations on both record component and method
  - `@JsonKey` on record components for use as map keys

## Implementation Details
The key insight is that in Java records, an annotation declared on a component is automatically propagated to the component's field, accessor method, and constructor parameter. The validation logic now accounts for this by checking if a method and field represent the same record component (same name, no parameters, non-static, and the class is a record) before reporting a duplicate annotation error.

https://claude.ai/code/session_015GjGhnmPWKcTqgXeLYUAA3