### PR TITLE
fix(serde): honor global serialization inclusion in generated serializers

### DIFF
--- a/serde-api/src/main/java/io/micronaut/serde/util/GeneratedSerdeInclusionUtil.java
+++ b/serde-api/src/main/java/io/micronaut/serde/util/GeneratedSerdeInclusionUtil.java
@@ -112,13 +112,21 @@ public final class GeneratedSerdeInclusionUtil {
      * Default-value check for scalar wrappers encoded without a property serializer field.
      * Empty char sequences are treated as default (matches {@code NON_DEFAULT} vs {@code NON_EMPTY}
      * for strings); numeric zero / false / NUL match the corresponding number/boolean serdes.
+     * Only the boxed primitive-wrapper number types (Byte/Short/Integer/Long/Float/Double) treat
+     * zero as default, matching {@link io.micronaut.serde.support.serdes.NumberSerde} subtypes such
+     * as {@code IntegerSerde}/{@code LongSerde}. {@link java.math.BigInteger} and
+     * {@link java.math.BigDecimal} (and any other {@code Number}) don't override
+     * {@link Serializer#isDefault}, so their runtime-serializer default is {@code false} regardless
+     * of value; treating {@code BigInteger.ZERO}/{@code BigDecimal.ZERO} as default here would
+     * incorrectly omit them under {@code NON_DEFAULT} where the runtime path would not.
      */
     private static boolean isDefaultScalar(Object value) {
         if (value instanceof CharSequence charSequence) {
             return charSequence.isEmpty();
         }
-        if (value instanceof Number number) {
-            return number.doubleValue() == 0d;
+        if (value instanceof Byte || value instanceof Short || value instanceof Integer
+            || value instanceof Long || value instanceof Float || value instanceof Double) {
+            return ((Number) value).doubleValue() == 0d;
         }
         if (value instanceof Boolean bool) {
             return !bool;

--- a/serde-api/src/main/java/io/micronaut/serde/util/GeneratedSerdeInclusionUtil.java
+++ b/serde-api/src/main/java/io/micronaut/serde/util/GeneratedSerdeInclusionUtil.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.util;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.UsedByGeneratedCode;
+import io.micronaut.serde.Serializer;
+import io.micronaut.serde.config.SerializationConfiguration;
+import io.micronaut.serde.config.annotation.SerdeConfig;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Inclusion helpers used by generated serializers so global
+ * {@code micronaut.serde.serialization.inclusion} is honored without falling
+ * back to the runtime object serializer for every simple shape.
+ *
+ * @since 3.1.1
+ */
+@Internal
+@UsedByGeneratedCode
+public final class GeneratedSerdeInclusionUtil {
+
+    private GeneratedSerdeInclusionUtil() {
+    }
+
+    /**
+     * Whether a property value should be written using the active global inclusion strategy
+     * and the property serializer's empty/absent/default checks.
+     *
+     * @param context    The encoder context
+     * @param serializer The property serializer
+     * @param value      The property value
+     * @return {@code true} if the property should be serialized
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static boolean shouldSerialize(Serializer.EncoderContext context,
+                                          Serializer serializer,
+                                          @Nullable Object value) {
+        SerdeConfig.SerInclude include = resolveInclusion(context);
+        return switch (include) {
+            case ALWAYS, USE_DEFAULTS -> true;
+            case NON_NULL -> value != null;
+            case NON_ABSENT -> !serializer.isAbsent(context, value);
+            case NON_EMPTY -> !serializer.isEmpty(context, value);
+            case NON_DEFAULT -> !serializer.isEmpty(context, value)
+                && (value == null || !serializer.isDefault(context, value));
+            case NEVER -> false;
+        };
+    }
+
+    /**
+     * Whether a scalar reference property (encoded without a cached property serializer)
+     * should be written using the active global inclusion strategy.
+     *
+     * @param context The encoder context
+     * @param value   The property value
+     * @return {@code true} if the property should be serialized
+     */
+    public static boolean shouldSerializeScalar(Serializer.EncoderContext context,
+                                                @Nullable Object value) {
+        SerdeConfig.SerInclude include = resolveInclusion(context);
+        return switch (include) {
+            case ALWAYS, USE_DEFAULTS -> true;
+            case NEVER -> false;
+            case NON_NULL, NON_ABSENT -> value != null;
+            case NON_EMPTY -> value != null && !isEmptyCharSequence(value);
+            case NON_DEFAULT -> value != null && !isDefaultScalar(value);
+        };
+    }
+
+    /**
+     * Whether a primitive property should be written using the active global inclusion strategy.
+     *
+     * @param context   The encoder context
+     * @param isDefault Whether the primitive value equals the Java language default for its type
+     * @return {@code true} if the property should be serialized
+     */
+    public static boolean shouldSerializePrimitive(Serializer.EncoderContext context,
+                                                   boolean isDefault) {
+        SerdeConfig.SerInclude include = resolveInclusion(context);
+        return switch (include) {
+            case NEVER -> false;
+            case NON_DEFAULT -> !isDefault;
+            default -> true;
+        };
+    }
+
+    private static SerdeConfig.SerInclude resolveInclusion(Serializer.EncoderContext context) {
+        return context.getSerializationConfiguration()
+            .map(SerializationConfiguration::getInclusion)
+            .orElse(SerdeConfig.SerInclude.NON_EMPTY);
+    }
+
+    private static boolean isEmptyCharSequence(Object value) {
+        return value instanceof CharSequence charSequence && charSequence.isEmpty();
+    }
+
+    /**
+     * Default-value check for scalar wrappers encoded without a property serializer field.
+     * Empty char sequences are treated as default (matches {@code NON_DEFAULT} vs {@code NON_EMPTY}
+     * for strings); numeric zero / false / NUL match the corresponding number/boolean serdes.
+     */
+    private static boolean isDefaultScalar(Object value) {
+        if (value instanceof CharSequence charSequence) {
+            return charSequence.isEmpty();
+        }
+        if (value instanceof Number number) {
+            return number.doubleValue() == 0d;
+        }
+        if (value instanceof Boolean bool) {
+            return !bool;
+        }
+        if (value instanceof Character character) {
+            return character == '\0';
+        }
+        return false;
+    }
+}
+

--- a/serde-api/src/main/java/io/micronaut/serde/util/GeneratedSerdeInclusionUtil.java
+++ b/serde-api/src/main/java/io/micronaut/serde/util/GeneratedSerdeInclusionUtil.java
@@ -23,11 +23,19 @@ import io.micronaut.serde.config.annotation.SerdeConfig;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Inclusion helpers used by generated serializers so global
- * {@code micronaut.serde.serialization.inclusion} is honored without falling
- * back to the runtime object serializer for every simple shape.
+ * Inclusion helpers used by generated serializers so that the global
+ * {@code micronaut.serde.serialization.inclusion} setting is honored without falling back to the
+ * runtime object serializer for every simple shape.
  *
- * @since 3.1.1
+ * <p>The active inclusion is resolved once, when a generated serializer is created, and is stored in
+ * a generated field. The per-property methods take the already resolved inclusion so that no
+ * configuration lookup happens on the serialization hot path.</p>
+ *
+ * <p>The scalar methods mirror the {@code isEmpty} / {@code isAbsent} / {@code isDefault} contract of
+ * the runtime serde that would otherwise write the value, so a generated serializer and the runtime
+ * object serializer agree for the same model and configuration.</p>
+ *
+ * @since 3.2
  */
 @Internal
 @UsedByGeneratedCode
@@ -37,19 +45,44 @@ public final class GeneratedSerdeInclusionUtil {
     }
 
     /**
-     * Whether a property value should be written using the active global inclusion strategy
-     * and the property serializer's empty/absent/default checks.
+     * Resolve the inclusion to apply for the given context. Invoked once per generated serializer
+     * instance, never on the per-property path.
      *
+     * @param context The encoder context
+     * @return The active inclusion
+     */
+    public static SerdeConfig.SerInclude resolveInclusion(Serializer.EncoderContext context) {
+        SerializationConfiguration configuration = context.getSerializationConfiguration().orElse(null);
+        // Matches CustomizedObjectSerializer, which also falls back to ALWAYS for a context that
+        // exposes no serialization configuration.
+        return configuration == null ? SerdeConfig.SerInclude.ALWAYS : configuration.getInclusion();
+    }
+
+    /**
+     * Whether the resolved inclusion writes every property, which lets generated serializers skip the
+     * per-property inclusion check entirely.
+     *
+     * @param include The resolved inclusion
+     * @return {@code true} if no property can be skipped
+     */
+    public static boolean includeAlways(SerdeConfig.SerInclude include) {
+        return include == SerdeConfig.SerInclude.ALWAYS || include == SerdeConfig.SerInclude.USE_DEFAULTS;
+    }
+
+    /**
+     * Whether a property written by the given serializer should be included.
+     *
+     * @param include    The resolved inclusion
      * @param context    The encoder context
      * @param serializer The property serializer
      * @param value      The property value
      * @return {@code true} if the property should be serialized
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
-    public static boolean shouldSerialize(Serializer.EncoderContext context,
+    public static boolean shouldSerialize(SerdeConfig.SerInclude include,
+                                          Serializer.EncoderContext context,
                                           Serializer serializer,
                                           @Nullable Object value) {
-        SerdeConfig.SerInclude include = resolveInclusion(context);
         return switch (include) {
             case ALWAYS, USE_DEFAULTS -> true;
             case NON_NULL -> value != null;
@@ -62,35 +95,14 @@ public final class GeneratedSerdeInclusionUtil {
     }
 
     /**
-     * Whether a scalar reference property (encoded without a cached property serializer)
-     * should be written using the active global inclusion strategy.
+     * Whether a primitive property should be included. Primitive values are never {@code null} and
+     * never empty, so only {@code NEVER} and {@code NON_DEFAULT} can skip them.
      *
-     * @param context The encoder context
-     * @param value   The property value
+     * @param include   The resolved inclusion
+     * @param isDefault Whether the value equals the default the matching serde reports for its type
      * @return {@code true} if the property should be serialized
      */
-    public static boolean shouldSerializeScalar(Serializer.EncoderContext context,
-                                                @Nullable Object value) {
-        SerdeConfig.SerInclude include = resolveInclusion(context);
-        return switch (include) {
-            case ALWAYS, USE_DEFAULTS -> true;
-            case NEVER -> false;
-            case NON_NULL, NON_ABSENT -> value != null;
-            case NON_EMPTY -> value != null && !isEmptyCharSequence(value);
-            case NON_DEFAULT -> value != null && !isDefaultScalar(value);
-        };
-    }
-
-    /**
-     * Whether a primitive property should be written using the active global inclusion strategy.
-     *
-     * @param context   The encoder context
-     * @param isDefault Whether the primitive value equals the Java language default for its type
-     * @return {@code true} if the property should be serialized
-     */
-    public static boolean shouldSerializePrimitive(Serializer.EncoderContext context,
-                                                   boolean isDefault) {
-        SerdeConfig.SerInclude include = resolveInclusion(context);
+    public static boolean shouldSerializePrimitive(SerdeConfig.SerInclude include, boolean isDefault) {
         return switch (include) {
             case NEVER -> false;
             case NON_DEFAULT -> !isDefault;
@@ -98,43 +110,94 @@ public final class GeneratedSerdeInclusionUtil {
         };
     }
 
-    private static SerdeConfig.SerInclude resolveInclusion(Serializer.EncoderContext context) {
-        return context.getSerializationConfiguration()
-            .map(SerializationConfiguration::getInclusion)
-            .orElse(SerdeConfig.SerInclude.NON_EMPTY);
-    }
-
-    private static boolean isEmptyCharSequence(Object value) {
-        return value instanceof CharSequence charSequence && charSequence.isEmpty();
+    /**
+     * Whether a {@link String} property should be included. Mirrors {@code StringSerde}, which reports
+     * {@code null} and the empty string as empty and reports no default value.
+     *
+     * @param include The resolved inclusion
+     * @param value   The property value
+     * @return {@code true} if the property should be serialized
+     */
+    public static boolean shouldSerializeString(SerdeConfig.SerInclude include, @Nullable String value) {
+        return switch (include) {
+            case ALWAYS, USE_DEFAULTS -> true;
+            case NON_NULL, NON_ABSENT -> value != null;
+            // NON_DEFAULT skips empty values too, and StringSerde reports no default value
+            case NON_EMPTY, NON_DEFAULT -> value != null && !value.isEmpty();
+            case NEVER -> false;
+        };
     }
 
     /**
-     * Default-value check for scalar wrappers encoded without a property serializer field.
-     * Empty char sequences are treated as default (matches {@code NON_DEFAULT} vs {@code NON_EMPTY}
-     * for strings); numeric zero / false / NUL match the corresponding number/boolean serdes.
-     * Only the boxed primitive-wrapper number types (Byte/Short/Integer/Long/Float/Double) treat
-     * zero as default, matching {@link io.micronaut.serde.support.serdes.NumberSerde} subtypes such
-     * as {@code IntegerSerde}/{@code LongSerde}. {@link java.math.BigInteger} and
-     * {@link java.math.BigDecimal} (and any other {@code Number}) don't override
-     * {@link Serializer#isDefault}, so their runtime-serializer default is {@code false} regardless
-     * of value; treating {@code BigInteger.ZERO}/{@code BigDecimal.ZERO} as default here would
-     * incorrectly omit them under {@code NON_DEFAULT} where the runtime path would not.
+     * Whether a {@link Number} property should be included. Mirrors the number serdes, which report
+     * only {@code null} as empty and treat the boxed zero of their own type as the default value.
+     *
+     * @param include The resolved inclusion
+     * @param value   The property value
+     * @return {@code true} if the property should be serialized
      */
-    private static boolean isDefaultScalar(Object value) {
-        if (value instanceof CharSequence charSequence) {
-            return charSequence.isEmpty();
-        }
-        if (value instanceof Byte || value instanceof Short || value instanceof Integer
-            || value instanceof Long || value instanceof Float || value instanceof Double) {
-            return ((Number) value).doubleValue() == 0d;
-        }
-        if (value instanceof Boolean bool) {
-            return !bool;
-        }
-        if (value instanceof Character character) {
-            return character == '\0';
-        }
-        return false;
+    public static boolean shouldSerializeNumber(SerdeConfig.SerInclude include, @Nullable Number value) {
+        return switch (include) {
+            case ALWAYS, USE_DEFAULTS -> true;
+            case NON_NULL, NON_ABSENT, NON_EMPTY -> value != null;
+            case NON_DEFAULT -> value != null && !isDefaultNumber(value);
+            case NEVER -> false;
+        };
+    }
+
+    /**
+     * Whether a {@link Boolean} property should be included. Mirrors {@code BooleanSerde}, which
+     * treats {@code false} as the default value.
+     *
+     * @param include The resolved inclusion
+     * @param value   The property value
+     * @return {@code true} if the property should be serialized
+     */
+    public static boolean shouldSerializeBoolean(SerdeConfig.SerInclude include, @Nullable Boolean value) {
+        return switch (include) {
+            case ALWAYS, USE_DEFAULTS -> true;
+            case NON_NULL, NON_ABSENT, NON_EMPTY -> value != null;
+            case NON_DEFAULT -> value != null && value;
+            case NEVER -> false;
+        };
+    }
+
+    /**
+     * Whether a {@link Character} property should be included. Mirrors {@code CharSerde}, which treats
+     * the NUL character as the default value.
+     *
+     * @param include The resolved inclusion
+     * @param value   The property value
+     * @return {@code true} if the property should be serialized
+     */
+    public static boolean shouldSerializeCharacter(SerdeConfig.SerInclude include, @Nullable Character value) {
+        return switch (include) {
+            case ALWAYS, USE_DEFAULTS -> true;
+            case NON_NULL, NON_ABSENT, NON_EMPTY -> value != null;
+            // Character.MIN_VALUE is the NUL character CharSerde reports as the default value
+            case NON_DEFAULT -> value != null && !value.equals(Character.MIN_VALUE);
+            case NEVER -> false;
+        };
+    }
+
+    /**
+     * Default-value check matching the number serdes registered for each boxed type. Only the boxed
+     * primitive wrappers override {@code Serializer#isDefault}; {@link java.math.BigInteger},
+     * {@link java.math.BigDecimal} and any other {@link Number} keep the {@code false} default, so
+     * treating their zero as a default value here would omit values the runtime path writes.
+     *
+     * @param value The value
+     * @return {@code true} if the value is the default value for its type
+     */
+    private static boolean isDefaultNumber(Number value) {
+        return switch (value) {
+            case Integer integer -> integer.equals(0);
+            case Long longValue -> longValue.equals(0L);
+            case Double doubleValue -> doubleValue.equals(0D);
+            case Float floatValue -> floatValue.equals(0F);
+            case Short shortValue -> shortValue.equals((short) 0);
+            case Byte byteValue -> byteValue.equals((byte) 0);
+            default -> false;
+        };
     }
 }
-

--- a/serde-jackson-cbor/src/test/groovy/io/micronaut/serde/cbor/CborByteArraySpec.groovy
+++ b/serde-jackson-cbor/src/test/groovy/io/micronaut/serde/cbor/CborByteArraySpec.groovy
@@ -1,10 +1,14 @@
 package io.micronaut.serde.cbor
 
+import io.micronaut.context.annotation.Property
 import io.micronaut.serde.cbor.data.BinaryBean
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
 import jakarta.inject.Inject
 import spock.lang.Specification
 
+// An empty byte array is empty under the default NON_EMPTY inclusion, so pin the inclusion here:
+// this spec is about the binary encoding of the value, not about whether it is written at all.
+@Property(name = 'micronaut.serde.serialization.inclusion', value = 'ALWAYS')
 @MicronautTest
 class CborByteArraySpec extends Specification {
 

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeJsonSerializeDeserializeSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/annotation/SerdeJsonSerializeDeserializeSpec.groovy
@@ -33,7 +33,7 @@ class RecursiveView {
         this.view = view;
     }
 }
-""")
+""", true, ['micronaut.serde.serialization.inclusion': 'ALWAYS'])
             def recursiveType = argumentOf(context, 'test.RecursiveView')
             def root = newInstance(context, 'test.RecursiveView', [id: 'root'])
             def child = newInstance(context, 'test.RecursiveView', [id: 'child'])
@@ -63,7 +63,7 @@ import io.micronaut.serde.annotation.Serdeable;
 @Serdeable
 public record RecursiveRecordView(String id, RecursiveRecordView view) {
 }
-""")
+""", true, ['micronaut.serde.serialization.inclusion': 'ALWAYS'])
             def recursiveType = argumentOf(context, 'test.RecursiveRecordView')
             def recursiveClass = recursiveType.type
             def constructor = recursiveClass.getDeclaredConstructor(String, recursiveClass)

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeSourceGenSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeSourceGenSpec.groovy
@@ -454,6 +454,39 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
         context.close()
     }
 
+    void 'test generated serializers honor global inclusion NON_DEFAULT for BigInteger and BigDecimal zero'() {
+        given:
+        def context = ApplicationContext.run([
+            'micronaut.serde.serialization.inclusion': 'NON_DEFAULT'
+        ])
+        jsonMapper = context.getBean(JsonMapper)
+        def registry = context.getBean(SerdeRegistry)
+        Argument beanArgument = Argument.of(SourceGenNonDefaultScalarBean)
+
+        when:
+        def zeroBean = new SourceGenNonDefaultScalarBean()
+        zeroBean.count = 0
+        zeroBean.bigCount = BigInteger.ZERO
+        zeroBean.bigAmount = BigDecimal.ZERO
+        String zeroJson = serializeToString(jsonMapper, zeroBean)
+        def nonZeroBean = new SourceGenNonDefaultScalarBean()
+        nonZeroBean.count = 1
+        nonZeroBean.bigCount = BigInteger.ONE
+        nonZeroBean.bigAmount = BigDecimal.ONE
+        String nonZeroJson = serializeToString(jsonMapper, nonZeroBean)
+
+        then:
+        assertGeneratedSerializer(registry, beanArgument)
+        // Integer/int zero is the language default and is omitted, but BigInteger/BigDecimal
+        // ZERO is not treated as a default value (matches CustomizedObjectSerializer, which
+        // relies on Serializer#isDefault, unset for BigInteger/BigDecimal).
+        validateJsonWithoutOrder(jsonMapper, '{"bigCount":0,"bigAmount":0}', zeroJson)
+        validateJsonWithoutOrder(jsonMapper, '{"count":1,"bigCount":1,"bigAmount":1}', nonZeroJson)
+
+        cleanup:
+        context.close()
+    }
+
     void 'test generated serializers honor default inclusion NON_EMPTY for null properties'() {
         given:
         def context = ApplicationContext.run()

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeSourceGenSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/CompileTimeSourceGenSpec.groovy
@@ -24,9 +24,18 @@ import tools.jackson.core.json.JsonFactory
 
 class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
+    /**
+     * Compile-time sourcegen tests that assert explicit {@code null} property output need
+     * {@code ALWAYS} inclusion. Production default is {@code NON_EMPTY}; generated serializers
+     * now honor that setting (see micronaut-core#12838).
+     */
+    private static ApplicationContext runWithAlwaysInclusion(Map extra = [:]) {
+        ApplicationContext.run(['micronaut.serde.serialization.inclusion': 'ALWAYS'] + extra)
+    }
+
     void 'test generated serializers use object encoder and generated classes use indexed fields'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         Class<?> beanType = SourceGenIndexedShapeBean.class
         Class<?> recordType = SourceGenIndexedShapeRecord.class
         def introspections = context.getBean(SerdeIntrospections)
@@ -92,7 +101,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated serializers and deserializers are selected for bean and record shapes'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
         Class<?> beanType = SourceGenIndexedShapeBean.class
@@ -132,7 +141,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated property serdes fall back for customised property metadata'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
         Argument payloadArgument = Argument.of(SourceGenPropertyAnnotationPayload)
@@ -158,7 +167,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated bean shape supports field properties'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
         Class<?> beanType = SourceGenFieldShapeBean.class
@@ -186,7 +195,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated default serializers are selected and functional'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
 
@@ -245,7 +254,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated field default serdes are selected and functional'() {
         given:
-        def context = ApplicationContext.run([
+        def context = runWithAlwaysInclusion([
             'micronaut.serde.deserialization.fail-on-null-for-primitives': false
         ])
         jsonMapper = context.getBean(JsonMapper)
@@ -331,7 +340,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated enum serializer object and formatted branches are functional'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
         Argument enumArgument = Argument.of(SourceGenFeatureEnum)
@@ -362,7 +371,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated enum deserializer reports unknown values'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
         Argument enumArgument = Argument.of(SourceGenFeatureEnum)
@@ -381,7 +390,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated serializers can be disabled with serialization feature'() {
         given:
-        def context = ApplicationContext.run([
+        def context = runWithAlwaysInclusion([
             'micronaut.serde.serialization.disable-generated-serializer': true
         ])
         jsonMapper = context.getBean(JsonMapper)
@@ -410,9 +419,64 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
         context.close()
     }
 
-    void 'test generated deserializers can be disabled with deserialization feature'() {
+    void 'test generated serializers honor global inclusion NON_NULL'() {
         given:
         def context = ApplicationContext.run([
+            'micronaut.serde.serialization.inclusion': 'NON_NULL'
+        ])
+        jsonMapper = context.getBean(JsonMapper)
+        def registry = context.getBean(SerdeRegistry)
+        Argument recordArgument = Argument.of(SourceGenIndexedShapeRecord)
+        Argument beanArgument = Argument.of(SourceGenIndexedShapeBean)
+
+        when:
+        def record = new SourceGenIndexedShapeRecord(null, null)
+        def bean = new SourceGenIndexedShapeBean()
+        bean.value = null
+        bean.tags = null
+        String recordJson = serializeToString(jsonMapper, record)
+        String beanJson = serializeToString(jsonMapper, bean)
+        String recordPresentJson = serializeToString(jsonMapper, new SourceGenIndexedShapeRecord('hi', ['x']))
+        def beanPresent = new SourceGenIndexedShapeBean()
+        beanPresent.value = 'hi'
+        beanPresent.tags = ['x']
+        String beanPresentJson = serializeToString(jsonMapper, beanPresent)
+
+        then:
+        assertGeneratedSerializer(registry, recordArgument)
+        assertGeneratedSerializer(registry, beanArgument)
+        recordJson == '{}'
+        beanJson == '{}'
+        validateJsonWithoutOrder(jsonMapper, '{"value":"hi","tags":["x"]}', recordPresentJson)
+        validateJsonWithoutOrder(jsonMapper, '{"value":"hi","tags":["x"]}', beanPresentJson)
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test generated serializers honor default inclusion NON_EMPTY for null properties'() {
+        given:
+        def context = ApplicationContext.run()
+        jsonMapper = context.getBean(JsonMapper)
+        def registry = context.getBean(SerdeRegistry)
+        Argument recordArgument = Argument.of(SourceGenIndexedShapeRecord)
+
+        when:
+        String nullJson = serializeToString(jsonMapper, new SourceGenIndexedShapeRecord(null, null))
+        String emptyJson = serializeToString(jsonMapper, new SourceGenIndexedShapeRecord('', []))
+
+        then:
+        assertGeneratedSerializer(registry, recordArgument)
+        nullJson == '{}'
+        emptyJson == '{}'
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test generated deserializers can be disabled with deserialization feature'() {
+        given:
+        def context = runWithAlwaysInclusion([
             'micronaut.serde.deserialization.disable-generated-deserializer': true
         ])
         jsonMapper = context.getBean(JsonMapper)
@@ -444,7 +508,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
     @SuppressWarnings('JsonDuplicatePropertyKeys')
     void 'test generated bean deserializer dispatch source for small boundary and large property sets'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
         def decoderContext = registry.newDecoderContext(Object)
@@ -530,7 +594,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated large bean serializer wraps property exceptions'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         def registry = context.getBean(SerdeRegistry)
         def encoderContext = registry.newEncoderContext(Object)
         Argument argument = Argument.of(SourceGenLargeDispatchBean)
@@ -568,7 +632,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated large record serializers cover nullable branches'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
         Argument argument = Argument.of(type)
@@ -595,7 +659,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated large record serializers wrap property exceptions'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         def registry = context.getBean(SerdeRegistry)
         def encoderContext = registry.newEncoderContext(Object)
         Argument argument = Argument.of(type)
@@ -639,7 +703,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated record deserializer dispatch source for small boundary and large property sets'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
         def decoderContext = registry.newDecoderContext(Object)
@@ -700,7 +764,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated non null record serializers are selected and functional'() {
         given:
-        def context = ApplicationContext.run()
+        def context = runWithAlwaysInclusion()
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
         Argument smallArgument = Argument.of(SourceGenSmallDispatchNonNullRecord)
@@ -730,7 +794,7 @@ class CompileTimeSourceGenSpec extends JsonCompileSpec {
 
     void 'test generated record constructor failures match runtime for small and large property sets'() {
         given:
-        def context = ApplicationContext.run(['micronaut.serde.deserialization.strict-nullable': true])
+        def context = runWithAlwaysInclusion(['micronaut.serde.deserialization.strict-nullable': true])
         jsonMapper = context.getBean(JsonMapper)
 
         expect:

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/GeneratedInclusionParitySpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/GeneratedInclusionParitySpec.groovy
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.jackson.compiletime
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.type.Argument
+import io.micronaut.json.JsonMapper
+import io.micronaut.serde.SerdeRegistry
+import io.micronaut.serde.Serializer
+import io.micronaut.serde.jackson.JsonCompileSpec
+import spock.lang.Unroll
+
+/**
+ * Generated serializers apply {@code micronaut.serde.serialization.inclusion} themselves instead of
+ * falling back to the runtime object serializer, so every inclusion has to produce exactly what the
+ * runtime path produces for the same model and payload.
+ */
+class GeneratedInclusionParitySpec extends JsonCompileSpec {
+
+    private static final List<String> INCLUSIONS = [
+        'ALWAYS', 'USE_DEFAULTS', 'NON_NULL', 'NON_ABSENT', 'NON_EMPTY', 'NON_DEFAULT', 'NEVER'
+    ]
+
+    @Unroll
+    void 'test generated bean serializer matches the runtime serializer for inclusion #inclusion'() {
+        given:
+        def generatedContext = ApplicationContext.run(['micronaut.serde.serialization.inclusion': inclusion])
+        def runtimeContext = ApplicationContext.run([
+            'micronaut.serde.serialization.inclusion'                   : inclusion,
+            'micronaut.serde.serialization.disable-generated-serializer': true
+        ])
+        def generatedMapper = generatedContext.getBean(JsonMapper)
+        def runtimeMapper = runtimeContext.getBean(JsonMapper)
+        Argument argument = Argument.of(SourceGenInclusionShapeBean)
+
+        expect:
+        assertGeneratedSerializer(generatedContext.getBean(SerdeRegistry), argument, true)
+        assertGeneratedSerializer(runtimeContext.getBean(SerdeRegistry), argument, false)
+
+        and:
+        beanPayloads().every { payload ->
+            String generatedJson = serializeToString(generatedMapper, payload)
+            String runtimeJson = serializeToString(runtimeMapper, payload)
+            assert generatedJson == runtimeJson
+            true
+        }
+
+        cleanup:
+        generatedContext.close()
+        runtimeContext.close()
+
+        where:
+        inclusion << INCLUSIONS
+    }
+
+    @Unroll
+    void 'test generated record serializer matches the runtime serializer for inclusion #inclusion'() {
+        given:
+        def generatedContext = ApplicationContext.run(['micronaut.serde.serialization.inclusion': inclusion])
+        def runtimeContext = ApplicationContext.run([
+            'micronaut.serde.serialization.inclusion'                   : inclusion,
+            'micronaut.serde.serialization.disable-generated-serializer': true
+        ])
+        def generatedMapper = generatedContext.getBean(JsonMapper)
+        def runtimeMapper = runtimeContext.getBean(JsonMapper)
+        Argument argument = Argument.of(SourceGenInclusionShapeRecord)
+
+        expect:
+        assertGeneratedSerializer(generatedContext.getBean(SerdeRegistry), argument, true)
+        assertGeneratedSerializer(runtimeContext.getBean(SerdeRegistry), argument, false)
+
+        and:
+        recordPayloads().every { payload ->
+            String generatedJson = serializeToString(generatedMapper, payload)
+            String runtimeJson = serializeToString(runtimeMapper, payload)
+            assert generatedJson == runtimeJson
+            true
+        }
+
+        cleanup:
+        generatedContext.close()
+        runtimeContext.close()
+
+        where:
+        inclusion << INCLUSIONS
+    }
+
+    void 'test generated serializers resolve the inclusion once per serializer instance'() {
+        given:
+        String source = generatedTestSource('io.micronaut.serde.jackson.compiletime.SerdeSourceGenInclusionShapeBeanSerializer')
+
+        expect: 'the configuration lookup happens in the constructor, not per property'
+        source.contains('this.include = GeneratedSerdeInclusionUtil.resolveInclusion(context);')
+        source.contains('this.includeAll = GeneratedSerdeInclusionUtil.includeAlways(this.include);')
+        source.count('resolveInclusion') == 1
+        source.count('this.includeAll ||') == source.count('keysAwareEncoder.encodeKey(')
+
+        and: 'each property kind uses the check matching the serde that writes it'
+        source.contains('GeneratedSerdeInclusionUtil.shouldSerializeString(this.include, ')
+        source.contains('GeneratedSerdeInclusionUtil.shouldSerializeBoolean(this.include, ')
+        source.contains('GeneratedSerdeInclusionUtil.shouldSerializeCharacter(this.include, ')
+        source.contains('GeneratedSerdeInclusionUtil.shouldSerializeNumber(this.include, ')
+        source.contains('GeneratedSerdeInclusionUtil.shouldSerializePrimitive(this.include, ')
+        source.contains('GeneratedSerdeInclusionUtil.shouldSerialize(this.include, context, ')
+    }
+
+    private static List<SourceGenInclusionShapeBean> beanPayloads() {
+        return [
+            newBean {},
+            newBean {
+                it.text = 'value'
+                it.boxedFlag = Boolean.TRUE
+                it.boxedLetter = Character.valueOf('a' as char)
+                it.boxedByte = (byte) 1
+                it.boxedShort = (short) 1
+                it.boxedInt = 1
+                it.boxedLong = 1L
+                it.boxedFloat = 1.5F
+                it.boxedDouble = 1.5D
+                it.bigInteger = BigInteger.ONE
+                it.bigDecimal = BigDecimal.ONE
+                it.flag = true
+                it.letter = 'a' as char
+                it.count = 1
+                it.id = 1L
+                it.ratio = 1.5F
+                it.score = 1.5D
+                it.tags = ['a']
+                it.attributes = [a: 'b']
+            },
+            newBean {
+                it.text = ''
+                it.boxedFlag = Boolean.FALSE
+                it.boxedLetter = Character.valueOf((char) 0)
+                it.boxedByte = (byte) 0
+                it.boxedShort = (short) 0
+                it.boxedInt = 0
+                it.boxedLong = 0L
+                it.boxedFloat = 0F
+                it.boxedDouble = 0D
+                it.bigInteger = BigInteger.ZERO
+                it.bigDecimal = BigDecimal.ZERO
+                it.tags = []
+                it.attributes = [:]
+            },
+            newBean {
+                it.boxedFloat = -0.0F
+                it.boxedDouble = -0.0D
+                it.ratio = -0.0F
+                it.score = -0.0D
+            },
+            newBean {
+                it.boxedFloat = Float.NaN
+                it.boxedDouble = Double.NaN
+                it.ratio = Float.NaN
+                it.score = Double.NaN
+            }
+        ]
+    }
+
+    private static List<SourceGenInclusionShapeRecord> recordPayloads() {
+        return beanPayloads().collect { bean ->
+            new SourceGenInclusionShapeRecord(
+                bean.text,
+                bean.boxedFlag,
+                bean.boxedLetter,
+                bean.boxedByte,
+                bean.boxedShort,
+                bean.boxedInt,
+                bean.boxedLong,
+                bean.boxedFloat,
+                bean.boxedDouble,
+                bean.bigInteger,
+                bean.bigDecimal,
+                bean.flag,
+                bean.letter,
+                bean.count,
+                bean.id,
+                bean.ratio,
+                bean.score,
+                bean.tags,
+                bean.attributes
+            )
+        }
+    }
+
+    private static SourceGenInclusionShapeBean newBean(Closure<?> configurer) {
+        def bean = new SourceGenInclusionShapeBean()
+        configurer.call(bean)
+        return bean
+    }
+
+    private static void assertGeneratedSerializer(SerdeRegistry registry, Argument argument, boolean generated) {
+        Serializer serializer = registry.findSerializer(argument).createSpecific(registry.newEncoderContext(Object), argument)
+        assert (serializer.class.name == generatedClassName(argument.type, 'Serializer')) == generated
+    }
+
+    private static String generatedClassName(Class<?> type, String suffix) {
+        String packageName = type.package.name
+        String localName = type.name.substring(packageName.length() + 1)
+        "${packageName}.Serde${localName.replace('.', '_').replace('$', '_')}${suffix}"
+    }
+}

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/SerdeableGeneratedSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/SerdeableGeneratedSpec.groovy
@@ -25,7 +25,9 @@ class SerdeableGeneratedSpec extends JsonCompileSpec {
 
     void 'test serdeable generated serializer and deserializer are functional'() {
         given:
-        def context = ApplicationContext.run()
+        def context = ApplicationContext.run([
+            'micronaut.serde.serialization.inclusion': 'ALWAYS'
+        ])
         jsonMapper = context.getBean(JsonMapper)
         def registry = context.getBean(SerdeRegistry)
         Argument argument = Argument.of(SourceGenGeneratedShape)
@@ -67,6 +69,28 @@ class SerdeableGeneratedSpec extends JsonCompileSpec {
         then:
         def e = thrown(Exception)
         e.message.contains('Required property')
+
+        cleanup:
+        context.close()
+    }
+
+    void 'test serdeable generated serializer honors global inclusion NON_NULL'() {
+        given:
+        def context = ApplicationContext.run([
+            'micronaut.serde.serialization.inclusion': 'NON_NULL'
+        ])
+        jsonMapper = context.getBean(JsonMapper)
+        def registry = context.getBean(SerdeRegistry)
+        Argument argument = Argument.of(SourceGenGeneratedShape)
+
+        when:
+        String nullJson = serializeToString(jsonMapper, new SourceGenGeneratedShape(null, 7))
+        String presentJson = serializeToString(jsonMapper, new SourceGenGeneratedShape('Ada', 42))
+
+        then:
+        assertRegistrySelection(registry, argument, 'Serializer', true)
+        nullJson == '{"count":7}'
+        presentJson == '{"name":"Ada","count":42}'
 
         cleanup:
         context.close()

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenInclusionShapeBean.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenInclusionShapeBean.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Covers every property shape a generated serializer can take an inclusion decision for: primitives,
+ * boxed scalars encoded without a property serializer, and values written through a property
+ * serializer.
+ */
+@SerdeableGenerated
+@Introspected
+public class SourceGenInclusionShapeBean {
+    private String text;
+    private Boolean boxedFlag;
+    private Character boxedLetter;
+    private Byte boxedByte;
+    private Short boxedShort;
+    private Integer boxedInt;
+    private Long boxedLong;
+    private Float boxedFloat;
+    private Double boxedDouble;
+    private BigInteger bigInteger;
+    private BigDecimal bigDecimal;
+    private boolean flag;
+    private char letter;
+    private int count;
+    private long id;
+    private float ratio;
+    private double score;
+    private List<String> tags;
+    private Map<String, String> attributes;
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public Boolean getBoxedFlag() {
+        return boxedFlag;
+    }
+
+    public void setBoxedFlag(Boolean boxedFlag) {
+        this.boxedFlag = boxedFlag;
+    }
+
+    public Character getBoxedLetter() {
+        return boxedLetter;
+    }
+
+    public void setBoxedLetter(Character boxedLetter) {
+        this.boxedLetter = boxedLetter;
+    }
+
+    public Byte getBoxedByte() {
+        return boxedByte;
+    }
+
+    public void setBoxedByte(Byte boxedByte) {
+        this.boxedByte = boxedByte;
+    }
+
+    public Short getBoxedShort() {
+        return boxedShort;
+    }
+
+    public void setBoxedShort(Short boxedShort) {
+        this.boxedShort = boxedShort;
+    }
+
+    public Integer getBoxedInt() {
+        return boxedInt;
+    }
+
+    public void setBoxedInt(Integer boxedInt) {
+        this.boxedInt = boxedInt;
+    }
+
+    public Long getBoxedLong() {
+        return boxedLong;
+    }
+
+    public void setBoxedLong(Long boxedLong) {
+        this.boxedLong = boxedLong;
+    }
+
+    public Float getBoxedFloat() {
+        return boxedFloat;
+    }
+
+    public void setBoxedFloat(Float boxedFloat) {
+        this.boxedFloat = boxedFloat;
+    }
+
+    public Double getBoxedDouble() {
+        return boxedDouble;
+    }
+
+    public void setBoxedDouble(Double boxedDouble) {
+        this.boxedDouble = boxedDouble;
+    }
+
+    public BigInteger getBigInteger() {
+        return bigInteger;
+    }
+
+    public void setBigInteger(BigInteger bigInteger) {
+        this.bigInteger = bigInteger;
+    }
+
+    public BigDecimal getBigDecimal() {
+        return bigDecimal;
+    }
+
+    public void setBigDecimal(BigDecimal bigDecimal) {
+        this.bigDecimal = bigDecimal;
+    }
+
+    public boolean isFlag() {
+        return flag;
+    }
+
+    public void setFlag(boolean flag) {
+        this.flag = flag;
+    }
+
+    public char getLetter() {
+        return letter;
+    }
+
+    public void setLetter(char letter) {
+        this.letter = letter;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public float getRatio() {
+        return ratio;
+    }
+
+    public void setRatio(float ratio) {
+        this.ratio = ratio;
+    }
+
+    public double getScore() {
+        return score;
+    }
+
+    public void setScore(double score) {
+        this.score = score;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, String> attributes) {
+        this.attributes = attributes;
+    }
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenInclusionShapeRecord.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenInclusionShapeRecord.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Record counterpart of {@link SourceGenInclusionShapeBean}.
+ *
+ * @param text         A string component
+ * @param boxedFlag    A boxed boolean component
+ * @param boxedLetter  A boxed character component
+ * @param boxedByte    A boxed byte component
+ * @param boxedShort   A boxed short component
+ * @param boxedInt     A boxed int component
+ * @param boxedLong    A boxed long component
+ * @param boxedFloat   A boxed float component
+ * @param boxedDouble  A boxed double component
+ * @param bigInteger   A big integer component
+ * @param bigDecimal   A big decimal component
+ * @param flag         A primitive boolean component
+ * @param letter       A primitive char component
+ * @param count        A primitive int component
+ * @param id           A primitive long component
+ * @param ratio        A primitive float component
+ * @param score        A primitive double component
+ * @param tags         A list component written through a property serializer
+ * @param attributes   A map component written through a property serializer
+ */
+@SerdeableGenerated
+public record SourceGenInclusionShapeRecord(
+    String text,
+    Boolean boxedFlag,
+    Character boxedLetter,
+    Byte boxedByte,
+    Short boxedShort,
+    Integer boxedInt,
+    Long boxedLong,
+    Float boxedFloat,
+    Double boxedDouble,
+    BigInteger bigInteger,
+    BigDecimal bigDecimal,
+    boolean flag,
+    char letter,
+    int count,
+    long id,
+    float ratio,
+    double score,
+    List<String> tags,
+    Map<String, String> attributes
+) {
+}

--- a/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenNonDefaultScalarBean.java
+++ b/serde-jackson/src/test/java/io/micronaut/serde/jackson/compiletime/SourceGenNonDefaultScalarBean.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.jackson.compiletime;
+
+import io.micronaut.core.annotation.Introspected;
+import io.micronaut.serde.annotation.SerdeableGenerated;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+@SerdeableGenerated
+@Introspected
+public class SourceGenNonDefaultScalarBean {
+    private Integer count;
+    private BigInteger bigCount;
+    private BigDecimal bigAmount;
+
+    public Integer getCount() {
+        return count;
+    }
+
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+
+    public BigInteger getBigCount() {
+        return bigCount;
+    }
+
+    public void setBigCount(BigInteger bigCount) {
+        this.bigCount = bigCount;
+    }
+
+    public BigDecimal getBigAmount() {
+        return bigAmount;
+    }
+
+    public void setBigAmount(BigDecimal bigAmount) {
+        this.bigAmount = bigAmount;
+    }
+}

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/SerdeInclusionSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/SerdeInclusionSourceGen.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.processor.sourcegen;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.reflect.ReflectionUtils;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.serde.Serializer;
+import io.micronaut.serde.config.annotation.SerdeConfig;
+import io.micronaut.serde.util.GeneratedSerdeInclusionUtil;
+import io.micronaut.sourcegen.model.ClassTypeDef;
+import io.micronaut.sourcegen.model.ExpressionDef;
+import io.micronaut.sourcegen.model.FieldDef;
+import io.micronaut.sourcegen.model.StatementDef;
+import io.micronaut.sourcegen.model.TypeDef;
+import io.micronaut.sourcegen.model.VariableDef;
+
+import javax.lang.model.element.Modifier;
+import java.lang.reflect.Method;
+import java.util.List;
+
+/**
+ * Generates the inclusion handling shared by the bean and record serializer generators.
+ *
+ * <p>The active inclusion is resolved once, in the generated constructor, into two final fields: the
+ * {@link SerdeConfig.SerInclude} itself and a flag for a configuration that never skips a property.
+ * A per-property check is then a field read plus, at most, a static call that switches on the already
+ * resolved value.</p>
+ *
+ * @since 3.2
+ */
+@Internal
+public final class SerdeInclusionSourceGen {
+    private static final String INCLUDE_FIELD = "include";
+    private static final String INCLUDE_ALL_FIELD = "includeAll";
+
+    private static final Method RESOLVE_INCLUSION_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "resolveInclusion",
+        Serializer.EncoderContext.class
+    );
+    private static final Method INCLUDE_ALWAYS_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "includeAlways",
+        SerdeConfig.SerInclude.class
+    );
+    private static final Method SHOULD_SERIALIZE_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerialize",
+        SerdeConfig.SerInclude.class,
+        Serializer.EncoderContext.class,
+        Serializer.class,
+        Object.class
+    );
+    private static final Method SHOULD_SERIALIZE_PRIMITIVE_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerializePrimitive",
+        SerdeConfig.SerInclude.class,
+        boolean.class
+    );
+    private static final Method SHOULD_SERIALIZE_STRING_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerializeString",
+        SerdeConfig.SerInclude.class,
+        String.class
+    );
+    private static final Method SHOULD_SERIALIZE_NUMBER_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerializeNumber",
+        SerdeConfig.SerInclude.class,
+        Number.class
+    );
+    private static final Method SHOULD_SERIALIZE_BOOLEAN_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerializeBoolean",
+        SerdeConfig.SerInclude.class,
+        Boolean.class
+    );
+    private static final Method SHOULD_SERIALIZE_CHARACTER_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerializeCharacter",
+        SerdeConfig.SerInclude.class,
+        Character.class
+    );
+    private static final Method FLOAT_COMPARE_METHOD = ReflectionUtils.getRequiredMethod(Float.class, "compare", float.class, float.class);
+    private static final Method DOUBLE_COMPARE_METHOD = ReflectionUtils.getRequiredMethod(Double.class, "compare", double.class, double.class);
+
+    private static final ClassTypeDef INCLUSION_UTIL_TYPE = ClassTypeDef.of(GeneratedSerdeInclusionUtil.class);
+    private static final TypeDef SER_INCLUDE_TYPE = TypeDef.of(SerdeConfig.SerInclude.class);
+
+    private SerdeInclusionSourceGen() {
+    }
+
+    /**
+     * The fields holding the resolved inclusion.
+     *
+     * @return The generated fields
+     */
+    public static List<FieldDef> fields() {
+        return List.of(
+            FieldDef.builder(INCLUDE_FIELD, SER_INCLUDE_TYPE)
+                .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+                .build(),
+            FieldDef.builder(INCLUDE_ALL_FIELD, TypeDef.Primitive.BOOLEAN)
+                .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+                .build()
+        );
+    }
+
+    /**
+     * The constructor statements resolving the inclusion once per serializer instance.
+     *
+     * @param aThis   The serializer instance
+     * @param context The encoder context constructor parameter
+     * @return The generated statements
+     */
+    public static List<StatementDef> resolveStatements(VariableDef.This aThis, VariableDef.MethodParameter context) {
+        return List.of(
+            includeField(aThis).put(INCLUSION_UTIL_TYPE.invokeStatic(RESOLVE_INCLUSION_METHOD, context)),
+            aThis.field(INCLUDE_ALL_FIELD, TypeDef.Primitive.BOOLEAN)
+                .put(INCLUSION_UTIL_TYPE.invokeStatic(INCLUDE_ALWAYS_METHOD, includeField(aThis)))
+        );
+    }
+
+    /**
+     * The condition for writing a primitive property.
+     *
+     * @param aThis         The serializer instance
+     * @param type          The property type
+     * @param propertyValue The local holding the property value
+     * @return The generated condition
+     */
+    public static ExpressionDef.ConditionExpressionDef shouldSerializePrimitive(VariableDef.This aThis,
+                                                                               ClassElement type,
+                                                                               ExpressionDef propertyValue) {
+        return inclusionCheck(aThis, INCLUSION_UTIL_TYPE.invokeStatic(
+            SHOULD_SERIALIZE_PRIMITIVE_METHOD,
+            includeField(aThis),
+            primitiveIsDefaultExpression(type, propertyValue)
+        ));
+    }
+
+    /**
+     * The condition for writing a scalar property encoded without a property serializer.
+     *
+     * @param aThis         The serializer instance
+     * @param type          The property type
+     * @param propertyValue The local holding the property value
+     * @return The generated condition
+     */
+    public static ExpressionDef.ConditionExpressionDef shouldSerializeScalar(VariableDef.This aThis,
+                                                                            ClassElement type,
+                                                                            ExpressionDef propertyValue) {
+        return inclusionCheck(aThis, INCLUSION_UTIL_TYPE.invokeStatic(
+            scalarInclusionMethod(type),
+            includeField(aThis),
+            propertyValue
+        ));
+    }
+
+    /**
+     * The condition for writing a property through its property serializer.
+     *
+     * @param aThis         The serializer instance
+     * @param context       The encoder context parameter
+     * @param serializer    The property serializer field
+     * @param propertyValue The local holding the property value
+     * @return The generated condition
+     */
+    public static ExpressionDef.ConditionExpressionDef shouldSerializeValue(VariableDef.This aThis,
+                                                                           VariableDef.MethodParameter context,
+                                                                           ExpressionDef serializer,
+                                                                           ExpressionDef propertyValue) {
+        return inclusionCheck(aThis, INCLUSION_UTIL_TYPE.invokeStatic(
+            SHOULD_SERIALIZE_METHOD,
+            includeField(aThis),
+            context,
+            serializer,
+            propertyValue.cast(TypeDef.OBJECT)
+        ));
+    }
+
+    private static VariableDef.Field includeField(VariableDef.This aThis) {
+        return aThis.field(INCLUDE_FIELD, SER_INCLUDE_TYPE);
+    }
+
+    /**
+     * Combines an inclusion check with the precomputed "writes everything" flag so a configuration that
+     * never skips a property costs a single field read on the serialization hot path.
+     */
+    private static ExpressionDef.ConditionExpressionDef inclusionCheck(VariableDef.This aThis, ExpressionDef check) {
+        return aThis.field(INCLUDE_ALL_FIELD, TypeDef.Primitive.BOOLEAN).isTrue().or(check.isTrue());
+    }
+
+    /**
+     * The inclusion helper matching the serde that writes the value at runtime. Every scalar type
+     * written without a property serializer other than string, boolean and character is a number.
+     */
+    private static Method scalarInclusionMethod(ClassElement type) {
+        return switch (type.getName()) {
+            case "java.lang.String" -> SHOULD_SERIALIZE_STRING_METHOD;
+            case "java.lang.Boolean" -> SHOULD_SERIALIZE_BOOLEAN_METHOD;
+            case "java.lang.Character" -> SHOULD_SERIALIZE_CHARACTER_METHOD;
+            default -> SHOULD_SERIALIZE_NUMBER_METHOD;
+        };
+    }
+
+    /**
+     * Whether a primitive value equals the default value the matching serde reports for its type.
+     * Float and double go through {@code compare} so {@code -0.0} and {@code NaN} agree with
+     * {@code FloatSerde}/{@code DoubleSerde}, which compare the boxed value using {@code equals}.
+     */
+    private static ExpressionDef primitiveIsDefaultExpression(ClassElement type, ExpressionDef propertyValue) {
+        return switch (type.getName()) {
+            case "boolean" -> propertyValue.isFalse();
+            case "char" -> isEqual(propertyValue, ExpressionDef.constant(0).cast(TypeDef.Primitive.CHAR));
+            case "float" -> isEqual(
+                ClassTypeDef.of(Float.class).invokeStatic(FLOAT_COMPARE_METHOD, propertyValue, ExpressionDef.constant(0F)),
+                ExpressionDef.constant(0)
+            );
+            case "double" -> isEqual(
+                ClassTypeDef.of(Double.class).invokeStatic(DOUBLE_COMPARE_METHOD, propertyValue, ExpressionDef.constant(0D)),
+                ExpressionDef.constant(0)
+            );
+            case "long" -> isEqual(propertyValue, ExpressionDef.constant(0L));
+            case "byte" -> isEqual(propertyValue, ExpressionDef.constant(0).cast(TypeDef.Primitive.BYTE));
+            case "short" -> isEqual(propertyValue, ExpressionDef.constant(0).cast(TypeDef.Primitive.SHORT));
+            default -> isEqual(propertyValue, ExpressionDef.constant(0));
+        };
+    }
+
+    private static ExpressionDef isEqual(ExpressionDef left, ExpressionDef right) {
+        return left.compare(ExpressionDef.ComparisonOperation.OpType.EQUAL_TO, right);
+    }
+}

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanSerializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanSerializerSourceGen.java
@@ -29,6 +29,7 @@ import io.micronaut.serde.Keys;
 import io.micronaut.serde.KeysAwareEncoder;
 import io.micronaut.serde.ObjectSerializer;
 import io.micronaut.serde.Serializer;
+import io.micronaut.serde.config.annotation.SerdeConfig;
 import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.processor.sourcegen.SerdeSourceGenClassNaming;
 import io.micronaut.serde.util.GeneratedSerdeExceptionUtil;
@@ -66,6 +67,8 @@ public final class BeanSerializerSourceGen {
     private static final String VALUE_LOCAL_PREFIX = "value";
     private static final String GENERATED_VALUE_MEMBER = "value";
     private static final String KEYS_FIELD = "KEYS";
+    private static final String INCLUDE_FIELD = "include";
+    private static final String INCLUDE_ALL_FIELD = "includeAll";
 
     private static final TypeDef ARGUMENT_TYPE = TypeDef.of(Argument.class);
     private static final TypeDef SERIALIZER_TYPE = TypeDef.of(Serializer.class);
@@ -122,26 +125,58 @@ public final class BeanSerializerSourceGen {
         Argument.class,
         Argument.class
     );
+    private static final Method RESOLVE_INCLUSION_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "resolveInclusion",
+        Serializer.EncoderContext.class
+    );
+    private static final Method INCLUDE_ALWAYS_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "includeAlways",
+        SerdeConfig.SerInclude.class
+    );
     private static final Method SHOULD_SERIALIZE_METHOD = ReflectionUtils.getRequiredMethod(
         GeneratedSerdeInclusionUtil.class,
         "shouldSerialize",
+        SerdeConfig.SerInclude.class,
         Serializer.EncoderContext.class,
         Serializer.class,
-        Object.class
-    );
-    private static final Method SHOULD_SERIALIZE_SCALAR_METHOD = ReflectionUtils.getRequiredMethod(
-        GeneratedSerdeInclusionUtil.class,
-        "shouldSerializeScalar",
-        Serializer.EncoderContext.class,
         Object.class
     );
     private static final Method SHOULD_SERIALIZE_PRIMITIVE_METHOD = ReflectionUtils.getRequiredMethod(
         GeneratedSerdeInclusionUtil.class,
         "shouldSerializePrimitive",
-        Serializer.EncoderContext.class,
+        SerdeConfig.SerInclude.class,
         boolean.class
     );
+    private static final Method SHOULD_SERIALIZE_STRING_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerializeString",
+        SerdeConfig.SerInclude.class,
+        String.class
+    );
+    private static final Method SHOULD_SERIALIZE_NUMBER_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerializeNumber",
+        SerdeConfig.SerInclude.class,
+        Number.class
+    );
+    private static final Method SHOULD_SERIALIZE_BOOLEAN_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerializeBoolean",
+        SerdeConfig.SerInclude.class,
+        Boolean.class
+    );
+    private static final Method SHOULD_SERIALIZE_CHARACTER_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerializeCharacter",
+        SerdeConfig.SerInclude.class,
+        Character.class
+    );
+    private static final Method FLOAT_COMPARE_METHOD = ReflectionUtils.getRequiredMethod(Float.class, "compare", float.class, float.class);
+    private static final Method DOUBLE_COMPARE_METHOD = ReflectionUtils.getRequiredMethod(Double.class, "compare", double.class, double.class);
     private static final ClassTypeDef INCLUSION_UTIL_TYPE = ClassTypeDef.of(GeneratedSerdeInclusionUtil.class);
+    private static final TypeDef SER_INCLUDE_TYPE = TypeDef.of(SerdeConfig.SerInclude.class);
 
     private static String required(Map<String, String> names, String key) {
         return Objects.requireNonNull(names.get(key));
@@ -192,6 +227,16 @@ public final class BeanSerializerSourceGen {
                 .initializer(keysCreateExpression(serializerClassTypeDef, beanSerdeShape.properties(), new ArrayList<>(keyFieldNames.values())))
                 .build());
         }
+        // The active inclusion is resolved once per serializer, never per property and per document
+        boolean inclusionAware = !beanSerdeShape.properties().isEmpty();
+        if (inclusionAware) {
+            fields.add(FieldDef.builder(INCLUDE_FIELD, SER_INCLUDE_TYPE)
+                .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+                .build());
+            fields.add(FieldDef.builder(INCLUDE_ALL_FIELD, TypeDef.Primitive.BOOLEAN)
+                .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+                .build());
+        }
         ClassDef.ClassDefBuilder classDefBuilder = ClassDef.builder(SerdeSourceGenClassNaming.generatedSerializerClassName(element))
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
             .addAnnotation(Prototype.class)
@@ -204,7 +249,7 @@ public final class BeanSerializerSourceGen {
             .addMethod(generateCreateSpecificMethod(beanTypeDef))
             .addMethod(generateSerializeMethod(beanTypeDef))
             .addMethod(generateSerializeIntoMethod(beanTypeDef, serializerClassTypeDef, beanSerdeShape, argumentFieldNames, serializerFieldNames));
-        if (!serializerFieldNames.isEmpty()) {
+        if (inclusionAware) {
             classDefBuilder.addMethod(generateConstructor(
                 element,
                 beanTypeDef,
@@ -241,12 +286,12 @@ public final class BeanSerializerSourceGen {
             .addParameter(parameter(CONTEXT_PARAMETER, TypeDef.of(Serializer.EncoderContext.class)))
             .addParameter(parameter("type", TypeDef.parameterized(Argument.class, TypeDef.wildcardSubtypeOf(beanTypeDef))))
             .addThrows(TypeDef.of(SerdeException.class));
-        if (serializerFieldNames.isEmpty()) {
-            return constructorBuilder.build();
-        }
         return constructorBuilder.build((aThis, methodParameters) -> {
             List<StatementDef> statements = new ArrayList<>();
             VariableDef.MethodParameter context = methodParameters.get(0);
+            statements.add(includeField(aThis).put(INCLUSION_UTIL_TYPE.invokeStatic(RESOLVE_INCLUSION_METHOD, context)));
+            statements.add(aThis.field(INCLUDE_ALL_FIELD, TypeDef.Primitive.BOOLEAN)
+                .put(INCLUSION_UTIL_TYPE.invokeStatic(INCLUDE_ALWAYS_METHOD, includeField(aThis))));
             for (Map.Entry<String, String> serializerFieldEntry : serializerFieldNames.entrySet()) {
                 String propertyName = serializerFieldEntry.getKey();
                 String serializerFieldName = serializerFieldEntry.getValue();
@@ -413,45 +458,42 @@ public final class BeanSerializerSourceGen {
                                            Map<String, String> argumentFieldNames,
                                            Map<String, String> serializerFieldNames) {
         ExpressionDef argumentExpression = serializerClassTypeDef.getStaticField(required(argumentFieldNames, property.name()), ARGUMENT_TYPE);
-        Method scalarMethod = scalarEncoderMethod(property.serializationType());
+        ClassElement propertyType = property.serializationType();
+        Method scalarMethod = scalarEncoderMethod(propertyType);
         ExpressionDef propertyValue = readPropertyValue(value, property);
         StatementDef encodeKey = encodeKeyStatement(serializerClassTypeDef, keyEncoder, index);
+        String valueLocalName = BeanSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index);
+        boolean primitive = propertyType.isPrimitive() && !propertyType.isArray();
         if (scalarMethod != null) {
-            if (property.serializationType().isPrimitive() && !property.serializationType().isArray()) {
-                ExpressionDef isDefault = primitiveIsDefaultExpression(property.serializationType(), propertyValue);
+            // A local keeps the property read to a single access: the inclusion check must not repeat a getter
+            StatementDef.DefineAndAssign scalarValueDef = propertyValue.newLocal(valueLocalName);
+            if (primitive) {
                 StatementDef writePrimitive = StatementDef.multi(
                     encodeKey,
-                    objectEncoder.invoke(scalarMethod, propertyValue)
+                    objectEncoder.invoke(scalarMethod, scalarValueDef.variable())
                 );
-                return wrapWithPropertyPath(
-                    INCLUSION_UTIL_TYPE.invokeStatic(SHOULD_SERIALIZE_PRIMITIVE_METHOD, context, isDefault)
-                        .ifTrue(writePrimitive),
-                    type,
-                    argumentExpression
-                );
+                return wrapWithPropertyPath(StatementDef.multi(
+                    scalarValueDef,
+                    shouldSerializePrimitive(aThis, propertyType, scalarValueDef.variable()).ifTrue(writePrimitive)
+                ), type, argumentExpression);
             }
-            StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(BeanSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
             StatementDef writeScalar = StatementDef.multi(
                 encodeKey,
-                propertyValueDef.variable().isNull().ifTrue(
+                scalarValueDef.variable().isNull().ifTrue(
                     objectEncoder.invoke(ENCODE_NULL_METHOD),
-                    StatementDef.multi(objectEncoder.invoke(scalarMethod, propertyValueDef.variable()))
+                    StatementDef.multi(objectEncoder.invoke(scalarMethod, scalarValueDef.variable()))
                 )
             );
             return wrapWithPropertyPath(StatementDef.multi(
-                propertyValueDef,
-                INCLUSION_UTIL_TYPE.invokeStatic(
-                    SHOULD_SERIALIZE_SCALAR_METHOD,
-                    context,
-                    propertyValueDef.variable().cast(TypeDef.OBJECT)
-                ).ifTrue(writeScalar)
+                scalarValueDef,
+                shouldSerializeScalar(aThis, propertyType, scalarValueDef.variable()).ifTrue(writeScalar)
             ), type, argumentExpression);
         }
         String serializerFieldName = required(serializerFieldNames, property.name());
         ExpressionDef serializer = aThis.field(serializerFieldName, SERIALIZER_TYPE);
 
-        if (property.serializationType().isPrimitive() && !property.serializationType().isArray()) {
-            ExpressionDef isDefault = primitiveIsDefaultExpression(property.serializationType(), propertyValue);
+        StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(valueLocalName);
+        if (primitive) {
             StatementDef writePrimitive = StatementDef.multi(
                 encodeKey,
                 serializer.invoke(
@@ -459,17 +501,14 @@ public final class BeanSerializerSourceGen {
                     objectEncoder,
                     context,
                     argumentExpression,
-                    propertyValue.cast(TypeDef.OBJECT)
+                    propertyValueDef.variable().cast(TypeDef.OBJECT)
                 )
             );
-            return wrapWithPropertyPath(
-                INCLUSION_UTIL_TYPE.invokeStatic(SHOULD_SERIALIZE_PRIMITIVE_METHOD, context, isDefault)
-                    .ifTrue(writePrimitive),
-                type,
-                argumentExpression
-            );
+            return wrapWithPropertyPath(StatementDef.multi(
+                propertyValueDef,
+                shouldSerializePrimitive(aThis, propertyType, propertyValueDef.variable()).ifTrue(writePrimitive)
+            ), type, argumentExpression);
         }
-        StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(BeanSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
         StatementDef writeValue = StatementDef.multi(
             encodeKey,
             propertyValueDef.variable().isNull().ifTrue(
@@ -487,26 +526,94 @@ public final class BeanSerializerSourceGen {
         );
         return wrapWithPropertyPath(StatementDef.multi(
             propertyValueDef,
-            INCLUSION_UTIL_TYPE.invokeStatic(
-                SHOULD_SERIALIZE_METHOD,
-                context,
-                serializer,
-                propertyValueDef.variable().cast(TypeDef.OBJECT)
-            ).ifTrue(writeValue)
+            shouldSerializeValue(aThis, context, serializer, propertyValueDef.variable()).ifTrue(writeValue)
         ), type, argumentExpression);
     }
 
+    private VariableDef.Field includeField(VariableDef.This aThis) {
+        return aThis.field(INCLUDE_FIELD, SER_INCLUDE_TYPE);
+    }
+
+    /**
+     * Combines an inclusion check with the precomputed "writes everything" flag so a configuration that
+     * never skips a property costs a single field read on the serialization hot path.
+     */
+    private ExpressionDef.ConditionExpressionDef inclusionCheck(VariableDef.This aThis, ExpressionDef check) {
+        return aThis.field(INCLUDE_ALL_FIELD, TypeDef.Primitive.BOOLEAN).isTrue().or(check.isTrue());
+    }
+
+    private ExpressionDef.ConditionExpressionDef shouldSerializePrimitive(VariableDef.This aThis,
+                                                                         ClassElement type,
+                                                                         ExpressionDef propertyValue) {
+        return inclusionCheck(aThis, INCLUSION_UTIL_TYPE.invokeStatic(
+            SHOULD_SERIALIZE_PRIMITIVE_METHOD,
+            includeField(aThis),
+            primitiveIsDefaultExpression(type, propertyValue)
+        ));
+    }
+
+    private ExpressionDef.ConditionExpressionDef shouldSerializeScalar(VariableDef.This aThis,
+                                                                      ClassElement type,
+                                                                      ExpressionDef propertyValue) {
+        return inclusionCheck(aThis, INCLUSION_UTIL_TYPE.invokeStatic(
+            scalarInclusionMethod(type),
+            includeField(aThis),
+            propertyValue
+        ));
+    }
+
+    private ExpressionDef.ConditionExpressionDef shouldSerializeValue(VariableDef.This aThis,
+                                                                     VariableDef.MethodParameter context,
+                                                                     ExpressionDef serializer,
+                                                                     ExpressionDef propertyValue) {
+        return inclusionCheck(aThis, INCLUSION_UTIL_TYPE.invokeStatic(
+            SHOULD_SERIALIZE_METHOD,
+            includeField(aThis),
+            context,
+            serializer,
+            propertyValue.cast(TypeDef.OBJECT)
+        ));
+    }
+
+    /**
+     * The inclusion helper matching the serde that writes the value at runtime. Every scalar type
+     * handled by {@link #scalarEncoderMethod} other than string, boolean and character is a number.
+     */
+    private Method scalarInclusionMethod(ClassElement type) {
+        return switch (type.getName()) {
+            case "java.lang.String" -> SHOULD_SERIALIZE_STRING_METHOD;
+            case "java.lang.Boolean" -> SHOULD_SERIALIZE_BOOLEAN_METHOD;
+            case "java.lang.Character" -> SHOULD_SERIALIZE_CHARACTER_METHOD;
+            default -> SHOULD_SERIALIZE_NUMBER_METHOD;
+        };
+    }
+
+    /**
+     * Whether a primitive value equals the default value the matching serde reports for its type.
+     * Float and double go through {@code compare} so {@code -0.0} and {@code NaN} agree with
+     * {@code FloatSerde}/{@code DoubleSerde}, which compare the boxed value using {@code equals}.
+     */
     private ExpressionDef primitiveIsDefaultExpression(ClassElement type, ExpressionDef propertyValue) {
         return switch (type.getName()) {
             case "boolean" -> propertyValue.isFalse();
-            case "char" -> propertyValue.equalsStructurally(ExpressionDef.constant(0).cast(TypeDef.Primitive.CHAR));
-            case "float" -> propertyValue.equalsStructurally(ExpressionDef.constant(0f));
-            case "double" -> propertyValue.equalsStructurally(ExpressionDef.constant(0d));
-            case "long" -> propertyValue.equalsStructurally(ExpressionDef.constant(0L));
-            case "byte" -> propertyValue.equalsStructurally(ExpressionDef.constant(0).cast(TypeDef.Primitive.BYTE));
-            case "short" -> propertyValue.equalsStructurally(ExpressionDef.constant(0).cast(TypeDef.Primitive.SHORT));
-            default -> propertyValue.equalsStructurally(ExpressionDef.constant(0));
+            case "char" -> isEqual(propertyValue, ExpressionDef.constant(0).cast(TypeDef.Primitive.CHAR));
+            case "float" -> isEqual(
+                ClassTypeDef.of(Float.class).invokeStatic(FLOAT_COMPARE_METHOD, propertyValue, ExpressionDef.constant(0F)),
+                ExpressionDef.constant(0)
+            );
+            case "double" -> isEqual(
+                ClassTypeDef.of(Double.class).invokeStatic(DOUBLE_COMPARE_METHOD, propertyValue, ExpressionDef.constant(0D)),
+                ExpressionDef.constant(0)
+            );
+            case "long" -> isEqual(propertyValue, ExpressionDef.constant(0L));
+            case "byte" -> isEqual(propertyValue, ExpressionDef.constant(0).cast(TypeDef.Primitive.BYTE));
+            case "short" -> isEqual(propertyValue, ExpressionDef.constant(0).cast(TypeDef.Primitive.SHORT));
+            default -> isEqual(propertyValue, ExpressionDef.constant(0));
         };
+    }
+
+    private ExpressionDef isEqual(ExpressionDef left, ExpressionDef right) {
+        return left.compare(ExpressionDef.ComparisonOperation.OpType.EQUAL_TO, right);
     }
 
     private ExpressionDef readPropertyValue(VariableDef.MethodParameter value, BeanSerdeShape.BeanProperty property) {

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanSerializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanSerializerSourceGen.java
@@ -29,12 +29,11 @@ import io.micronaut.serde.Keys;
 import io.micronaut.serde.KeysAwareEncoder;
 import io.micronaut.serde.ObjectSerializer;
 import io.micronaut.serde.Serializer;
-import io.micronaut.serde.config.annotation.SerdeConfig;
 import io.micronaut.serde.exceptions.SerdeException;
+import io.micronaut.serde.processor.sourcegen.SerdeInclusionSourceGen;
 import io.micronaut.serde.processor.sourcegen.SerdeSourceGenClassNaming;
 import io.micronaut.serde.util.GeneratedSerdeExceptionUtil;
 import io.micronaut.serde.util.GeneratedSerdeFallbackUtil;
-import io.micronaut.serde.util.GeneratedSerdeInclusionUtil;
 import io.micronaut.sourcegen.model.AnnotationDef;
 import io.micronaut.sourcegen.model.ClassDef;
 import io.micronaut.sourcegen.model.ClassTypeDef;
@@ -67,8 +66,6 @@ public final class BeanSerializerSourceGen {
     private static final String VALUE_LOCAL_PREFIX = "value";
     private static final String GENERATED_VALUE_MEMBER = "value";
     private static final String KEYS_FIELD = "KEYS";
-    private static final String INCLUDE_FIELD = "include";
-    private static final String INCLUDE_ALL_FIELD = "includeAll";
 
     private static final TypeDef ARGUMENT_TYPE = TypeDef.of(Argument.class);
     private static final TypeDef SERIALIZER_TYPE = TypeDef.of(Serializer.class);
@@ -125,58 +122,6 @@ public final class BeanSerializerSourceGen {
         Argument.class,
         Argument.class
     );
-    private static final Method RESOLVE_INCLUSION_METHOD = ReflectionUtils.getRequiredMethod(
-        GeneratedSerdeInclusionUtil.class,
-        "resolveInclusion",
-        Serializer.EncoderContext.class
-    );
-    private static final Method INCLUDE_ALWAYS_METHOD = ReflectionUtils.getRequiredMethod(
-        GeneratedSerdeInclusionUtil.class,
-        "includeAlways",
-        SerdeConfig.SerInclude.class
-    );
-    private static final Method SHOULD_SERIALIZE_METHOD = ReflectionUtils.getRequiredMethod(
-        GeneratedSerdeInclusionUtil.class,
-        "shouldSerialize",
-        SerdeConfig.SerInclude.class,
-        Serializer.EncoderContext.class,
-        Serializer.class,
-        Object.class
-    );
-    private static final Method SHOULD_SERIALIZE_PRIMITIVE_METHOD = ReflectionUtils.getRequiredMethod(
-        GeneratedSerdeInclusionUtil.class,
-        "shouldSerializePrimitive",
-        SerdeConfig.SerInclude.class,
-        boolean.class
-    );
-    private static final Method SHOULD_SERIALIZE_STRING_METHOD = ReflectionUtils.getRequiredMethod(
-        GeneratedSerdeInclusionUtil.class,
-        "shouldSerializeString",
-        SerdeConfig.SerInclude.class,
-        String.class
-    );
-    private static final Method SHOULD_SERIALIZE_NUMBER_METHOD = ReflectionUtils.getRequiredMethod(
-        GeneratedSerdeInclusionUtil.class,
-        "shouldSerializeNumber",
-        SerdeConfig.SerInclude.class,
-        Number.class
-    );
-    private static final Method SHOULD_SERIALIZE_BOOLEAN_METHOD = ReflectionUtils.getRequiredMethod(
-        GeneratedSerdeInclusionUtil.class,
-        "shouldSerializeBoolean",
-        SerdeConfig.SerInclude.class,
-        Boolean.class
-    );
-    private static final Method SHOULD_SERIALIZE_CHARACTER_METHOD = ReflectionUtils.getRequiredMethod(
-        GeneratedSerdeInclusionUtil.class,
-        "shouldSerializeCharacter",
-        SerdeConfig.SerInclude.class,
-        Character.class
-    );
-    private static final Method FLOAT_COMPARE_METHOD = ReflectionUtils.getRequiredMethod(Float.class, "compare", float.class, float.class);
-    private static final Method DOUBLE_COMPARE_METHOD = ReflectionUtils.getRequiredMethod(Double.class, "compare", double.class, double.class);
-    private static final ClassTypeDef INCLUSION_UTIL_TYPE = ClassTypeDef.of(GeneratedSerdeInclusionUtil.class);
-    private static final TypeDef SER_INCLUDE_TYPE = TypeDef.of(SerdeConfig.SerInclude.class);
 
     private static String required(Map<String, String> names, String key) {
         return Objects.requireNonNull(names.get(key));
@@ -230,12 +175,7 @@ public final class BeanSerializerSourceGen {
         // The active inclusion is resolved once per serializer, never per property and per document
         boolean inclusionAware = !beanSerdeShape.properties().isEmpty();
         if (inclusionAware) {
-            fields.add(FieldDef.builder(INCLUDE_FIELD, SER_INCLUDE_TYPE)
-                .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
-                .build());
-            fields.add(FieldDef.builder(INCLUDE_ALL_FIELD, TypeDef.Primitive.BOOLEAN)
-                .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
-                .build());
+            fields.addAll(SerdeInclusionSourceGen.fields());
         }
         ClassDef.ClassDefBuilder classDefBuilder = ClassDef.builder(SerdeSourceGenClassNaming.generatedSerializerClassName(element))
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
@@ -289,9 +229,7 @@ public final class BeanSerializerSourceGen {
         return constructorBuilder.build((aThis, methodParameters) -> {
             List<StatementDef> statements = new ArrayList<>();
             VariableDef.MethodParameter context = methodParameters.get(0);
-            statements.add(includeField(aThis).put(INCLUSION_UTIL_TYPE.invokeStatic(RESOLVE_INCLUSION_METHOD, context)));
-            statements.add(aThis.field(INCLUDE_ALL_FIELD, TypeDef.Primitive.BOOLEAN)
-                .put(INCLUSION_UTIL_TYPE.invokeStatic(INCLUDE_ALWAYS_METHOD, includeField(aThis))));
+            statements.addAll(SerdeInclusionSourceGen.resolveStatements(aThis, context));
             for (Map.Entry<String, String> serializerFieldEntry : serializerFieldNames.entrySet()) {
                 String propertyName = serializerFieldEntry.getKey();
                 String serializerFieldName = serializerFieldEntry.getValue();
@@ -474,7 +412,7 @@ public final class BeanSerializerSourceGen {
                 );
                 return wrapWithPropertyPath(StatementDef.multi(
                     scalarValueDef,
-                    shouldSerializePrimitive(aThis, propertyType, scalarValueDef.variable()).ifTrue(writePrimitive)
+                    SerdeInclusionSourceGen.shouldSerializePrimitive(aThis, propertyType, scalarValueDef.variable()).ifTrue(writePrimitive)
                 ), type, argumentExpression);
             }
             StatementDef writeScalar = StatementDef.multi(
@@ -486,7 +424,7 @@ public final class BeanSerializerSourceGen {
             );
             return wrapWithPropertyPath(StatementDef.multi(
                 scalarValueDef,
-                shouldSerializeScalar(aThis, propertyType, scalarValueDef.variable()).ifTrue(writeScalar)
+                SerdeInclusionSourceGen.shouldSerializeScalar(aThis, propertyType, scalarValueDef.variable()).ifTrue(writeScalar)
             ), type, argumentExpression);
         }
         String serializerFieldName = required(serializerFieldNames, property.name());
@@ -506,7 +444,7 @@ public final class BeanSerializerSourceGen {
             );
             return wrapWithPropertyPath(StatementDef.multi(
                 propertyValueDef,
-                shouldSerializePrimitive(aThis, propertyType, propertyValueDef.variable()).ifTrue(writePrimitive)
+                SerdeInclusionSourceGen.shouldSerializePrimitive(aThis, propertyType, propertyValueDef.variable()).ifTrue(writePrimitive)
             ), type, argumentExpression);
         }
         StatementDef writeValue = StatementDef.multi(
@@ -526,94 +464,8 @@ public final class BeanSerializerSourceGen {
         );
         return wrapWithPropertyPath(StatementDef.multi(
             propertyValueDef,
-            shouldSerializeValue(aThis, context, serializer, propertyValueDef.variable()).ifTrue(writeValue)
+            SerdeInclusionSourceGen.shouldSerializeValue(aThis, context, serializer, propertyValueDef.variable()).ifTrue(writeValue)
         ), type, argumentExpression);
-    }
-
-    private VariableDef.Field includeField(VariableDef.This aThis) {
-        return aThis.field(INCLUDE_FIELD, SER_INCLUDE_TYPE);
-    }
-
-    /**
-     * Combines an inclusion check with the precomputed "writes everything" flag so a configuration that
-     * never skips a property costs a single field read on the serialization hot path.
-     */
-    private ExpressionDef.ConditionExpressionDef inclusionCheck(VariableDef.This aThis, ExpressionDef check) {
-        return aThis.field(INCLUDE_ALL_FIELD, TypeDef.Primitive.BOOLEAN).isTrue().or(check.isTrue());
-    }
-
-    private ExpressionDef.ConditionExpressionDef shouldSerializePrimitive(VariableDef.This aThis,
-                                                                         ClassElement type,
-                                                                         ExpressionDef propertyValue) {
-        return inclusionCheck(aThis, INCLUSION_UTIL_TYPE.invokeStatic(
-            SHOULD_SERIALIZE_PRIMITIVE_METHOD,
-            includeField(aThis),
-            primitiveIsDefaultExpression(type, propertyValue)
-        ));
-    }
-
-    private ExpressionDef.ConditionExpressionDef shouldSerializeScalar(VariableDef.This aThis,
-                                                                      ClassElement type,
-                                                                      ExpressionDef propertyValue) {
-        return inclusionCheck(aThis, INCLUSION_UTIL_TYPE.invokeStatic(
-            scalarInclusionMethod(type),
-            includeField(aThis),
-            propertyValue
-        ));
-    }
-
-    private ExpressionDef.ConditionExpressionDef shouldSerializeValue(VariableDef.This aThis,
-                                                                     VariableDef.MethodParameter context,
-                                                                     ExpressionDef serializer,
-                                                                     ExpressionDef propertyValue) {
-        return inclusionCheck(aThis, INCLUSION_UTIL_TYPE.invokeStatic(
-            SHOULD_SERIALIZE_METHOD,
-            includeField(aThis),
-            context,
-            serializer,
-            propertyValue.cast(TypeDef.OBJECT)
-        ));
-    }
-
-    /**
-     * The inclusion helper matching the serde that writes the value at runtime. Every scalar type
-     * handled by {@link #scalarEncoderMethod} other than string, boolean and character is a number.
-     */
-    private Method scalarInclusionMethod(ClassElement type) {
-        return switch (type.getName()) {
-            case "java.lang.String" -> SHOULD_SERIALIZE_STRING_METHOD;
-            case "java.lang.Boolean" -> SHOULD_SERIALIZE_BOOLEAN_METHOD;
-            case "java.lang.Character" -> SHOULD_SERIALIZE_CHARACTER_METHOD;
-            default -> SHOULD_SERIALIZE_NUMBER_METHOD;
-        };
-    }
-
-    /**
-     * Whether a primitive value equals the default value the matching serde reports for its type.
-     * Float and double go through {@code compare} so {@code -0.0} and {@code NaN} agree with
-     * {@code FloatSerde}/{@code DoubleSerde}, which compare the boxed value using {@code equals}.
-     */
-    private ExpressionDef primitiveIsDefaultExpression(ClassElement type, ExpressionDef propertyValue) {
-        return switch (type.getName()) {
-            case "boolean" -> propertyValue.isFalse();
-            case "char" -> isEqual(propertyValue, ExpressionDef.constant(0).cast(TypeDef.Primitive.CHAR));
-            case "float" -> isEqual(
-                ClassTypeDef.of(Float.class).invokeStatic(FLOAT_COMPARE_METHOD, propertyValue, ExpressionDef.constant(0F)),
-                ExpressionDef.constant(0)
-            );
-            case "double" -> isEqual(
-                ClassTypeDef.of(Double.class).invokeStatic(DOUBLE_COMPARE_METHOD, propertyValue, ExpressionDef.constant(0D)),
-                ExpressionDef.constant(0)
-            );
-            case "long" -> isEqual(propertyValue, ExpressionDef.constant(0L));
-            case "byte" -> isEqual(propertyValue, ExpressionDef.constant(0).cast(TypeDef.Primitive.BYTE));
-            case "short" -> isEqual(propertyValue, ExpressionDef.constant(0).cast(TypeDef.Primitive.SHORT));
-            default -> isEqual(propertyValue, ExpressionDef.constant(0));
-        };
-    }
-
-    private ExpressionDef isEqual(ExpressionDef left, ExpressionDef right) {
-        return left.compare(ExpressionDef.ComparisonOperation.OpType.EQUAL_TO, right);
     }
 
     private ExpressionDef readPropertyValue(VariableDef.MethodParameter value, BeanSerdeShape.BeanProperty property) {

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanSerializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanSerializerSourceGen.java
@@ -33,6 +33,7 @@ import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.processor.sourcegen.SerdeSourceGenClassNaming;
 import io.micronaut.serde.util.GeneratedSerdeExceptionUtil;
 import io.micronaut.serde.util.GeneratedSerdeFallbackUtil;
+import io.micronaut.serde.util.GeneratedSerdeInclusionUtil;
 import io.micronaut.sourcegen.model.AnnotationDef;
 import io.micronaut.sourcegen.model.ClassDef;
 import io.micronaut.sourcegen.model.ClassTypeDef;
@@ -121,6 +122,26 @@ public final class BeanSerializerSourceGen {
         Argument.class,
         Argument.class
     );
+    private static final Method SHOULD_SERIALIZE_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerialize",
+        Serializer.EncoderContext.class,
+        Serializer.class,
+        Object.class
+    );
+    private static final Method SHOULD_SERIALIZE_SCALAR_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerializeScalar",
+        Serializer.EncoderContext.class,
+        Object.class
+    );
+    private static final Method SHOULD_SERIALIZE_PRIMITIVE_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerializePrimitive",
+        Serializer.EncoderContext.class,
+        boolean.class
+    );
+    private static final ClassTypeDef INCLUSION_UTIL_TYPE = ClassTypeDef.of(GeneratedSerdeInclusionUtil.class);
 
     private static String required(Map<String, String> names, String key) {
         return Objects.requireNonNull(names.get(key));
@@ -352,8 +373,19 @@ public final class BeanSerializerSourceGen {
         List<StatementDef> statements = new ArrayList<>();
         int index = 0;
         for (BeanSerdeShape.BeanProperty property : beanSerdeShape.properties()) {
-            statements.add(encodeKeyStatement(serializerClassTypeDef, keyEncoder, index));
-            statements.add(serializeProperty(aThis, serializerClassTypeDef, valueEncoder, context, type, value, property, index++, argumentFieldNames, serializerFieldNames));
+            statements.add(serializeProperty(
+                aThis,
+                serializerClassTypeDef,
+                valueEncoder,
+                keyEncoder,
+                context,
+                type,
+                value,
+                property,
+                index++,
+                argumentFieldNames,
+                serializerFieldNames
+            ));
         }
         return statements;
     }
@@ -372,6 +404,7 @@ public final class BeanSerializerSourceGen {
     private StatementDef serializeProperty(VariableDef.This aThis,
                                            ClassTypeDef serializerClassTypeDef,
                                            VariableDef objectEncoder,
+                                           VariableDef keyEncoder,
                                            VariableDef.MethodParameter context,
                                            VariableDef.MethodParameter type,
                                            VariableDef.MethodParameter value,
@@ -382,38 +415,63 @@ public final class BeanSerializerSourceGen {
         ExpressionDef argumentExpression = serializerClassTypeDef.getStaticField(required(argumentFieldNames, property.name()), ARGUMENT_TYPE);
         Method scalarMethod = scalarEncoderMethod(property.serializationType());
         ExpressionDef propertyValue = readPropertyValue(value, property);
+        StatementDef encodeKey = encodeKeyStatement(serializerClassTypeDef, keyEncoder, index);
         if (scalarMethod != null) {
-            StatementDef scalarStatement;
             if (property.serializationType().isPrimitive() && !property.serializationType().isArray()) {
-                scalarStatement = objectEncoder.invoke(scalarMethod, propertyValue);
-            } else {
-                StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(BeanSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
-                scalarStatement = StatementDef.multi(
-                    propertyValueDef,
-                    propertyValueDef.variable().isNull().ifTrue(
-                        objectEncoder.invoke(ENCODE_NULL_METHOD),
-                        StatementDef.multi(objectEncoder.invoke(scalarMethod, propertyValueDef.variable()))
-                    )
+                ExpressionDef isDefault = primitiveIsDefaultExpression(property.serializationType(), propertyValue);
+                StatementDef writePrimitive = StatementDef.multi(
+                    encodeKey,
+                    objectEncoder.invoke(scalarMethod, propertyValue)
+                );
+                return wrapWithPropertyPath(
+                    INCLUSION_UTIL_TYPE.invokeStatic(SHOULD_SERIALIZE_PRIMITIVE_METHOD, context, isDefault)
+                        .ifTrue(writePrimitive),
+                    type,
+                    argumentExpression
                 );
             }
-            return wrapWithPropertyPath(scalarStatement, type, argumentExpression);
+            StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(BeanSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
+            StatementDef writeScalar = StatementDef.multi(
+                encodeKey,
+                propertyValueDef.variable().isNull().ifTrue(
+                    objectEncoder.invoke(ENCODE_NULL_METHOD),
+                    StatementDef.multi(objectEncoder.invoke(scalarMethod, propertyValueDef.variable()))
+                )
+            );
+            return wrapWithPropertyPath(StatementDef.multi(
+                propertyValueDef,
+                INCLUSION_UTIL_TYPE.invokeStatic(
+                    SHOULD_SERIALIZE_SCALAR_METHOD,
+                    context,
+                    propertyValueDef.variable().cast(TypeDef.OBJECT)
+                ).ifTrue(writeScalar)
+            ), type, argumentExpression);
         }
         String serializerFieldName = required(serializerFieldNames, property.name());
         ExpressionDef serializer = aThis.field(serializerFieldName, SERIALIZER_TYPE);
 
-        StatementDef serializeStatement = serializer.invoke(
-            SERIALIZE_METHOD,
-            objectEncoder,
-            context,
-            argumentExpression,
-            propertyValue.cast(TypeDef.OBJECT)
-        );
         if (property.serializationType().isPrimitive() && !property.serializationType().isArray()) {
-            return wrapWithPropertyPath(serializeStatement, type, argumentExpression);
+            ExpressionDef isDefault = primitiveIsDefaultExpression(property.serializationType(), propertyValue);
+            StatementDef writePrimitive = StatementDef.multi(
+                encodeKey,
+                serializer.invoke(
+                    SERIALIZE_METHOD,
+                    objectEncoder,
+                    context,
+                    argumentExpression,
+                    propertyValue.cast(TypeDef.OBJECT)
+                )
+            );
+            return wrapWithPropertyPath(
+                INCLUSION_UTIL_TYPE.invokeStatic(SHOULD_SERIALIZE_PRIMITIVE_METHOD, context, isDefault)
+                    .ifTrue(writePrimitive),
+                type,
+                argumentExpression
+            );
         }
         StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(BeanSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
-        return wrapWithPropertyPath(StatementDef.multi(
-            propertyValueDef,
+        StatementDef writeValue = StatementDef.multi(
+            encodeKey,
             propertyValueDef.variable().isNull().ifTrue(
                 objectEncoder.invoke(ENCODE_NULL_METHOD),
                 StatementDef.multi(
@@ -426,7 +484,29 @@ public final class BeanSerializerSourceGen {
                     )
                 )
             )
+        );
+        return wrapWithPropertyPath(StatementDef.multi(
+            propertyValueDef,
+            INCLUSION_UTIL_TYPE.invokeStatic(
+                SHOULD_SERIALIZE_METHOD,
+                context,
+                serializer,
+                propertyValueDef.variable().cast(TypeDef.OBJECT)
+            ).ifTrue(writeValue)
         ), type, argumentExpression);
+    }
+
+    private ExpressionDef primitiveIsDefaultExpression(ClassElement type, ExpressionDef propertyValue) {
+        return switch (type.getName()) {
+            case "boolean" -> propertyValue.isFalse();
+            case "char" -> propertyValue.equalsStructurally(ExpressionDef.constant(0).cast(TypeDef.Primitive.CHAR));
+            case "float" -> propertyValue.equalsStructurally(ExpressionDef.constant(0f));
+            case "double" -> propertyValue.equalsStructurally(ExpressionDef.constant(0d));
+            case "long" -> propertyValue.equalsStructurally(ExpressionDef.constant(0L));
+            case "byte" -> propertyValue.equalsStructurally(ExpressionDef.constant(0).cast(TypeDef.Primitive.BYTE));
+            case "short" -> propertyValue.equalsStructurally(ExpressionDef.constant(0).cast(TypeDef.Primitive.SHORT));
+            default -> propertyValue.equalsStructurally(ExpressionDef.constant(0));
+        };
     }
 
     private ExpressionDef readPropertyValue(VariableDef.MethodParameter value, BeanSerdeShape.BeanProperty property) {

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerializerSourceGen.java
@@ -64,6 +64,8 @@ public final class RecordSerializerSourceGen {
     private static final String VALUE_LOCAL_PREFIX = "value";
     private static final String GENERATED_VALUE_MEMBER = "value";
     private static final String KEYS_FIELD = "KEYS";
+    private static final String INCLUDE_FIELD = "include";
+    private static final String INCLUDE_ALL_FIELD = "includeAll";
 
     private static final TypeDef ARGUMENT_TYPE = TypeDef.of(Argument.class);
     private static final TypeDef SERIALIZER_TYPE = TypeDef.of(Serializer.class);
@@ -120,26 +122,58 @@ public final class RecordSerializerSourceGen {
         Argument.class,
         Argument.class
     );
+    private static final Method RESOLVE_INCLUSION_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "resolveInclusion",
+        Serializer.EncoderContext.class
+    );
+    private static final Method INCLUDE_ALWAYS_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "includeAlways",
+        SerdeConfig.SerInclude.class
+    );
     private static final Method SHOULD_SERIALIZE_METHOD = ReflectionUtils.getRequiredMethod(
         GeneratedSerdeInclusionUtil.class,
         "shouldSerialize",
+        SerdeConfig.SerInclude.class,
         Serializer.EncoderContext.class,
         Serializer.class,
-        Object.class
-    );
-    private static final Method SHOULD_SERIALIZE_SCALAR_METHOD = ReflectionUtils.getRequiredMethod(
-        GeneratedSerdeInclusionUtil.class,
-        "shouldSerializeScalar",
-        Serializer.EncoderContext.class,
         Object.class
     );
     private static final Method SHOULD_SERIALIZE_PRIMITIVE_METHOD = ReflectionUtils.getRequiredMethod(
         GeneratedSerdeInclusionUtil.class,
         "shouldSerializePrimitive",
-        Serializer.EncoderContext.class,
+        SerdeConfig.SerInclude.class,
         boolean.class
     );
+    private static final Method SHOULD_SERIALIZE_STRING_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerializeString",
+        SerdeConfig.SerInclude.class,
+        String.class
+    );
+    private static final Method SHOULD_SERIALIZE_NUMBER_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerializeNumber",
+        SerdeConfig.SerInclude.class,
+        Number.class
+    );
+    private static final Method SHOULD_SERIALIZE_BOOLEAN_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerializeBoolean",
+        SerdeConfig.SerInclude.class,
+        Boolean.class
+    );
+    private static final Method SHOULD_SERIALIZE_CHARACTER_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerializeCharacter",
+        SerdeConfig.SerInclude.class,
+        Character.class
+    );
+    private static final Method FLOAT_COMPARE_METHOD = ReflectionUtils.getRequiredMethod(Float.class, "compare", float.class, float.class);
+    private static final Method DOUBLE_COMPARE_METHOD = ReflectionUtils.getRequiredMethod(Double.class, "compare", double.class, double.class);
     private static final ClassTypeDef INCLUSION_UTIL_TYPE = ClassTypeDef.of(GeneratedSerdeInclusionUtil.class);
+    private static final TypeDef SER_INCLUDE_TYPE = TypeDef.of(SerdeConfig.SerInclude.class);
 
     public ClassDef generate(ClassElement element, RecordSerdeShape recordSerdeShape) {
         recordSerdeShape = new RecordSerdeShape(
@@ -188,6 +222,16 @@ public final class RecordSerializerSourceGen {
                 .initializer(keysCreateExpression(serializerClassTypeDef, recordSerdeShape.components(), new ArrayList<>(keyFieldNames.values())))
                 .build());
         }
+        // The active inclusion is resolved once per serializer, never per component and per document
+        boolean inclusionAware = !recordSerdeShape.components().isEmpty();
+        if (inclusionAware) {
+            fields.add(FieldDef.builder(INCLUDE_FIELD, SER_INCLUDE_TYPE)
+                .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+                .build());
+            fields.add(FieldDef.builder(INCLUDE_ALL_FIELD, TypeDef.Primitive.BOOLEAN)
+                .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
+                .build());
+        }
         ClassDef.ClassDefBuilder classDefBuilder = ClassDef.builder(SerdeSourceGenClassNaming.generatedSerializerClassName(element))
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
             .addAnnotation(Prototype.class)
@@ -200,7 +244,7 @@ public final class RecordSerializerSourceGen {
             .addMethod(generateCreateSpecificMethod(recordTypeDef))
             .addMethod(generateSerializeMethod(recordTypeDef))
             .addMethod(generateSerializeIntoMethod(recordTypeDef, serializerClassTypeDef, recordSerdeShape, argumentFieldNames, serializerFieldNames));
-        if (!serializerFieldNames.isEmpty()) {
+        if (inclusionAware) {
             classDefBuilder.addMethod(generateConstructor(
                 element,
                 recordTypeDef,
@@ -225,12 +269,12 @@ public final class RecordSerializerSourceGen {
             .addParameter(parameter(CONTEXT_PARAMETER, TypeDef.of(Serializer.EncoderContext.class)))
             .addParameter(parameter("type", TypeDef.parameterized(Argument.class, TypeDef.wildcardSubtypeOf(recordTypeDef))))
             .addThrows(TypeDef.of(SerdeException.class));
-        if (serializerFieldNames.isEmpty()) {
-            return constructorBuilder.build();
-        }
         return constructorBuilder.build((aThis, methodParameters) -> {
             List<StatementDef> statements = new ArrayList<>();
             VariableDef.MethodParameter context = methodParameters.get(0);
+            statements.add(includeField(aThis).put(INCLUSION_UTIL_TYPE.invokeStatic(RESOLVE_INCLUSION_METHOD, context)));
+            statements.add(aThis.field(INCLUDE_ALL_FIELD, TypeDef.Primitive.BOOLEAN)
+                .put(INCLUSION_UTIL_TYPE.invokeStatic(INCLUDE_ALWAYS_METHOD, includeField(aThis))));
             for (Map.Entry<String, String> serializerFieldEntry : serializerFieldNames.entrySet()) {
                 String componentName = serializerFieldEntry.getKey();
                 String serializerFieldName = serializerFieldEntry.getValue();
@@ -399,45 +443,42 @@ public final class RecordSerializerSourceGen {
                                             Map<String, String> argumentFieldNames,
                                             Map<String, String> serializerFieldNames) {
         ExpressionDef argumentExpression = serializerClassTypeDef.getStaticField(required(argumentFieldNames, component.name()), ARGUMENT_TYPE);
-        Method scalarMethod = scalarEncoderMethod(component.type());
+        ClassElement componentType = component.type();
+        Method scalarMethod = scalarEncoderMethod(componentType);
         ExpressionDef propertyValue = value.getPropertyValue(component.propertyElement());
         StatementDef encodeKey = encodeKeyStatement(serializerClassTypeDef, keyEncoder, index);
+        String valueLocalName = RecordSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index);
+        boolean primitive = componentType.isPrimitive() && !componentType.isArray();
         if (scalarMethod != null) {
-            if (component.type().isPrimitive() && !component.type().isArray()) {
-                ExpressionDef isDefault = primitiveIsDefaultExpression(component.type(), propertyValue);
+            // A local keeps the property read to a single access: the inclusion check must not repeat a getter
+            StatementDef.DefineAndAssign scalarValueDef = propertyValue.newLocal(valueLocalName);
+            if (primitive) {
                 StatementDef writePrimitive = StatementDef.multi(
                     encodeKey,
-                    objectEncoder.invoke(scalarMethod, propertyValue)
+                    objectEncoder.invoke(scalarMethod, scalarValueDef.variable())
                 );
-                return wrapWithPropertyPath(
-                    INCLUSION_UTIL_TYPE.invokeStatic(SHOULD_SERIALIZE_PRIMITIVE_METHOD, context, isDefault)
-                        .ifTrue(writePrimitive),
-                    type,
-                    argumentExpression
-                );
+                return wrapWithPropertyPath(StatementDef.multi(
+                    scalarValueDef,
+                    shouldSerializePrimitive(aThis, componentType, scalarValueDef.variable()).ifTrue(writePrimitive)
+                ), type, argumentExpression);
             }
-            StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(RecordSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
             StatementDef writeScalar = StatementDef.multi(
                 encodeKey,
-                propertyValueDef.variable().isNull().ifTrue(
+                scalarValueDef.variable().isNull().ifTrue(
                     objectEncoder.invoke(ENCODE_NULL_METHOD),
-                    StatementDef.multi(objectEncoder.invoke(scalarMethod, propertyValueDef.variable()))
+                    StatementDef.multi(objectEncoder.invoke(scalarMethod, scalarValueDef.variable()))
                 )
             );
             return wrapWithPropertyPath(StatementDef.multi(
-                propertyValueDef,
-                INCLUSION_UTIL_TYPE.invokeStatic(
-                    SHOULD_SERIALIZE_SCALAR_METHOD,
-                    context,
-                    propertyValueDef.variable().cast(TypeDef.OBJECT)
-                ).ifTrue(writeScalar)
+                scalarValueDef,
+                shouldSerializeScalar(aThis, componentType, scalarValueDef.variable()).ifTrue(writeScalar)
             ), type, argumentExpression);
         }
         String serializerFieldName = required(serializerFieldNames, component.name());
         ExpressionDef serializer = aThis.field(serializerFieldName, SERIALIZER_TYPE);
 
-        if (component.type().isPrimitive() && !component.type().isArray()) {
-            ExpressionDef isDefault = primitiveIsDefaultExpression(component.type(), propertyValue);
+        StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(valueLocalName);
+        if (primitive) {
             StatementDef writePrimitive = StatementDef.multi(
                 encodeKey,
                 serializer.invoke(
@@ -445,17 +486,14 @@ public final class RecordSerializerSourceGen {
                     objectEncoder,
                     context,
                     argumentExpression,
-                    propertyValue.cast(TypeDef.OBJECT)
+                    propertyValueDef.variable().cast(TypeDef.OBJECT)
                 )
             );
-            return wrapWithPropertyPath(
-                INCLUSION_UTIL_TYPE.invokeStatic(SHOULD_SERIALIZE_PRIMITIVE_METHOD, context, isDefault)
-                    .ifTrue(writePrimitive),
-                type,
-                argumentExpression
-            );
+            return wrapWithPropertyPath(StatementDef.multi(
+                propertyValueDef,
+                shouldSerializePrimitive(aThis, componentType, propertyValueDef.variable()).ifTrue(writePrimitive)
+            ), type, argumentExpression);
         }
-        StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(RecordSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
         StatementDef writeValue = StatementDef.multi(
             encodeKey,
             propertyValueDef.variable().isNull().ifTrue(
@@ -473,26 +511,94 @@ public final class RecordSerializerSourceGen {
         );
         return wrapWithPropertyPath(StatementDef.multi(
             propertyValueDef,
-            INCLUSION_UTIL_TYPE.invokeStatic(
-                SHOULD_SERIALIZE_METHOD,
-                context,
-                serializer,
-                propertyValueDef.variable().cast(TypeDef.OBJECT)
-            ).ifTrue(writeValue)
+            shouldSerializeValue(aThis, context, serializer, propertyValueDef.variable()).ifTrue(writeValue)
         ), type, argumentExpression);
     }
 
+    private VariableDef.Field includeField(VariableDef.This aThis) {
+        return aThis.field(INCLUDE_FIELD, SER_INCLUDE_TYPE);
+    }
+
+    /**
+     * Combines an inclusion check with the precomputed "writes everything" flag so a configuration that
+     * never skips a property costs a single field read on the serialization hot path.
+     */
+    private ExpressionDef.ConditionExpressionDef inclusionCheck(VariableDef.This aThis, ExpressionDef check) {
+        return aThis.field(INCLUDE_ALL_FIELD, TypeDef.Primitive.BOOLEAN).isTrue().or(check.isTrue());
+    }
+
+    private ExpressionDef.ConditionExpressionDef shouldSerializePrimitive(VariableDef.This aThis,
+                                                                         ClassElement type,
+                                                                         ExpressionDef propertyValue) {
+        return inclusionCheck(aThis, INCLUSION_UTIL_TYPE.invokeStatic(
+            SHOULD_SERIALIZE_PRIMITIVE_METHOD,
+            includeField(aThis),
+            primitiveIsDefaultExpression(type, propertyValue)
+        ));
+    }
+
+    private ExpressionDef.ConditionExpressionDef shouldSerializeScalar(VariableDef.This aThis,
+                                                                      ClassElement type,
+                                                                      ExpressionDef propertyValue) {
+        return inclusionCheck(aThis, INCLUSION_UTIL_TYPE.invokeStatic(
+            scalarInclusionMethod(type),
+            includeField(aThis),
+            propertyValue
+        ));
+    }
+
+    private ExpressionDef.ConditionExpressionDef shouldSerializeValue(VariableDef.This aThis,
+                                                                     VariableDef.MethodParameter context,
+                                                                     ExpressionDef serializer,
+                                                                     ExpressionDef propertyValue) {
+        return inclusionCheck(aThis, INCLUSION_UTIL_TYPE.invokeStatic(
+            SHOULD_SERIALIZE_METHOD,
+            includeField(aThis),
+            context,
+            serializer,
+            propertyValue.cast(TypeDef.OBJECT)
+        ));
+    }
+
+    /**
+     * The inclusion helper matching the serde that writes the value at runtime. Every scalar type
+     * handled by {@link #scalarEncoderMethod} other than string, boolean and character is a number.
+     */
+    private Method scalarInclusionMethod(ClassElement type) {
+        return switch (type.getName()) {
+            case "java.lang.String" -> SHOULD_SERIALIZE_STRING_METHOD;
+            case "java.lang.Boolean" -> SHOULD_SERIALIZE_BOOLEAN_METHOD;
+            case "java.lang.Character" -> SHOULD_SERIALIZE_CHARACTER_METHOD;
+            default -> SHOULD_SERIALIZE_NUMBER_METHOD;
+        };
+    }
+
+    /**
+     * Whether a primitive value equals the default value the matching serde reports for its type.
+     * Float and double go through {@code compare} so {@code -0.0} and {@code NaN} agree with
+     * {@code FloatSerde}/{@code DoubleSerde}, which compare the boxed value using {@code equals}.
+     */
     private ExpressionDef primitiveIsDefaultExpression(ClassElement type, ExpressionDef propertyValue) {
         return switch (type.getName()) {
             case "boolean" -> propertyValue.isFalse();
-            case "char" -> propertyValue.equalsStructurally(ExpressionDef.constant(0).cast(TypeDef.Primitive.CHAR));
-            case "float" -> propertyValue.equalsStructurally(ExpressionDef.constant(0f));
-            case "double" -> propertyValue.equalsStructurally(ExpressionDef.constant(0d));
-            case "long" -> propertyValue.equalsStructurally(ExpressionDef.constant(0L));
-            case "byte" -> propertyValue.equalsStructurally(ExpressionDef.constant(0).cast(TypeDef.Primitive.BYTE));
-            case "short" -> propertyValue.equalsStructurally(ExpressionDef.constant(0).cast(TypeDef.Primitive.SHORT));
-            default -> propertyValue.equalsStructurally(ExpressionDef.constant(0));
+            case "char" -> isEqual(propertyValue, ExpressionDef.constant(0).cast(TypeDef.Primitive.CHAR));
+            case "float" -> isEqual(
+                ClassTypeDef.of(Float.class).invokeStatic(FLOAT_COMPARE_METHOD, propertyValue, ExpressionDef.constant(0F)),
+                ExpressionDef.constant(0)
+            );
+            case "double" -> isEqual(
+                ClassTypeDef.of(Double.class).invokeStatic(DOUBLE_COMPARE_METHOD, propertyValue, ExpressionDef.constant(0D)),
+                ExpressionDef.constant(0)
+            );
+            case "long" -> isEqual(propertyValue, ExpressionDef.constant(0L));
+            case "byte" -> isEqual(propertyValue, ExpressionDef.constant(0).cast(TypeDef.Primitive.BYTE));
+            case "short" -> isEqual(propertyValue, ExpressionDef.constant(0).cast(TypeDef.Primitive.SHORT));
+            default -> isEqual(propertyValue, ExpressionDef.constant(0));
         };
+    }
+
+    private ExpressionDef isEqual(ExpressionDef left, ExpressionDef right) {
+        return left.compare(ExpressionDef.ComparisonOperation.OpType.EQUAL_TO, right);
     }
 
     private String indexedName(String prefix, int index) {

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerializerSourceGen.java
@@ -31,6 +31,7 @@ import io.micronaut.serde.exceptions.SerdeException;
 import io.micronaut.serde.processor.sourcegen.SerdeSourceGenClassNaming;
 import io.micronaut.serde.util.GeneratedSerdeExceptionUtil;
 import io.micronaut.serde.util.GeneratedSerdeFallbackUtil;
+import io.micronaut.serde.util.GeneratedSerdeInclusionUtil;
 import io.micronaut.sourcegen.model.AnnotationDef;
 import io.micronaut.sourcegen.model.ClassDef;
 import io.micronaut.sourcegen.model.ClassTypeDef;
@@ -119,6 +120,26 @@ public final class RecordSerializerSourceGen {
         Argument.class,
         Argument.class
     );
+    private static final Method SHOULD_SERIALIZE_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerialize",
+        Serializer.EncoderContext.class,
+        Serializer.class,
+        Object.class
+    );
+    private static final Method SHOULD_SERIALIZE_SCALAR_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerializeScalar",
+        Serializer.EncoderContext.class,
+        Object.class
+    );
+    private static final Method SHOULD_SERIALIZE_PRIMITIVE_METHOD = ReflectionUtils.getRequiredMethod(
+        GeneratedSerdeInclusionUtil.class,
+        "shouldSerializePrimitive",
+        Serializer.EncoderContext.class,
+        boolean.class
+    );
+    private static final ClassTypeDef INCLUSION_UTIL_TYPE = ClassTypeDef.of(GeneratedSerdeInclusionUtil.class);
 
     public ClassDef generate(ClassElement element, RecordSerdeShape recordSerdeShape) {
         recordSerdeShape = new RecordSerdeShape(
@@ -338,8 +359,19 @@ public final class RecordSerializerSourceGen {
         List<StatementDef> statements = new ArrayList<>();
         int index = 0;
         for (RecordSerdeShape.RecordComponent component : recordSerdeShape.components()) {
-            statements.add(encodeKeyStatement(serializerClassTypeDef, keyEncoder, index));
-            statements.add(serializeComponent(aThis, serializerClassTypeDef, valueEncoder, context, type, value, component, index++, argumentFieldNames, serializerFieldNames));
+            statements.add(serializeComponent(
+                aThis,
+                serializerClassTypeDef,
+                valueEncoder,
+                keyEncoder,
+                context,
+                type,
+                value,
+                component,
+                index++,
+                argumentFieldNames,
+                serializerFieldNames
+            ));
         }
         return statements;
     }
@@ -358,6 +390,7 @@ public final class RecordSerializerSourceGen {
     private StatementDef serializeComponent(VariableDef.This aThis,
                                             ClassTypeDef serializerClassTypeDef,
                                             VariableDef objectEncoder,
+                                            VariableDef keyEncoder,
                                             VariableDef.MethodParameter context,
                                             VariableDef.MethodParameter type,
                                             VariableDef.MethodParameter value,
@@ -368,38 +401,63 @@ public final class RecordSerializerSourceGen {
         ExpressionDef argumentExpression = serializerClassTypeDef.getStaticField(required(argumentFieldNames, component.name()), ARGUMENT_TYPE);
         Method scalarMethod = scalarEncoderMethod(component.type());
         ExpressionDef propertyValue = value.getPropertyValue(component.propertyElement());
+        StatementDef encodeKey = encodeKeyStatement(serializerClassTypeDef, keyEncoder, index);
         if (scalarMethod != null) {
-            StatementDef scalarStatement;
             if (component.type().isPrimitive() && !component.type().isArray()) {
-                scalarStatement = objectEncoder.invoke(scalarMethod, propertyValue);
-            } else {
-                StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(RecordSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
-                scalarStatement = StatementDef.multi(
-                    propertyValueDef,
-                    propertyValueDef.variable().isNull().ifTrue(
-                        objectEncoder.invoke(ENCODE_NULL_METHOD),
-                        StatementDef.multi(objectEncoder.invoke(scalarMethod, propertyValueDef.variable()))
-                    )
+                ExpressionDef isDefault = primitiveIsDefaultExpression(component.type(), propertyValue);
+                StatementDef writePrimitive = StatementDef.multi(
+                    encodeKey,
+                    objectEncoder.invoke(scalarMethod, propertyValue)
+                );
+                return wrapWithPropertyPath(
+                    INCLUSION_UTIL_TYPE.invokeStatic(SHOULD_SERIALIZE_PRIMITIVE_METHOD, context, isDefault)
+                        .ifTrue(writePrimitive),
+                    type,
+                    argumentExpression
                 );
             }
-            return wrapWithPropertyPath(scalarStatement, type, argumentExpression);
+            StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(RecordSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
+            StatementDef writeScalar = StatementDef.multi(
+                encodeKey,
+                propertyValueDef.variable().isNull().ifTrue(
+                    objectEncoder.invoke(ENCODE_NULL_METHOD),
+                    StatementDef.multi(objectEncoder.invoke(scalarMethod, propertyValueDef.variable()))
+                )
+            );
+            return wrapWithPropertyPath(StatementDef.multi(
+                propertyValueDef,
+                INCLUSION_UTIL_TYPE.invokeStatic(
+                    SHOULD_SERIALIZE_SCALAR_METHOD,
+                    context,
+                    propertyValueDef.variable().cast(TypeDef.OBJECT)
+                ).ifTrue(writeScalar)
+            ), type, argumentExpression);
         }
         String serializerFieldName = required(serializerFieldNames, component.name());
         ExpressionDef serializer = aThis.field(serializerFieldName, SERIALIZER_TYPE);
 
-        StatementDef serializeStatement = serializer.invoke(
-            SERIALIZE_METHOD,
-            objectEncoder,
-            context,
-            argumentExpression,
-            propertyValue.cast(TypeDef.OBJECT)
-        );
         if (component.type().isPrimitive() && !component.type().isArray()) {
-            return wrapWithPropertyPath(serializeStatement, type, argumentExpression);
+            ExpressionDef isDefault = primitiveIsDefaultExpression(component.type(), propertyValue);
+            StatementDef writePrimitive = StatementDef.multi(
+                encodeKey,
+                serializer.invoke(
+                    SERIALIZE_METHOD,
+                    objectEncoder,
+                    context,
+                    argumentExpression,
+                    propertyValue.cast(TypeDef.OBJECT)
+                )
+            );
+            return wrapWithPropertyPath(
+                INCLUSION_UTIL_TYPE.invokeStatic(SHOULD_SERIALIZE_PRIMITIVE_METHOD, context, isDefault)
+                    .ifTrue(writePrimitive),
+                type,
+                argumentExpression
+            );
         }
         StatementDef.DefineAndAssign propertyValueDef = propertyValue.newLocal(RecordSerdeSourceGenUtils.localName(VALUE_LOCAL_PREFIX, index));
-        return wrapWithPropertyPath(StatementDef.multi(
-            propertyValueDef,
+        StatementDef writeValue = StatementDef.multi(
+            encodeKey,
             propertyValueDef.variable().isNull().ifTrue(
                 objectEncoder.invoke(ENCODE_NULL_METHOD),
                 StatementDef.multi(
@@ -412,7 +470,29 @@ public final class RecordSerializerSourceGen {
                     )
                 )
             )
+        );
+        return wrapWithPropertyPath(StatementDef.multi(
+            propertyValueDef,
+            INCLUSION_UTIL_TYPE.invokeStatic(
+                SHOULD_SERIALIZE_METHOD,
+                context,
+                serializer,
+                propertyValueDef.variable().cast(TypeDef.OBJECT)
+            ).ifTrue(writeValue)
         ), type, argumentExpression);
+    }
+
+    private ExpressionDef primitiveIsDefaultExpression(ClassElement type, ExpressionDef propertyValue) {
+        return switch (type.getName()) {
+            case "boolean" -> propertyValue.isFalse();
+            case "char" -> propertyValue.equalsStructurally(ExpressionDef.constant(0).cast(TypeDef.Primitive.CHAR));
+            case "float" -> propertyValue.equalsStructurally(ExpressionDef.constant(0f));
+            case "double" -> propertyValue.equalsStructurally(ExpressionDef.constant(0d));
+            case "long" -> propertyValue.equalsStructurally(ExpressionDef.constant(0L));
+            case "byte" -> propertyValue.equalsStructurally(ExpressionDef.constant(0).cast(TypeDef.Primitive.BYTE));
+            case "short" -> propertyValue.equalsStructurally(ExpressionDef.constant(0).cast(TypeDef.Primitive.SHORT));
+            default -> propertyValue.equalsStructurally(ExpressionDef.constant(0));
+        };
     }
 
     private String indexedName(String prefix, int index) {

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerializerSourceGen.java
@@ -28,10 +28,10 @@ import io.micronaut.serde.ObjectSerializer;
 import io.micronaut.serde.Serializer;
 import io.micronaut.serde.config.annotation.SerdeConfig;
 import io.micronaut.serde.exceptions.SerdeException;
+import io.micronaut.serde.processor.sourcegen.SerdeInclusionSourceGen;
 import io.micronaut.serde.processor.sourcegen.SerdeSourceGenClassNaming;
 import io.micronaut.serde.util.GeneratedSerdeExceptionUtil;
 import io.micronaut.serde.util.GeneratedSerdeFallbackUtil;
-import io.micronaut.serde.util.GeneratedSerdeInclusionUtil;
 import io.micronaut.sourcegen.model.AnnotationDef;
 import io.micronaut.sourcegen.model.ClassDef;
 import io.micronaut.sourcegen.model.ClassTypeDef;
@@ -64,8 +64,6 @@ public final class RecordSerializerSourceGen {
     private static final String VALUE_LOCAL_PREFIX = "value";
     private static final String GENERATED_VALUE_MEMBER = "value";
     private static final String KEYS_FIELD = "KEYS";
-    private static final String INCLUDE_FIELD = "include";
-    private static final String INCLUDE_ALL_FIELD = "includeAll";
 
     private static final TypeDef ARGUMENT_TYPE = TypeDef.of(Argument.class);
     private static final TypeDef SERIALIZER_TYPE = TypeDef.of(Serializer.class);
@@ -122,58 +120,6 @@ public final class RecordSerializerSourceGen {
         Argument.class,
         Argument.class
     );
-    private static final Method RESOLVE_INCLUSION_METHOD = ReflectionUtils.getRequiredMethod(
-        GeneratedSerdeInclusionUtil.class,
-        "resolveInclusion",
-        Serializer.EncoderContext.class
-    );
-    private static final Method INCLUDE_ALWAYS_METHOD = ReflectionUtils.getRequiredMethod(
-        GeneratedSerdeInclusionUtil.class,
-        "includeAlways",
-        SerdeConfig.SerInclude.class
-    );
-    private static final Method SHOULD_SERIALIZE_METHOD = ReflectionUtils.getRequiredMethod(
-        GeneratedSerdeInclusionUtil.class,
-        "shouldSerialize",
-        SerdeConfig.SerInclude.class,
-        Serializer.EncoderContext.class,
-        Serializer.class,
-        Object.class
-    );
-    private static final Method SHOULD_SERIALIZE_PRIMITIVE_METHOD = ReflectionUtils.getRequiredMethod(
-        GeneratedSerdeInclusionUtil.class,
-        "shouldSerializePrimitive",
-        SerdeConfig.SerInclude.class,
-        boolean.class
-    );
-    private static final Method SHOULD_SERIALIZE_STRING_METHOD = ReflectionUtils.getRequiredMethod(
-        GeneratedSerdeInclusionUtil.class,
-        "shouldSerializeString",
-        SerdeConfig.SerInclude.class,
-        String.class
-    );
-    private static final Method SHOULD_SERIALIZE_NUMBER_METHOD = ReflectionUtils.getRequiredMethod(
-        GeneratedSerdeInclusionUtil.class,
-        "shouldSerializeNumber",
-        SerdeConfig.SerInclude.class,
-        Number.class
-    );
-    private static final Method SHOULD_SERIALIZE_BOOLEAN_METHOD = ReflectionUtils.getRequiredMethod(
-        GeneratedSerdeInclusionUtil.class,
-        "shouldSerializeBoolean",
-        SerdeConfig.SerInclude.class,
-        Boolean.class
-    );
-    private static final Method SHOULD_SERIALIZE_CHARACTER_METHOD = ReflectionUtils.getRequiredMethod(
-        GeneratedSerdeInclusionUtil.class,
-        "shouldSerializeCharacter",
-        SerdeConfig.SerInclude.class,
-        Character.class
-    );
-    private static final Method FLOAT_COMPARE_METHOD = ReflectionUtils.getRequiredMethod(Float.class, "compare", float.class, float.class);
-    private static final Method DOUBLE_COMPARE_METHOD = ReflectionUtils.getRequiredMethod(Double.class, "compare", double.class, double.class);
-    private static final ClassTypeDef INCLUSION_UTIL_TYPE = ClassTypeDef.of(GeneratedSerdeInclusionUtil.class);
-    private static final TypeDef SER_INCLUDE_TYPE = TypeDef.of(SerdeConfig.SerInclude.class);
 
     public ClassDef generate(ClassElement element, RecordSerdeShape recordSerdeShape) {
         recordSerdeShape = new RecordSerdeShape(
@@ -225,12 +171,7 @@ public final class RecordSerializerSourceGen {
         // The active inclusion is resolved once per serializer, never per component and per document
         boolean inclusionAware = !recordSerdeShape.components().isEmpty();
         if (inclusionAware) {
-            fields.add(FieldDef.builder(INCLUDE_FIELD, SER_INCLUDE_TYPE)
-                .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
-                .build());
-            fields.add(FieldDef.builder(INCLUDE_ALL_FIELD, TypeDef.Primitive.BOOLEAN)
-                .addModifiers(Modifier.PRIVATE, Modifier.FINAL)
-                .build());
+            fields.addAll(SerdeInclusionSourceGen.fields());
         }
         ClassDef.ClassDefBuilder classDefBuilder = ClassDef.builder(SerdeSourceGenClassNaming.generatedSerializerClassName(element))
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
@@ -272,9 +213,7 @@ public final class RecordSerializerSourceGen {
         return constructorBuilder.build((aThis, methodParameters) -> {
             List<StatementDef> statements = new ArrayList<>();
             VariableDef.MethodParameter context = methodParameters.get(0);
-            statements.add(includeField(aThis).put(INCLUSION_UTIL_TYPE.invokeStatic(RESOLVE_INCLUSION_METHOD, context)));
-            statements.add(aThis.field(INCLUDE_ALL_FIELD, TypeDef.Primitive.BOOLEAN)
-                .put(INCLUSION_UTIL_TYPE.invokeStatic(INCLUDE_ALWAYS_METHOD, includeField(aThis))));
+            statements.addAll(SerdeInclusionSourceGen.resolveStatements(aThis, context));
             for (Map.Entry<String, String> serializerFieldEntry : serializerFieldNames.entrySet()) {
                 String componentName = serializerFieldEntry.getKey();
                 String serializerFieldName = serializerFieldEntry.getValue();
@@ -459,7 +398,7 @@ public final class RecordSerializerSourceGen {
                 );
                 return wrapWithPropertyPath(StatementDef.multi(
                     scalarValueDef,
-                    shouldSerializePrimitive(aThis, componentType, scalarValueDef.variable()).ifTrue(writePrimitive)
+                    SerdeInclusionSourceGen.shouldSerializePrimitive(aThis, componentType, scalarValueDef.variable()).ifTrue(writePrimitive)
                 ), type, argumentExpression);
             }
             StatementDef writeScalar = StatementDef.multi(
@@ -471,7 +410,7 @@ public final class RecordSerializerSourceGen {
             );
             return wrapWithPropertyPath(StatementDef.multi(
                 scalarValueDef,
-                shouldSerializeScalar(aThis, componentType, scalarValueDef.variable()).ifTrue(writeScalar)
+                SerdeInclusionSourceGen.shouldSerializeScalar(aThis, componentType, scalarValueDef.variable()).ifTrue(writeScalar)
             ), type, argumentExpression);
         }
         String serializerFieldName = required(serializerFieldNames, component.name());
@@ -491,7 +430,7 @@ public final class RecordSerializerSourceGen {
             );
             return wrapWithPropertyPath(StatementDef.multi(
                 propertyValueDef,
-                shouldSerializePrimitive(aThis, componentType, propertyValueDef.variable()).ifTrue(writePrimitive)
+                SerdeInclusionSourceGen.shouldSerializePrimitive(aThis, componentType, propertyValueDef.variable()).ifTrue(writePrimitive)
             ), type, argumentExpression);
         }
         StatementDef writeValue = StatementDef.multi(
@@ -511,94 +450,8 @@ public final class RecordSerializerSourceGen {
         );
         return wrapWithPropertyPath(StatementDef.multi(
             propertyValueDef,
-            shouldSerializeValue(aThis, context, serializer, propertyValueDef.variable()).ifTrue(writeValue)
+            SerdeInclusionSourceGen.shouldSerializeValue(aThis, context, serializer, propertyValueDef.variable()).ifTrue(writeValue)
         ), type, argumentExpression);
-    }
-
-    private VariableDef.Field includeField(VariableDef.This aThis) {
-        return aThis.field(INCLUDE_FIELD, SER_INCLUDE_TYPE);
-    }
-
-    /**
-     * Combines an inclusion check with the precomputed "writes everything" flag so a configuration that
-     * never skips a property costs a single field read on the serialization hot path.
-     */
-    private ExpressionDef.ConditionExpressionDef inclusionCheck(VariableDef.This aThis, ExpressionDef check) {
-        return aThis.field(INCLUDE_ALL_FIELD, TypeDef.Primitive.BOOLEAN).isTrue().or(check.isTrue());
-    }
-
-    private ExpressionDef.ConditionExpressionDef shouldSerializePrimitive(VariableDef.This aThis,
-                                                                         ClassElement type,
-                                                                         ExpressionDef propertyValue) {
-        return inclusionCheck(aThis, INCLUSION_UTIL_TYPE.invokeStatic(
-            SHOULD_SERIALIZE_PRIMITIVE_METHOD,
-            includeField(aThis),
-            primitiveIsDefaultExpression(type, propertyValue)
-        ));
-    }
-
-    private ExpressionDef.ConditionExpressionDef shouldSerializeScalar(VariableDef.This aThis,
-                                                                      ClassElement type,
-                                                                      ExpressionDef propertyValue) {
-        return inclusionCheck(aThis, INCLUSION_UTIL_TYPE.invokeStatic(
-            scalarInclusionMethod(type),
-            includeField(aThis),
-            propertyValue
-        ));
-    }
-
-    private ExpressionDef.ConditionExpressionDef shouldSerializeValue(VariableDef.This aThis,
-                                                                     VariableDef.MethodParameter context,
-                                                                     ExpressionDef serializer,
-                                                                     ExpressionDef propertyValue) {
-        return inclusionCheck(aThis, INCLUSION_UTIL_TYPE.invokeStatic(
-            SHOULD_SERIALIZE_METHOD,
-            includeField(aThis),
-            context,
-            serializer,
-            propertyValue.cast(TypeDef.OBJECT)
-        ));
-    }
-
-    /**
-     * The inclusion helper matching the serde that writes the value at runtime. Every scalar type
-     * handled by {@link #scalarEncoderMethod} other than string, boolean and character is a number.
-     */
-    private Method scalarInclusionMethod(ClassElement type) {
-        return switch (type.getName()) {
-            case "java.lang.String" -> SHOULD_SERIALIZE_STRING_METHOD;
-            case "java.lang.Boolean" -> SHOULD_SERIALIZE_BOOLEAN_METHOD;
-            case "java.lang.Character" -> SHOULD_SERIALIZE_CHARACTER_METHOD;
-            default -> SHOULD_SERIALIZE_NUMBER_METHOD;
-        };
-    }
-
-    /**
-     * Whether a primitive value equals the default value the matching serde reports for its type.
-     * Float and double go through {@code compare} so {@code -0.0} and {@code NaN} agree with
-     * {@code FloatSerde}/{@code DoubleSerde}, which compare the boxed value using {@code equals}.
-     */
-    private ExpressionDef primitiveIsDefaultExpression(ClassElement type, ExpressionDef propertyValue) {
-        return switch (type.getName()) {
-            case "boolean" -> propertyValue.isFalse();
-            case "char" -> isEqual(propertyValue, ExpressionDef.constant(0).cast(TypeDef.Primitive.CHAR));
-            case "float" -> isEqual(
-                ClassTypeDef.of(Float.class).invokeStatic(FLOAT_COMPARE_METHOD, propertyValue, ExpressionDef.constant(0F)),
-                ExpressionDef.constant(0)
-            );
-            case "double" -> isEqual(
-                ClassTypeDef.of(Double.class).invokeStatic(DOUBLE_COMPARE_METHOD, propertyValue, ExpressionDef.constant(0D)),
-                ExpressionDef.constant(0)
-            );
-            case "long" -> isEqual(propertyValue, ExpressionDef.constant(0L));
-            case "byte" -> isEqual(propertyValue, ExpressionDef.constant(0).cast(TypeDef.Primitive.BYTE));
-            case "short" -> isEqual(propertyValue, ExpressionDef.constant(0).cast(TypeDef.Primitive.SHORT));
-            default -> isEqual(propertyValue, ExpressionDef.constant(0));
-        };
-    }
-
-    private ExpressionDef isEqual(ExpressionDef left, ExpressionDef right) {
-        return left.compare(ExpressionDef.ComparisonOperation.OpType.EQUAL_TO, right);
     }
 
     private String indexedName(String prefix, int index) {


### PR DESCRIPTION
Supersedes #1378 for `3.2.x`: @arimu1's two commits from that PR, rebased onto `3.2.x`, plus a follow-up addressing the performance concern @graemerocher raised there and three correctness issues found while reviewing it. Original commits are preserved with their authorship.

Fixes micronaut-projects/micronaut-core#12838.

## The bug

Source-generated serializers for simple `@Serdeable` beans and records always wrote every property, including `null`, so `micronaut.serde.serialization.inclusion` had no effect on them. The runtime path (`CustomizedObjectSerializer` / `SerBean`) has always honored it. The workaround from the issue — `disable-generated-serializer=true`, or a type-level `@JsonInclude` — is no longer needed.

## How the inclusion is applied

The active inclusion is resolved **once**, in the generated constructor, into two final fields — the `SerInclude` and a flag for "this configuration never skips a property". A per-property check is then a field read plus, at most, a static call that switches on the already-resolved value, and an `ALWAYS`/`USE_DEFAULTS` configuration short-circuits on the flag alone:

```java
private final SerdeConfig.SerInclude include;
private final boolean includeAll;

public SerdeSourceGenIndexedShapeRecordSerializer(@Parameter Serializer.EncoderContext context, ...) {
  this.include = GeneratedSerdeInclusionUtil.resolveInclusion(context);
  this.includeAll = GeneratedSerdeInclusionUtil.includeAlways(this.include);
  this.serializer1 = context.findSerializer(ARGUMENT_1).createSpecific(context, ARGUMENT_1);
}
...
String value0 = value.value();
if (this.includeAll || GeneratedSerdeInclusionUtil.shouldSerializeString(this.include, value0)) {
  keysAwareEncoder.encodeKey(KEYS, 0);
  ...
}
```

This follows `serde-processor/AGENTS.md` ("do not add repeated context lookups … inside generated per-property hot paths"; "any value derived from `EncoderContext` … should be computed once during specific serde creation or constructor setup and stored in a generated field") and mirrors the runtime path, where `SerBean.SerProperty#include` is resolved at bean-build time.

The earlier shape of the change called `context.getSerializationConfiguration().map(…).orElse(…)` per property per document. `UserBeanSerdeBenchmark.serialize` / `Serde Jackson Generated` (which runs with `inclusion=ALWAYS`), JDK 25 on a 4-core container — noisy, so directional, but two independent rounds agree:

| Revision | 3 forks, 5×1s warmup, 5×1s | 1 fork, 3 warmup, 5×1s, `-prof gc` | `gc.alloc.rate.norm` |
| --- | ---: | ---: | ---: |
| baseline, no inclusion support | 213,848 ± 16,722 ops/s | 225,399 ± 9,935 ops/s | 6056.842 B/op |
| per-property resolution | 202,707 ± 4,424 ops/s | 207,613 ± 4,112 ops/s | 6056.890 B/op |
| this PR | 210,517 ± 8,667 ops/s | 226,108 ± 17,383 ops/s | 6056.821 B/op |

Allocation is identical across all three — escape analysis scalarises the `Optional`s once the method is hot — so the cost was CPU (repeated interface call and re-derivation per property), not GC.

## Correctness

- **A property getter was invoked twice per serialized property.** The primitive branches emitted the same property-read expression into both the `isDefault` argument and the encoder call. Each property is now read into a local that the check and the write share.
- **`-0.0f` / `-0.0d` were dropped under `NON_DEFAULT`.** `FloatSerde`/`DoubleSerde#isDefault` compare the boxed value with `equals`, so `-0.0` is not a default value at runtime, but `== 0f` says it is. Generated code now uses `Float.compare(v, 0F) == 0` / `Double.compare(v, 0D) == 0`, which matches `equals` semantics exactly for `-0.0` and `NaN`.
- **The scalar checks no longer re-derive serde semantics from the runtime class.** That duplication is what produced the `BigInteger`/`BigDecimal` bug caught in review on #1378, and the `-0.0` one above is the same class of problem. The generator knows the property type at compile time, so it emits the check belonging to the serde that writes the value — `shouldSerializeString`, `shouldSerializeBoolean`, `shouldSerializeCharacter`, `shouldSerializeNumber` — each mirroring that serde's `isEmpty`/`isAbsent`/`isDefault`. `BigInteger`/`BigDecimal` fall out correctly because they don't override `isDefault`.
- A context that exposes no serialization configuration falls back to `ALWAYS`, matching `CustomizedObjectSerializer`'s fallback for the same situation, rather than silently dropping properties.

## Tests

`GeneratedInclusionParitySpec` serializes bean and record shapes covering every property kind a generated serializer takes an inclusion decision for — primitives, boxed scalars on the no-serializer fast path, and values written through a property serializer — with **every** inclusion (`ALWAYS`, `USE_DEFAULTS`, `NON_NULL`, `NON_ABSENT`, `NON_EMPTY`, `NON_DEFAULT`, `NEVER`), and asserts the generated output is byte-identical to the same context with `disable-generated-serializer=true`. Payloads include empty string and empty collections, `BigInteger.ZERO` / `BigDecimal.ZERO`, boxed zeros, the NUL character, `-0.0` and `NaN`. It has teeth: run against #1378's head it fails on the `-0.0` case above. A further test asserts the generated source resolves the inclusion exactly once.

Existing compile-time specs that assert explicit `null` output now pin `inclusion=ALWAYS`, since the production default is `NON_EMPTY`. `CborByteArraySpec` does the same: an empty byte array is empty under `NON_EMPTY`, and the runtime object serializer drops it today too — that spec is about how a byte array is encoded, not whether it is written.

Green locally on JDK 25: `:micronaut-serde-jackson:test` (1667), `:micronaut-serde-processor:test`, `:micronaut-serde-support:test`, `:micronaut-serde-api:test`, `:micronaut-serde-bson:test`, `:micronaut-serde-jsonp:test`, `:micronaut-serde-jsonb:test`, `:micronaut-serde-properties:test`, `:micronaut-serde-tck-tests:test`, `:micronaut-serde-oracle-jdbc-json:test`, `:micronaut-serde-jackson-cbor:test`, `:micronaut-serde-stax-xml:test`, `:micronaut-serde-woodstox-xml:test`, `:test-suite-tck-serde:test`, `:test-suite-jaxb-tck-impl:test`, `:test-suite-jaxb-tck-stax:test`, `:test-suite-xml-jackson-databind:test`, `:test-suite-properties-jackson-databind:test`, `spotlessCheck`, `cM`. (`:test-suite-tck-jackson-databind:test` fails in my container while writing its HTML report — a test name containing a NUL character is not encodable as a filename under the container's default charset — but it fails identically on unmodified `3.2.x`.)

## Note for reviewers

This changes the default output of generated serializers: they used to write everything, and now apply the `NON_EMPTY` default the runtime path has always applied. That is the bug being fixed, but it may deserve a release-note line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WV9Zoz9rSzXP4hsAMGQiUc

---
_Generated by [Claude Code](https://claude.ai/code/session_01WV9Zoz9rSzXP4hsAMGQiUc)_