### PR TITLE
fix(yaml): get 3.2.x green — inclusion-independent TCK assertion and native-image charsets

### DIFF
--- a/serde-yaml-tck/src/main/groovy/io/micronaut/serde/yaml/tck/AbstractYamlCollectionSpec.groovy
+++ b/serde-yaml-tck/src/main/groovy/io/micronaut/serde/yaml/tck/AbstractYamlCollectionSpec.groovy
@@ -16,6 +16,7 @@
 package io.micronaut.serde.yaml.tck
 
 import io.micronaut.core.type.Argument
+import io.micronaut.serde.config.annotation.SerdeConfig
 import spock.lang.Specification
 
 /**
@@ -25,10 +26,19 @@ abstract class AbstractYamlCollectionSpec extends Specification implements YamlS
 
     void "collections are written as block sequences and mappings"() {
         given:
+        def bean = new CollectionsBean(["A", "B"], [one: 1, two: 2], [new SimpleBean("Hamza", 21)])
+
+        expect:
+        writeYaml(bean) == "values:\n- A\n- B\ncounts:\n  one: 1\n  two: 2\nbeans:\n- name: Hamza\n  age: 21\n"
+    }
+
+    void "a null collection is written as a null scalar when the inclusion writes nulls"() {
+        given:
         def bean = new CollectionsBean(["A", "B"], [one: 1, two: 2], null)
 
         expect:
-        writeYaml(bean) == "values:\n- A\n- B\ncounts:\n  one: 1\n  two: 2\nbeans: null\n"
+        writeYamlWithProperties(['micronaut.serde.serialization.inclusion': SerdeConfig.SerInclude.ALWAYS], bean) ==
+                "values:\n- A\n- B\ncounts:\n  one: 1\n  two: 2\nbeans: null\n"
     }
 
     void "collections round trip"() {

--- a/serde-yaml/src/main/resources/META-INF/native-image/io.micronaut.serde/micronaut-serde-yaml/native-image.properties
+++ b/serde-yaml/src/main/resources/META-INF/native-image/io.micronaut.serde/micronaut-serde-yaml/native-image.properties
@@ -1,0 +1,1 @@
+Args = -H:+AddAllCharsets


### PR DESCRIPTION
Fixes both failures currently red on `3.2.x`, each introduced when #1409 landed on top of #1410.

| Failing check on `3.2.x` | Cause | Fix here |
|---|---|---|
| [`Java CI / Test Report (25)`](https://github.com/micronaut-projects/micronaut-serialization/actions/runs/34235447332) — `SerdeYamlCollectionSpec` | Shared YAML TCK asserted a null property in an inclusion-dependent way | Commit 1 (test-only) |
| [`GraalVM Latest CI`](https://github.com/micronaut-projects/micronaut-serialization/actions/runs/34235447347) — `micronaut-example-java:nativeTest` | `snakeyaml-engine` resolves UTF-32 charsets that are absent from a native image | Commit 2 |

---

## 1. Inclusion-dependent TCK assertion

```
writeYaml(bean) == "values:\n- A\n- B\ncounts:\n  one: 1\n  two: 2\nbeans: null\n"
|         |     |
|         |     false
|         |     values:\n- A\n- B\ncounts:\n  one: 1\n  two: 2\n(------------~)
|         |     values:\n- A\n- B\ncounts:\n  one: 1\n  two: 2\n(beans: null\n)
```

`AbstractYamlCollectionSpec` wrote a `CollectionsBean` whose nested `beans` list is `null` and expected `beans: null`. That expectation depends on the active inclusion:

* Jackson Databind writes nulls by default, so `JacksonYamlCollectionSpec` passes.
* Micronaut Serialization defaults to `NON_EMPTY`, and since #1410 generated serializers honor `micronaut.serde.serialization.inclusion`, so the null property is no longer written and `SerdeYamlCollectionSpec` fails.

#1409 and #1410 were each green on their own base; they only collide once both are on `3.2.x`. Dropping a null under `NON_EMPTY` is the intended behaviour — the shared TCK assertion is what needed to stop depending on it.

In `serde-yaml-tck/.../AbstractYamlCollectionSpec.groovy`:

* `collections are written as block sequences and mappings` now populates every property, making the assertion inclusion-independent. It also gains coverage for writing a nested sequence of mappings (`beans:\n- name: Hamza\n  age: 21\n`), which the spec did not assert before.
* The null scalar moves to its own test pinning `micronaut.serde.serialization.inclusion: ALWAYS` via `writeYamlWithProperties`, mirroring what `AbstractYamlSerializationSpec` already does for `nullValue: null`. Runners that ignore unknown configuration keys — the Jackson one — are unaffected, because they write nulls regardless.

## 2. Native-image charsets

`example.YamlQuickStartTest` fails in the native image with:

```
=> java.lang.ExceptionInInitializerError
   org.snakeyaml.engine.v2.api.lowlevel.Parse.lambda$parseInputStream$0(Parse.java:54)
   io.micronaut.serde.yaml.YamlDecoder.<init>(YamlDecoder.java:107)
 Caused by: java.nio.charset.UnsupportedCharsetException: UTF-32BE
   org.snakeyaml.engine.v2.api.YamlUnicodeReader.<clinit>(YamlUnicodeReader.java:50)
```

`org.snakeyaml.engine.v2.api.YamlUnicodeReader` holds `UTF8`, `UTF16BE`, `UTF16LE`, `UTF32BE` and `UTF32LE` as static `Charset` fields (verified against `snakeyaml-engine-3.0.1`), resolved with `Charset.forName` in its static initializer for BOM detection. GraalVM builds only the default charsets into an image, so the UTF-32 lookups throw, the class fails to initialize, and every later read gets `NoClassDefFoundError: Could not initialize class ...YamlUnicodeReader`.

`micronaut-serde-yaml` shipped no `native-image.properties`, so nothing asked for the extra charsets. Added:

```properties
# serde-yaml/src/main/resources/META-INF/native-image/io.micronaut.serde/micronaut-serde-yaml/native-image.properties
Args = -H:+AddAllCharsets
```

the same flag `micronaut-serde-jsonp` already carries for this problem.

## Verification

Run on JDK 25, matching CI:

* `:test-suite-yaml-serde:test` — green (was the failing suite)
* `:test-suite-yaml-jackson-databind:test` — green (same TCK spec, reference implementation)
* `:micronaut-serde-yaml:test`, `:micronaut-serde-yaml-tck:check` — green
* `spotlessCheck`, `:micronaut-serde-yaml-tck:checkstyleMain` — green
* `:micronaut-serde-yaml:jar` — confirms the properties file is packaged at `META-INF/native-image/io.micronaut.serde/micronaut-serde-yaml/native-image.properties`

The TCK failure reproduced locally before the change and both collection specs pass 11/11 after it. **The native-image change could not be validated locally** — no GraalVM `native-image` toolchain was available in that environment — so it rests on the stack trace above plus the existing `serde-jsonp` precedent, and needs the `nativeTest` job to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzjusrCXYD9NG3gskMmV6s