### PR TITLE
fix(processor): make generated serdes compile under NullAway in null-marked packages

### DIFF
--- a/serde-jackson/build.gradle.kts
+++ b/serde-jackson/build.gradle.kts
@@ -14,7 +14,23 @@ val jacocoClassExcludes = listOf(
     "**/*Spec\$*.class"
 )
 
+// Null-marked fixtures compiled with NullAway enabled, unlike the test sources, so that the
+// serializers and deserializers generated for them are checked by NullAway too
+val nullMarkedSourceGen: SourceSet by sourceSets.creating {
+    compileClasspath += sourceSets.main.get().output
+    runtimeClasspath += sourceSets.main.get().output
+}
+
+configurations.named(nullMarkedSourceGen.implementationConfigurationName) {
+    extendsFrom(configurations.api.get(), configurations.implementation.get())
+}
+configurations.named(nullMarkedSourceGen.annotationProcessorConfigurationName) {
+    extendsFrom(configurations.annotationProcessor.get())
+}
+
 dependencies {
+    testImplementation(nullMarkedSourceGen.output)
+
     annotationProcessor(mn.micronaut.inject.java)
     annotationProcessor(projects.micronautSerdeProcessor)
 

--- a/serde-jackson/src/nullMarkedSourceGen/java/io/micronaut/serde/jackson/nullmarked/NullMarkedBean.java
+++ b/serde-jackson/src/nullMarkedSourceGen/java/io/micronaut/serde/jackson/nullmarked/NullMarkedBean.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.jackson.nullmarked;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.serde.annotation.Serdeable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A null-marked default-constructor bean with non-null properties.
+ */
+@Serdeable
+public class NullMarkedBean {
+
+    private String name = "";
+    private List<String> tags = new ArrayList<>();
+    private NullMarkedPlainRecord plain = new NullMarkedPlainRecord("", 0);
+
+    /**
+     * @return The name
+     */
+    @JsonProperty("bean_name")
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name The name
+     */
+    @JsonProperty("bean_name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return The tags
+     */
+    public List<String> getTags() {
+        return tags;
+    }
+
+    /**
+     * @param tags The tags
+     */
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    /**
+     * @return The nested record
+     */
+    public NullMarkedPlainRecord getPlain() {
+        return plain;
+    }
+
+    /**
+     * @param plain The nested record
+     */
+    public void setPlain(NullMarkedPlainRecord plain) {
+        this.plain = plain;
+    }
+}

--- a/serde-jackson/src/nullMarkedSourceGen/java/io/micronaut/serde/jackson/nullmarked/NullMarkedCollectionRecord.java
+++ b/serde-jackson/src/nullMarkedSourceGen/java/io/micronaut/serde/jackson/nullmarked/NullMarkedCollectionRecord.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.jackson.nullmarked;
+
+import io.micronaut.serde.annotation.Serdeable;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A null-marked record with non-null collection components.
+ *
+ * @param tags   The tags
+ * @param counts The counts
+ * @param items  The nested items
+ * @param note   An optional note
+ */
+@Serdeable
+public record NullMarkedCollectionRecord(
+    List<String> tags,
+    Map<String, Integer> counts,
+    List<NullMarkedPlainRecord> items,
+    @Nullable String note
+) {
+}

--- a/serde-jackson/src/nullMarkedSourceGen/java/io/micronaut/serde/jackson/nullmarked/NullMarkedConstructorBean.java
+++ b/serde-jackson/src/nullMarkedSourceGen/java/io/micronaut/serde/jackson/nullmarked/NullMarkedConstructorBean.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.jackson.nullmarked;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.serde.annotation.Serdeable;
+
+import java.util.List;
+
+/**
+ * A null-marked bean bound through its constructor with non-null properties.
+ */
+@Serdeable
+public final class NullMarkedConstructorBean {
+
+    private final String name;
+    private final List<String> tags;
+
+    /**
+     * @param name The name
+     * @param tags The tags
+     */
+    @JsonCreator
+    public NullMarkedConstructorBean(@JsonProperty("name") String name, @JsonProperty("tags") List<String> tags) {
+        this.name = name;
+        this.tags = tags;
+    }
+
+    /**
+     * @return The name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return The tags
+     */
+    public List<String> getTags() {
+        return tags;
+    }
+}

--- a/serde-jackson/src/nullMarkedSourceGen/java/io/micronaut/serde/jackson/nullmarked/NullMarkedPlainRecord.java
+++ b/serde-jackson/src/nullMarkedSourceGen/java/io/micronaut/serde/jackson/nullmarked/NullMarkedPlainRecord.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.jackson.nullmarked;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+/**
+ * A null-marked record with a non-null reference component.
+ *
+ * @param name  The name
+ * @param count The count
+ */
+@Serdeable
+public record NullMarkedPlainRecord(String name, int count) {
+}

--- a/serde-jackson/src/nullMarkedSourceGen/java/io/micronaut/serde/jackson/nullmarked/NullMarkedRenamedRecord.java
+++ b/serde-jackson/src/nullMarkedSourceGen/java/io/micronaut/serde/jackson/nullmarked/NullMarkedRenamedRecord.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.jackson.nullmarked;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.micronaut.serde.annotation.Serdeable;
+
+/**
+ * A null-marked record with renamed non-null components, an enum and a nested record.
+ *
+ * @param displayName The display name
+ * @param status      The status
+ * @param plain       The nested record
+ */
+@Serdeable
+public record NullMarkedRenamedRecord(
+    @JsonProperty("display_name") String displayName,
+    @JsonProperty("state") NullMarkedStatus status,
+    @JsonProperty("nested") NullMarkedPlainRecord plain
+) {
+}

--- a/serde-jackson/src/nullMarkedSourceGen/java/io/micronaut/serde/jackson/nullmarked/NullMarkedStatus.java
+++ b/serde-jackson/src/nullMarkedSourceGen/java/io/micronaut/serde/jackson/nullmarked/NullMarkedStatus.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.serde.jackson.nullmarked;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+/**
+ * A null-marked enum.
+ */
+@Serdeable
+public enum NullMarkedStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/serde-jackson/src/nullMarkedSourceGen/java/io/micronaut/serde/jackson/nullmarked/package-info.java
+++ b/serde-jackson/src/nullMarkedSourceGen/java/io/micronaut/serde/jackson/nullmarked/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017-2026 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Null-marked serde fixtures compiled with NullAway enabled, so the serializers and deserializers
+ * generated for them are checked by NullAway as well.
+ */
+@NullMarked
+package io.micronaut.serde.jackson.nullmarked;
+
+import org.jspecify.annotations.NullMarked;

--- a/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/NullMarkedSourceGenSpec.groovy
+++ b/serde-jackson/src/test/groovy/io/micronaut/serde/jackson/compiletime/NullMarkedSourceGenSpec.groovy
@@ -1,0 +1,98 @@
+package io.micronaut.serde.jackson.compiletime
+
+import io.micronaut.context.ApplicationContext
+import io.micronaut.core.type.Argument
+import io.micronaut.json.JsonMapper
+import io.micronaut.serde.SerdeRegistry
+import io.micronaut.serde.jackson.nullmarked.NullMarkedBean
+import io.micronaut.serde.jackson.nullmarked.NullMarkedCollectionRecord
+import io.micronaut.serde.jackson.nullmarked.NullMarkedConstructorBean
+import io.micronaut.serde.jackson.nullmarked.NullMarkedPlainRecord
+import io.micronaut.serde.jackson.nullmarked.NullMarkedRenamedRecord
+import io.micronaut.serde.jackson.nullmarked.NullMarkedStatus
+import spock.lang.AutoCleanup
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * The fixtures live in the {@code nullMarkedSourceGen} source set, which is compiled with NullAway
+ * enabled, so the generated serdes for them have to be NullAway-compatible for this spec to run.
+ */
+class NullMarkedSourceGenSpec extends Specification {
+
+    @Shared
+    @AutoCleanup
+    ApplicationContext context = ApplicationContext.run()
+
+    @Shared
+    JsonMapper jsonMapper = context.getBean(JsonMapper)
+
+    @Shared
+    SerdeRegistry registry = context.getBean(SerdeRegistry)
+
+    void 'test null-marked #type.simpleName uses generated serdes'() {
+        given:
+        Argument argument = Argument.of(type)
+
+        expect:
+        registry.findSerializer(argument).createSpecific(registry.newEncoderContext(Object), argument).class.name == generatedClassName(type, 'Serializer')
+        registry.findDeserializer(argument).createSpecific(registry.newDecoderContext(Object), argument).class.name == generatedClassName(type, 'Deserializer')
+
+        where:
+        type << [
+            NullMarkedPlainRecord,
+            NullMarkedRenamedRecord,
+            NullMarkedCollectionRecord,
+            NullMarkedBean,
+            NullMarkedConstructorBean
+        ]
+    }
+
+    void 'test null-marked records round trip through generated serdes'() {
+        given:
+        def renamed = new NullMarkedRenamedRecord('Ada', NullMarkedStatus.ACTIVE, new NullMarkedPlainRecord('nested', 2))
+        def collections = new NullMarkedCollectionRecord(['a', 'b'], [x: 1], [new NullMarkedPlainRecord('item', 3)], null)
+
+        when:
+        String renamedJson = jsonMapper.writeValueAsString(renamed)
+        String collectionsJson = jsonMapper.writeValueAsString(collections)
+
+        then:
+        renamedJson == '{"display_name":"Ada","state":"ACTIVE","nested":{"name":"nested","count":2}}'
+        jsonMapper.readValue(renamedJson, NullMarkedRenamedRecord) == renamed
+        collectionsJson == '{"tags":["a","b"],"counts":{"x":1},"items":[{"name":"item","count":3}]}'
+        jsonMapper.readValue(collectionsJson, NullMarkedCollectionRecord) == collections
+    }
+
+    void 'test null-marked beans round trip through generated serdes'() {
+        given:
+        def bean = new NullMarkedBean()
+        bean.name = 'Ada'
+        bean.tags = ['a']
+        bean.plain = new NullMarkedPlainRecord('nested', 2)
+
+        when:
+        String beanJson = jsonMapper.writeValueAsString(bean)
+        NullMarkedBean decodedBean = jsonMapper.readValue(beanJson, NullMarkedBean)
+        NullMarkedConstructorBean decodedConstructorBean = jsonMapper.readValue('{"name":"Ada","tags":["a"]}', NullMarkedConstructorBean)
+
+        then:
+        beanJson == '{"bean_name":"Ada","tags":["a"],"plain":{"name":"nested","count":2}}'
+        decodedBean.name == 'Ada'
+        decodedBean.tags == ['a']
+        decodedBean.plain == bean.plain
+        decodedConstructorBean.name == 'Ada'
+        decodedConstructorBean.tags == ['a']
+    }
+
+    void 'test absent non-null component keeps the runtime default'() {
+        // Matches the runtime object deserializer: an absent component is only rejected when
+        // strict-nullable or require-all-creator-parameters is enabled
+        expect:
+        jsonMapper.readValue('{"count":1}', NullMarkedPlainRecord) == new NullMarkedPlainRecord(null, 1)
+    }
+
+    private static String generatedClassName(Class<?> type, String suffix) {
+        "${type.package.name}.Serde${type.simpleName}${suffix}"
+    }
+}

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanDeserializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanDeserializerSourceGen.java
@@ -78,6 +78,7 @@ public final class BeanDeserializerSourceGen {
     private static final String FAIL_ON_NULL_FOR_PRIMITIVES_FIELD = "failOnNullForPrimitives";
     private static final String IGNORE_UNKNOWN_FIELD = "ignoreUnknown";
     private static final String GENERATED_VALUE_MEMBER = "value";
+    private static final String NULLAWAY_WARNING = "NullAway";
     private static final String HANDLED_DISPATCH_RESULT = "HANDLED";
     private static final String UNKNOWN_DISPATCH_RESULT = "UNKNOWN";
     private static final String DUPLICATE_DISPATCH_RESULT = "DUPLICATE";
@@ -333,15 +334,15 @@ public final class BeanDeserializerSourceGen {
             failOnNullForPrimitives
         ));
 
+        // Generated serdes keep the runtime null semantics, which NullAway can reject in a null-marked package
         List<Object> suppressWarnings = new ArrayList<>();
+        suppressWarnings.add(NULLAWAY_WARNING);
         if (fieldAccessProperties) {
             suppressWarnings.add("UnnecessaryParentheses");
         }
-        if (!suppressWarnings.isEmpty()) {
-            classDefBuilder.addAnnotation(AnnotationDef.builder(SuppressWarnings.class)
-                .addMember(GENERATED_VALUE_MEMBER, suppressWarnings)
-                .build());
-        }
+        classDefBuilder.addAnnotation(AnnotationDef.builder(SuppressWarnings.class)
+            .addMember(GENERATED_VALUE_MEMBER, suppressWarnings)
+            .build());
         if (fieldAccessProperties) {
             classDefBuilder.addAnnotation(Secondary.class);
         }

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanSerializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/beans/BeanSerializerSourceGen.java
@@ -66,6 +66,7 @@ public final class BeanSerializerSourceGen {
     private static final String VALUE_PARAMETER = "value";
     private static final String VALUE_LOCAL_PREFIX = "value";
     private static final String GENERATED_VALUE_MEMBER = "value";
+    private static final String NULLAWAY_WARNING = "NullAway";
     private static final String KEYS_FIELD = "KEYS";
 
     private static final TypeDef ARGUMENT_TYPE = TypeDef.of(Argument.class);
@@ -214,15 +215,15 @@ public final class BeanSerializerSourceGen {
             ));
         }
 
+        // Generated serdes keep the runtime null semantics, which NullAway can reject in a null-marked package
         List<Object> suppressWarnings = new ArrayList<>();
+        suppressWarnings.add(NULLAWAY_WARNING);
         if (fieldAccessProperties) {
             suppressWarnings.add("UnnecessaryParentheses");
         }
-        if (!suppressWarnings.isEmpty()) {
-            classDefBuilder.addAnnotation(AnnotationDef.builder(SuppressWarnings.class)
-                .addMember(GENERATED_VALUE_MEMBER, suppressWarnings)
-                .build());
-        }
+        classDefBuilder.addAnnotation(AnnotationDef.builder(SuppressWarnings.class)
+            .addMember(GENERATED_VALUE_MEMBER, suppressWarnings)
+            .build());
         if (fieldAccessProperties) {
             classDefBuilder.addAnnotation(Secondary.class);
         }

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/enums/EnumDeserializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/enums/EnumDeserializerSourceGen.java
@@ -56,6 +56,7 @@ public final class EnumDeserializerSourceGen {
     private static final TypeDef DESERIALIZER_TYPE = TypeDef.of(Deserializer.class);
     private static final String CONTEXT_PARAMETER = "context";
     private static final String GENERATED_VALUE_MEMBER = "value";
+    private static final String NULLAWAY_WARNING = "NullAway";
     private static final String ARGUMENT_STRING_FIELD = "ARGUMENT_STRING";
     private static final String STRING_DESERIALIZER_FIELD = "stringDeserializer";
     private static final String STRING_DESERIALIZER_LOCAL = "stringDeserializer";
@@ -111,6 +112,10 @@ public final class EnumDeserializerSourceGen {
             .addAnnotation(Prototype.class)
             .addAnnotation(AnnotationDef.builder(Generated.class)
                 .addMember(GENERATED_VALUE_MEMBER, "Micronaut")
+                .build())
+            // Like the runtime deserializer, an unknown value can be read as null, which NullAway rejects in a null-marked package
+            .addAnnotation(AnnotationDef.builder(SuppressWarnings.class)
+                .addMember(GENERATED_VALUE_MEMBER, NULLAWAY_WARNING)
                 .build())
             .addSuperinterface(TypeDef.parameterized(FormattedDeserializer.class, enumTypeDef))
             .addField(FieldDef.builder(ARGUMENT_STRING_FIELD, ARGUMENT_TYPE)

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/enums/EnumSerializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/enums/EnumSerializerSourceGen.java
@@ -50,6 +50,7 @@ public final class EnumSerializerSourceGen {
     private static final String CONTEXT_PARAMETER = "context";
     private static final String VALUE_PARAMETER = "value";
     private static final String GENERATED_VALUE_MEMBER = "value";
+    private static final String NULLAWAY_WARNING = "NullAway";
 
     private static final Method ENCODE_STRING_METHOD = ReflectionUtils.getRequiredMethod(Encoder.class, "encodeString", String.class);
     private static final Method ENUM_NAME_METHOD = ReflectionUtils.getRequiredMethod(Enum.class, "name");
@@ -76,6 +77,10 @@ public final class EnumSerializerSourceGen {
             .addAnnotation(AnnotationDef.builder(Generated.class)
                 .addMember(GENERATED_VALUE_MEMBER, "Micronaut")
             .build())
+            // Generated serdes keep the runtime null semantics, which NullAway can reject in a null-marked package
+            .addAnnotation(AnnotationDef.builder(SuppressWarnings.class)
+                .addMember(GENERATED_VALUE_MEMBER, NULLAWAY_WARNING)
+                .build())
             .addSuperinterface(TypeDef.parameterized(FormattedSerializer.class, enumTypeDef))
             .addSuperinterface(TypeDef.parameterized(ObjectSerializer.class, enumTypeDef))
             .addMethod(generateCreateSpecificMethod(enumTypeDef))

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordDeserializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordDeserializerSourceGen.java
@@ -75,6 +75,7 @@ public final class RecordDeserializerSourceGen {
     private static final String STRICT_NULLABLE_FIELD = "strictNullable";
     private static final String REQUIRE_ALL_CREATOR_PARAMETERS_FIELD = "requireAllCreatorParameters";
     private static final String GENERATED_VALUE_MEMBER = "value";
+    private static final String NULLAWAY_WARNING = "NullAway";
     private static final String HANDLED_DISPATCH_RESULT = "HANDLED";
     private static final String UNKNOWN_DISPATCH_RESULT = "UNKNOWN";
     private static final String DUPLICATE_DISPATCH_RESULT = "DUPLICATE";
@@ -301,6 +302,11 @@ public final class RecordDeserializerSourceGen {
             .addAnnotation(Prototype.class)
             .addAnnotation(AnnotationDef.builder(Generated.class)
                 .addMember(GENERATED_VALUE_MEMBER, "Micronaut")
+                .build())
+            // Like the runtime deserializer, an absent component is passed to the constructor as null
+            // unless strict nullability is enabled, which NullAway rejects in a null-marked package
+            .addAnnotation(AnnotationDef.builder(SuppressWarnings.class)
+                .addMember(GENERATED_VALUE_MEMBER, NULLAWAY_WARNING)
                 .build())
             .addSuperinterface(TypeDef.parameterized(Deserializer.class, recordTypeDef))
             .addFields(fields)

--- a/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerializerSourceGen.java
+++ b/serde-processor/src/main/java/io/micronaut/serde/processor/sourcegen/records/RecordSerializerSourceGen.java
@@ -64,6 +64,7 @@ public final class RecordSerializerSourceGen {
     private static final String VALUE_PARAMETER = "value";
     private static final String VALUE_LOCAL_PREFIX = "value";
     private static final String GENERATED_VALUE_MEMBER = "value";
+    private static final String NULLAWAY_WARNING = "NullAway";
     private static final String KEYS_FIELD = "KEYS";
 
     private static final TypeDef ARGUMENT_TYPE = TypeDef.of(Argument.class);
@@ -188,6 +189,10 @@ public final class RecordSerializerSourceGen {
             .addAnnotation(Prototype.class)
             .addAnnotation(AnnotationDef.builder(Generated.class)
                 .addMember(GENERATED_VALUE_MEMBER, "Micronaut")
+                .build())
+            // Generated serdes keep the runtime null semantics, which NullAway can reject in a null-marked package
+            .addAnnotation(AnnotationDef.builder(SuppressWarnings.class)
+                .addMember(GENERATED_VALUE_MEMBER, NULLAWAY_WARNING)
                 .build())
             .addSuperinterface(TypeDef.parameterized(Serializer.class, recordTypeDef))
             .addSuperinterface(TypeDef.parameterized(ObjectSerializer.class, recordTypeDef))


### PR DESCRIPTION
## Problem

Generated serdes don't compile under NullAway when the model is in a `@NullMarked` package:

```
SerdePlainDeserializer.java:65: error: [NullAway] passing @Nullable parameter 'propertyValue0' where @NonNull is required
          return new repro.model.Plain(propertyValue0, propertyValue1);
```

- **Record and constructor-bean deserializers:** each reference component local starts as `null`. If the property is absent, that `null` goes to the constructor unless `strict-nullable` or `require-all-creator-parameters` is on. The runtime `DeserBean` path does the same, so this is intended behaviour. Only the generated source is the problem.
- **Enum deserializers:** they return the nullable result of `GeneratedSerdeExceptionUtil.handleUnknownEnumValue`.

This already happened in 3.1.1 for plain `@NullMarked` records. #1412 generates serdes for more types, so more models now hit it. For example, Micronaut Data's `DefaultCursoredPageable` now fails `:micronaut-data-model:compileJava`. CI missed it because NullAway is turned off for test compilation, and all the existing null-marked source-gen fixtures are test sources.

## Fix

Every generated serializer and deserializer class (records, beans, enums) now gets `@SuppressWarnings("NullAway")`. The bean generators already added a `@SuppressWarnings` for `UnnecessaryParentheses`; `NullAway` is now merged into it. Runtime behaviour is unchanged. #1275 already fixed the lazy serde fields with `@Nullable`; that stays as it is.

## Regression test

`serde-jackson` has a new `nullMarkedSourceGen` source set. It is compiled with Error Prone and NullAway on; the source-set name has no "test" in it, so the convention leaves NullAway enabled. It contains a `@NullMarked` package with:
- a plain record with a non-null `String` component
- a record with `@JsonProperty`-renamed non-null components, an enum and a nested record
- a record with non-null `List`/`Map` components and a `@Nullable` component
- a default-constructor bean with a renamed non-null property
- a `@JsonCreator` constructor bean
- an enum

`test` depends on this output, so a NullAway error in generated code fails `:micronaut-serde-jackson:test`. `NullMarkedSourceGenSpec` checks that the generated serdes are the ones used and that each type round trips. It also checks that an absent non-null component still decodes to `null` with the default config, which matches the runtime path.

Before the fix, `compileNullMarkedSourceGenJava` failed with 11 NullAway errors: record deserializers for the plain record, the renamed record and the constructor bean, plus the enum deserializer. With the fix it compiles and all 8 spec cases pass.

Other checks run:
- `:micronaut-serde-jackson:test`: 1766 tests, 0 failures, 15 skipped. This includes the `Generated*ParitySpec`, `SerdeSourceGenEligibilitySpec`, `CompileTimeSourceGenSpec` and `SerdeSourceGen*Spec`.
- `:micronaut-serde-processor:test`: has no test sources, so no tests ran.
- `checkstyleMain` and `spotlessCheck` on the processor, and `checkstyleNullMarkedSourceGen` and `spotlessCheck` on jackson: all pass.
- `:micronaut-doc-examples:micronaut-example-groovy:test`: passes. This matters because the annotation is now also emitted in generated Groovy.

## Also worth a look (not changed here)

`gradle.properties` on `3.2.x` still says `projectVersion=3.1.2-SNAPSHOT`, the same as `3.1.x`. Both branches publish to the same snapshot coordinate: snapshot build #18 (2026-09-10 22:41 UTC) was 3.2.x content. This probably needs a bump to `3.2.0-SNAPSHOT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

