### PR TITLE
Sync CI workflows from the project template and skip drafts in json-tck.yml

### DIFF
--- a/.github/workflows/json-tck.yml
+++ b/.github/workflows/json-tck.yml
@@ -5,12 +5,18 @@ on:
       - master
       - '[0-9]+.[0-9]+.x'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
       - '[0-9]+.[0-9]+.x'
+# A new push to a pull request cancels its older run, freeing the shared runner
+# pool. Pushes to branches get a group of their own and are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 jobs:
   json-tck:
-    if: github.repository != 'micronaut-projects/micronaut-project-template'
+    if: github.repository != 'micronaut-projects/micronaut-project-template' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Manual sync of `.github/workflows` from [micronaut-project-template](https://github.com/micronaut-projects/micronaut-project-template), rolling out the CI load reductions already trialled on micronaut-projects/micronaut-serialization#1418.

### What changes

- **Draft PRs skip CI** — Java CI, GraalVM Latest CI and the Vulnerability Audit are skipped while a PR is a draft and run once it is marked ready for review. Template PR: micronaut-projects/micronaut-project-template#791
- **Superseded PR runs are cancelled** — a new push to a PR cancels the in-progress run of the same workflow. Push builds get a group per run and are never cancelled, since Java CI publishes snapshots and docs on push. Template PR: micronaut-projects/micronaut-project-template#788
- **GraalVM Dev CI runs every other Saturday** (01:00 Europe/Madrid) instead of Mon–Fri. Template PR: micronaut-projects/micronaut-project-template#790
- Any other template drift (Renovate action digest bumps, `main` branch triggers, the on-demand `sonar-pr.yml`) is picked up as well.
- Where this repository has project-specific workflows triggered by `pull_request`, they get the same draft skip, `ready_for_review` trigger and concurrency group (see the diff).

### Verification

This PR is opened as a draft on purpose: with the synced workflows in place, no CI runs while it is a draft, which itself verifies the draft skip without occupying the shared runner pool. Mark it ready for review to run CI before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
